### PR TITLE
Externalización de prompts

### DIFF
--- a/app/components/martin/MartinFloatingButton.tsx
+++ b/app/components/martin/MartinFloatingButton.tsx
@@ -4,6 +4,7 @@ import { Trash2, Copy, RefreshCw, X, Send, Loader2 } from 'lucide-react';
 import MartinIcon from './MartinIcon';
 import { useMartinStore } from '@/lib/store/useMartinStore';
 import { getAIConfig, chatStream, chatWithTools } from '@/lib/ai/client';
+import { buildMartinFloatingPrompt } from '@/lib/prompts/loader';
 import { createResourceTools } from '@/lib/ai/tools';
 import MarkdownRenderer from '@/components/chat/MarkdownRenderer';
 import { showToast } from '@/lib/store/useToastStore';
@@ -98,49 +99,18 @@ export default function MartinFloatingButton() {
     }
   }, [isOpen]);
 
-  // Build system prompt with context
+  // Build system prompt with context (from externalized prompts)
   const buildSystemPrompt = useCallback(() => {
     const context = getContextFromPath(pathname || '/');
     const now = new Date();
-
-    let prompt = `You are Many, Dome's AI assistant. You are friendly, conversational, and always try to help clearly. You speak in natural English.
-
-## Your Personality
-- Close and professional at the same time
-- You use clear and direct language
-- You explain complex concepts simply
-- You always try to be useful and constructive
-- You maintain a positive but not exaggerated tone
-
-## Current Context
-- Location: ${context.location}
-- The user is ${context.description}
-- Date: ${now.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}
-- Time: ${now.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })}
-`;
-
-    if (currentResourceTitle) {
-      prompt += `- Active resource: "${currentResourceTitle}"\n`;
-    }
-
-    prompt += `
-## Capabilities
-You can help the user with:
-- Answering questions about their resources and notes
-- Suggesting ideas and connections between content
-- Helping organize information
-- Generating summaries and analyses
-- Receiving content from WhatsApp${whatsappConnected ? ' (connected)' : ''}
-- Any other productivity tasks
-
-## Behavior
-- If the user asks something outside your knowledge, be honest
-- If you can suggest something useful based on context, do it
-- Keep responses concise but complete
-- Use markdown formatting for better readability (lists, bold, code, etc.)
-- Use emojis in moderation, only when they add value`;
-
-    return prompt;
+    return buildMartinFloatingPrompt({
+      location: context.location,
+      description: context.description,
+      date: now.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }),
+      time: now.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' }),
+      resourceTitle: currentResourceTitle || undefined,
+      whatsappConnected,
+    });
   }, [pathname, currentResourceTitle, whatsappConnected]);
 
   // Streaming message state

--- a/app/lib/hooks/useStudioGenerate.ts
+++ b/app/lib/hooks/useStudioGenerate.ts
@@ -15,6 +15,7 @@ import {
   providerSupportsTools,
   type AIProviderType,
 } from '@/lib/ai';
+import { getStudioPrompt } from '@/lib/prompts/loader';
 import { useAppStore } from '@/lib/store/useAppStore';
 import { showToast } from '@/lib/store/useToastStore';
 import type { StudioOutputType, StudioOutput } from '@/types';
@@ -329,9 +330,7 @@ export function useStudioGenerate(options?: {
 
         if (useTools) {
           userPrompt = buildGeneratePrompt(type, projectId, sourceIds, options?.resourceId);
-          systemPrompt = `You are a study assistant. Generate structured study materials from the user's knowledge base.
-When asked to generate, use the appropriate tools to fetch source content first, then return a valid JSON object.
-The JSON must have a "type" field matching the requested type. Return ONLY the JSON object, no markdown formatting or explanation.`;
+          systemPrompt = getStudioPrompt(true);
           messages = [
             { role: 'system', content: systemPrompt },
             { role: 'user', content: userPrompt },
@@ -339,8 +338,7 @@ The JSON must have a "type" field matching the requested type. Return ONLY the J
         } else {
           const context = await fetchContextForStudio(projectId, sourceIds);
           userPrompt = buildGeneratePromptNoTools(type, projectId, context);
-          systemPrompt = `You are a study assistant. Generate structured study materials from the provided source content.
-Return a valid JSON object with a "type" field matching the requested type. Return ONLY the JSON object, no markdown formatting or explanation.`;
+          systemPrompt = getStudioPrompt(false);
           messages = [
             { role: 'system', content: systemPrompt },
             { role: 'user', content: userPrompt },

--- a/app/lib/prompts/loader.ts
+++ b/app/lib/prompts/loader.ts
@@ -1,0 +1,152 @@
+/**
+ * Prompt loader for renderer process.
+ * Loads prompt templates from bundled assets (imported at build time).
+ */
+
+import martinBase from '../../../prompts/martin/base.txt?raw';
+import martinTools from '../../../prompts/martin/tools.txt?raw';
+import martinResourceContext from '../../../prompts/martin/resource-context.txt?raw';
+import martinFloatingBase from '../../../prompts/martin/floating-base.txt?raw';
+import editorSystem from '../../../prompts/editor/system.txt?raw';
+import editorReview from '../../../prompts/editor/actions/review.txt?raw';
+import editorExpand from '../../../prompts/editor/actions/expand.txt?raw';
+import editorSummarize from '../../../prompts/editor/actions/summarize.txt?raw';
+import editorImprove from '../../../prompts/editor/actions/improve.txt?raw';
+import editorTranslate from '../../../prompts/editor/actions/translate.txt?raw';
+import editorContinue from '../../../prompts/editor/actions/continue.txt?raw';
+import studioWithTools from '../../../prompts/studio/with-tools.txt?raw';
+import studioWithoutTools from '../../../prompts/studio/without-tools.txt?raw';
+
+export const prompts = {
+  martin: {
+    base: martinBase,
+    tools: martinTools,
+    resourceContext: martinResourceContext,
+    floatingBase: martinFloatingBase,
+  },
+  editor: {
+    system: editorSystem,
+    actions: {
+      review: editorReview,
+      expand: editorExpand,
+      summarize: editorSummarize,
+      improve: editorImprove,
+      translate: editorTranslate,
+      continue: editorContinue,
+    },
+  },
+  studio: {
+    withTools: studioWithTools,
+    withoutTools: studioWithoutTools,
+  },
+} as const;
+
+function replaceAll(template: string, replacements: Record<string, string>): string {
+  let result = template;
+  for (const [key, value] of Object.entries(replacements)) {
+    result = result.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+  }
+  return result;
+}
+
+/**
+ * Build Martin base prompt with placeholders replaced.
+ */
+export function buildMartinBasePrompt(options: {
+  location: 'workspace' | 'home' | 'whatsapp';
+  date?: string;
+  time?: string;
+  resourceTitle?: string;
+  includeDateTime?: boolean;
+}): string {
+  const resourceTitleLine = options.resourceTitle
+    ? `- Active resource: "${options.resourceTitle}"\n`
+    : '';
+  const dateTimeSection =
+    options.includeDateTime !== false && options.date && options.time
+      ? `- Date: ${options.date}\n- Time: ${options.time}\n`
+      : '';
+  return replaceAll(prompts.martin.base, {
+    location: options.location === 'workspace' ? 'Workspace' : options.location === 'home' ? 'Home' : 'WhatsApp',
+    dateTimeSection,
+    resourceTitleLine,
+  });
+}
+
+/**
+ * Build Martin floating button prompt.
+ */
+export function buildMartinFloatingPrompt(options: {
+  location: string;
+  description: string;
+  date: string;
+  time: string;
+  resourceTitle?: string;
+  whatsappConnected?: boolean;
+}): string {
+  const resourceTitleLine = options.resourceTitle ? `- Active resource: "${options.resourceTitle}"\n` : '';
+  const whatsappSuffix = options.whatsappConnected ? ' (connected)' : '';
+  return replaceAll(prompts.martin.floatingBase, {
+    location: options.location,
+    description: options.description,
+    date: options.date,
+    time: options.time,
+    resourceTitleLine,
+    whatsappSuffix,
+  });
+}
+
+/**
+ * Build Martin resource context section.
+ */
+export function buildMartinResourceContext(options: {
+  type?: string;
+  summary?: string;
+  content?: string;
+  transcription?: string;
+  maxContentLen?: number;
+  maxTranscriptionLen?: number;
+}): string {
+  const maxContent = options.maxContentLen ?? 2000;
+  const maxTranscription = options.maxTranscriptionLen ?? 2000;
+  const resourceTypeLine = options.type ? `Type: ${options.type}` : '';
+  const resourceSummarySection = options.summary ? `\n\nSummary: ${options.summary}` : '';
+  const contentTruncated = (options.content?.length ?? 0) > maxContent;
+  const resourceContentSection = options.content
+    ? `\n\nContent${contentTruncated ? ' (excerpt)' : ''}:\n${options.content.substring(0, maxContent)}${contentTruncated ? '...' : ''}`
+    : '';
+  const transcriptionTruncated = (options.transcription?.length ?? 0) > maxTranscription;
+  const resourceTranscriptionSection = options.transcription
+    ? `\n\nTranscription${transcriptionTruncated ? ' (excerpt)' : ''}:\n${options.transcription.substring(0, maxTranscription)}${transcriptionTruncated ? '...' : ''}`
+    : '';
+
+  return replaceAll(prompts.martin.resourceContext, {
+    resourceTypeLine,
+    resourceSummarySection,
+    resourceContentSection,
+    resourceTranscriptionSection,
+  });
+}
+
+/**
+ * Build editor system prompt.
+ */
+export function buildEditorSystemPrompt(contextSnippet: string): string {
+  return replaceAll(prompts.editor.system, { contextSnippet });
+}
+
+/**
+ * Get editor action prompt by action type.
+ */
+export function getEditorActionPrompt(
+  action: 'review' | 'expand' | 'summarize' | 'improve' | 'translate' | 'continue',
+): string {
+  return prompts.editor.actions[action];
+}
+
+/**
+ * Get Studio system prompt.
+ */
+export function getStudioPrompt(withTools: boolean): string {
+  return withTools ? prompts.studio.withTools : prompts.studio.withoutTools;
+}

--- a/app/types/global.d.ts
+++ b/app/types/global.d.ts
@@ -1,5 +1,11 @@
 export { };
 
+// Raw text imports for prompts
+declare module '*.txt?raw' {
+  const content: string;
+  export default content;
+}
+
 // Tiptap custom commands declaration
 import type { CalloutBlockAttributes, DividerAttributes, ToggleBlockAttributes, PDFEmbedAttributes, FileBlockAttributes } from '@/types';
 

--- a/electron/personality-loader.cjs
+++ b/electron/personality-loader.cjs
@@ -326,8 +326,10 @@ function buildSystemPrompt(params = {}) {
     sections.push(resourceSection);
   }
 
-  // Sección: Capacidades disponibles
-  sections.push(`## Capabilities in Dome
+  // Sección: Capacidades disponibles (desde prompts/martin/capabilities.txt)
+  const promptsLoader = require('./prompts-loader.cjs');
+  const capabilities = promptsLoader.getMartinCapabilities();
+  sections.push(capabilities || `## Capabilities in Dome
 
 Within Dome you can:
 - Analyze and answer questions about saved resources

--- a/electron/prompts-loader.cjs
+++ b/electron/prompts-loader.cjs
@@ -1,0 +1,62 @@
+/**
+ * Prompt loader for Electron main process.
+ * Reads prompt templates from prompts/ folder (sync fs access).
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { app } = require('electron');
+
+function getPromptsDir() {
+  // In dev: project root. In prod: same level as app.asar
+  const appPath = app?.getAppPath ? app.getAppPath() : process.cwd();
+  return path.join(appPath, 'prompts');
+}
+
+function readPrompt(relativePath) {
+  try {
+    const fullPath = path.join(getPromptsDir(), relativePath);
+    if (fs.existsSync(fullPath)) {
+      return fs.readFileSync(fullPath, 'utf8');
+    }
+  } catch (err) {
+    console.error('[Prompts] Error reading', relativePath, err.message);
+  }
+  return null;
+}
+
+/**
+ * Build WhatsApp system prompt with dynamic context.
+ * @param {Object} options
+ * @param {string} options.contextSection - Built context (project, resources, date, time)
+ */
+function buildWhatsAppPrompt(contextSection) {
+  const template = readPrompt('whatsapp/base.txt');
+  if (!template) {
+    return `You are Many, Dome's AI assistant.\n\n${contextSection}`;
+  }
+  return template.replace(/\{\{contextSection\}\}/g, contextSection);
+}
+
+/**
+ * Build the context section for WhatsApp (project, recent resources, date, time).
+ * Called by message-handler with actual data.
+ */
+function buildWhatsAppContextSection(lines) {
+  return lines.filter(Boolean).join('\n');
+}
+
+/**
+ * Read Martin capabilities section (used by personality-loader).
+ */
+function getMartinCapabilities() {
+  return readPrompt('martin/capabilities.txt');
+}
+
+module.exports = {
+  getPromptsDir,
+  readPrompt,
+  buildWhatsAppPrompt,
+  buildWhatsAppContextSection,
+  getMartinCapabilities,
+};

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "files": [
       "dist/**/*",
       "electron/**/*",
+      "prompts/**/*",
       "package.json",
       "!**/node_modules/*/{CHANGELOG.md,README.md,readme.md,readme,test,__tests__,tests,powered-test,*.ts,*.map}",
       "!**/node_modules/.bin",

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,41 @@
+# Dome AI Prompts
+
+Prompts externos organizados por caso de uso para facilitar la iteración y mejora.
+
+## Estructura por caso de uso
+
+| Carpeta | Uso | Consumidor |
+|---------|-----|------------|
+| **martin/** | Asistente Many (chat principal) | `app/lib/ai/client.ts`, AIChatTab |
+| **martin/floating-base.txt** | Many en botón flotante global | MartinFloatingButton |
+| **martin/capabilities.txt** | Capacidades (personality-loader) | `electron/personality-loader.cjs` |
+| **editor/** | Asistente de edición inline en notas | `app/lib/ai/editor-ai.ts` |
+| **studio/** | Generación de materiales de estudio | `app/lib/hooks/useStudioGenerate.ts` |
+| **whatsapp/** | Many en contexto WhatsApp | `electron/whatsapp/message-handler.cjs` |
+
+## Archivos y placeholders
+
+### martin/base.txt
+- `{{location}}` - Workspace, Home, WhatsApp
+- `{{dateTimeSection}}` - Bloque fecha/hora (o vacío)
+- `{{resourceTitleLine}}` - Línea "Active resource: X" (o vacío)
+
+### martin/floating-base.txt
+- `{{location}}`, `{{description}}`, `{{date}}`, `{{time}}`
+- `{{resourceTitleLine}}`, `{{whatsappSuffix}}`
+
+### martin/resource-context.txt
+- `{{resourceTypeLine}}`, `{{resourceSummarySection}}`
+- `{{resourceContentSection}}`, `{{resourceTranscriptionSection}}`
+
+### editor/system.txt
+- `{{contextSnippet}}` - Fragmento del documento para contexto
+
+### whatsapp/base.txt
+- `{{contextSection}}` - Contexto dinámico (proyecto, recursos, fecha/hora)
+
+## Cómo editar
+
+1. Modifica el archivo `.txt` correspondiente al caso de uso.
+2. Los cambios se aplican en el próximo build (renderer) o al reiniciar (main process).
+3. No hace falta tocar código para iterar en el contenido de los prompts.

--- a/prompts/editor/actions/continue.txt
+++ b/prompts/editor/actions/continue.txt
@@ -1,0 +1,1 @@
+Continue writing from where the following text ends. Match the tone, style, and topic. Write 2-3 additional paragraphs. Return only the new content (do not repeat the original text).

--- a/prompts/editor/actions/expand.txt
+++ b/prompts/editor/actions/expand.txt
@@ -1,0 +1,1 @@
+Expand on the following text, adding more detail, depth, and supporting points while maintaining the same tone, style, and formatting. Return only the expanded text.

--- a/prompts/editor/actions/improve.txt
+++ b/prompts/editor/actions/improve.txt
@@ -1,0 +1,1 @@
+Improve the writing quality of the following text — make it clearer, more engaging, and better structured. Preserve the formatting. Return only the improved version.

--- a/prompts/editor/actions/review.txt
+++ b/prompts/editor/actions/review.txt
@@ -1,0 +1,1 @@
+Review the following text for grammar, spelling, and style issues. Return the corrected version only, with no explanation. Preserve all formatting (HTML tags, markdown, etc.).

--- a/prompts/editor/actions/summarize.txt
+++ b/prompts/editor/actions/summarize.txt
@@ -1,0 +1,1 @@
+Summarize the following text concisely, capturing the key points. Return only the summary.

--- a/prompts/editor/actions/translate.txt
+++ b/prompts/editor/actions/translate.txt
@@ -1,0 +1,1 @@
+Translate the following text. If it is in Spanish, translate to English. If it is in English, translate to Spanish. If it is in another language, translate to English. Return only the translation, preserving formatting.

--- a/prompts/editor/system.txt
+++ b/prompts/editor/system.txt
@@ -1,0 +1,12 @@
+You are an inline writing assistant embedded in a note-taking application called Dome. You help users improve, expand, review, and transform their text.
+
+CRITICAL RULES:
+- Respond ONLY with the modified/generated text
+- Do NOT include explanations, commentary, or meta-text
+- Do NOT wrap your response in quotes or code blocks
+- Preserve the original formatting (HTML tags, markdown, lists, etc.)
+- Match the language of the original text unless translating
+- Be concise and direct
+
+Document context (for reference only — do NOT repeat this):
+{{contextSnippet}}

--- a/prompts/martin/base.txt
+++ b/prompts/martin/base.txt
@@ -1,0 +1,29 @@
+You are Many, Dome's AI assistant. You are friendly, conversational, and always try to help clearly. You speak in natural English.
+
+## Your Personality
+- Close and professional at the same time
+- You use clear and direct language
+- You explain complex concepts simply
+- You always try to be useful and constructive
+- You maintain a positive but not exaggerated tone
+
+## Current Context
+- Location: {{location}}
+- The user is working on a resource
+{{dateTimeSection}}
+{{resourceTitleLine}}
+
+## Capabilities
+You can help the user with:
+- Answering questions about their resources and notes
+- Suggesting ideas and connections between content
+- Helping organize information
+- Generating summaries and analyses
+- Receiving content from WhatsApp
+- Any other productivity tasks
+
+## Behavior
+- If the user asks something outside your knowledge, be honest
+- If you can suggest something useful based on context, do it
+- Keep responses concise but complete
+- Use emojis in moderation, only when they add value

--- a/prompts/martin/capabilities.txt
+++ b/prompts/martin/capabilities.txt
@@ -1,0 +1,11 @@
+## Capabilities in Dome
+
+Within Dome you can:
+- Analyze and answer questions about saved resources
+- Help create and organize notes
+- Generate content summaries
+- Suggest connections between resources
+- Receive content from WhatsApp and process it
+- Read and analyze Gmail emails
+
+Always respond in English unless the user speaks to you in another language.

--- a/prompts/martin/floating-base.txt
+++ b/prompts/martin/floating-base.txt
@@ -1,0 +1,31 @@
+You are Many, Dome's AI assistant. You are friendly, conversational, and always try to help clearly. You speak in natural English.
+
+## Your Personality
+- Close and professional at the same time
+- You use clear and direct language
+- You explain complex concepts simply
+- You always try to be useful and constructive
+- You maintain a positive but not exaggerated tone
+
+## Current Context
+- Location: {{location}}
+- The user is {{description}}
+- Date: {{date}}
+- Time: {{time}}
+{{resourceTitleLine}}
+
+## Capabilities
+You can help the user with:
+- Answering questions about their resources and notes
+- Suggesting ideas and connections between content
+- Helping organize information
+- Generating summaries and analyses
+- Receiving content from WhatsApp{{whatsappSuffix}}
+- Any other productivity tasks
+
+## Behavior
+- If the user asks something outside your knowledge, be honest
+- If you can suggest something useful based on context, do it
+- Keep responses concise but complete
+- Use markdown formatting for better readability (lists, bold, code, etc.)
+- Use emojis in moderation, only when they add value

--- a/prompts/martin/resource-context.txt
+++ b/prompts/martin/resource-context.txt
@@ -1,0 +1,7 @@
+## Current Resource
+{{resourceTypeLine}}
+{{resourceSummarySection}}
+{{resourceContentSection}}
+{{resourceTranscriptionSection}}
+
+Help the user understand, analyze, and work with this resource.

--- a/prompts/martin/tools.txt
+++ b/prompts/martin/tools.txt
@@ -1,0 +1,33 @@
+
+## Available Tools
+You have access to tools you can use to better help the user:
+
+### Resource Search and Access
+- **resource_search**: Search resources by text (title and content)
+- **resource_get**: Get the full content of a specific resource
+- **resource_list**: List available resources
+- **resource_semantic_search**: Search resources by meaning (semantic search)
+
+### Resource Actions
+- **resource_create**: Create a new note or resource in the knowledge base
+- **resource_update**: Edit the content or title of an existing resource
+- **resource_delete**: Delete a resource (always ask the user for confirmation first)
+
+### Context Information
+- **project_list**: View the user's projects
+- **project_get**: Get project details
+- **interaction_list**: View notes and annotations of a resource
+- **get_recent_resources**: View the most recent resources
+
+### Web (if available)
+- **web_search**: Search for information on the internet
+- **web_fetch**: Get content from a web page
+
+## When to Use Tools
+1. When the user asks about their resources → use resource_search or resource_semantic_search
+2. If you need more detail from a resource → use resource_get
+3. For updated or external information → use web_search
+4. When the user asks to create a note or save information → use resource_create
+5. When the user asks to edit or update a resource → use resource_update
+6. When the user asks to delete a resource → use resource_delete (always confirm first)
+7. Cite sources when using information from resources or web

--- a/prompts/studio/with-tools.txt
+++ b/prompts/studio/with-tools.txt
@@ -1,0 +1,3 @@
+You are a study assistant. Generate structured study materials from the user's knowledge base.
+When asked to generate, use the appropriate tools to fetch source content first, then return a valid JSON object.
+The JSON must have a "type" field matching the requested type. Return ONLY the JSON object, no markdown formatting or explanation.

--- a/prompts/studio/without-tools.txt
+++ b/prompts/studio/without-tools.txt
@@ -1,0 +1,2 @@
+You are a study assistant. Generate structured study materials from the provided source content.
+Return a valid JSON object with a "type" field matching the requested type. Return ONLY the JSON object, no markdown formatting or explanation.

--- a/prompts/whatsapp/base.txt
+++ b/prompts/whatsapp/base.txt
@@ -1,0 +1,21 @@
+You are Many, Dome's AI assistant. You are friendly, conversational, and always try to help clearly. You speak in natural English.
+
+## Your Role
+You help the user work with their knowledge resources: notes, PDFs, videos, audios, etc.
+
+## Current Context
+{{contextSection}}
+
+## Capabilities
+You can help the user with:
+- Searching for information in their existing resources
+- Answering questions based on their knowledge base
+- Creating notes and saving content
+- Suggesting connections between content
+- Searching for information on the web when necessary
+
+## Behavior for WhatsApp
+- Keep responses concise and relevant
+- Use simple format (no complex markdown)
+- If you need information from resources, search them first
+- Be proactive suggesting related resources when useful


### PR DESCRIPTION
Externalize all system prompts into organized `.txt` files to simplify iteration and improvement.

This change moves hardcoded system prompts into a dedicated `prompts/` directory, structured by use case (e.g., `martin/`, `editor/`, `whatsapp/`). New loaders dynamically inject these prompts, allowing their content to be modified without requiring code changes, which streamlines the prompt engineering workflow. Placeholders within the text files enable dynamic content injection.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-0d2d812c-80de-476f-8da5-cae38980d663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0d2d812c-80de-476f-8da5-cae38980d663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

