### PR TITLE
fix: Electron overlay IPC, WhatsApp handler, macOS system prefs URLs

### DIFF
--- a/app/components/many/ManyVoiceHud.tsx
+++ b/app/components/many/ManyVoiceHud.tsx
@@ -443,9 +443,18 @@ export default function ManyVoiceHud() {
       remoteManyStatus === 'thinking'
     );
 
+  // Defer hiding slightly so a cold-start toggle can start STS before we call hide()
+  // (startRealtimeSession is async; hudOpen stays false for a few ms after onToggle runs).
   useEffect(() => {
-    if (!window.electron?.manyVoice?.overlaySetVisible) return;
-    void window.electron.manyVoice.overlaySetVisible(hudOpen);
+    if (!window.electron?.manyVoice?.overlaySetVisible) return undefined;
+    if (hudOpen) {
+      void window.electron.manyVoice.overlaySetVisible(true);
+      return undefined;
+    }
+    const t = window.setTimeout(() => {
+      void window.electron.manyVoice.overlaySetVisible(false);
+    }, 150);
+    return () => clearTimeout(t);
   }, [hudOpen]);
 
   // ── Notify AppShell top-bar indicators ─────────────────────────────────

--- a/app/types/global.d.ts
+++ b/app/types/global.d.ts
@@ -1404,6 +1404,7 @@ declare global {
           success: boolean;
           sources?: Array<{ id: string; name: string }>;
           error?: string;
+          errorCode?: 'screen_capture_permission';
         }>;
         setDisplayMediaSource: (sourceId: string) => Promise<{ success: boolean; error?: string }>;
         getPermissionsStatus: () => Promise<{

--- a/electron/init.cjs
+++ b/electron/init.cjs
@@ -164,7 +164,7 @@ async function initializeApp() {
 
   // If already initialized, return immediately
   if (isInitialized) {
-    console.log('[Init] ⚠️ App already initialized');
+    console.debug('[Init] App already initialized (idempotent IPC)');
     return {
       success: true,
       needsOnboarding: checkOnboardingStatus(),

--- a/electron/ipc/transcription.cjs
+++ b/electron/ipc/transcription.cjs
@@ -677,7 +677,16 @@ function register({ ipcMain, windowManager, database, fileStorage, aiToolsHandle
       };
     } catch (err) {
       console.error('[Transcription] list-desktop-capture-sources:', err);
-      return { success: false, error: err.message };
+      const base = err instanceof Error ? err.message : String(err);
+      const error =
+        process.platform === 'darwin'
+          ? `${base} Si persiste, concede a Dome permiso de «Grabación de pantalla» en Preferencias del Sistema → Privacidad y seguridad.`
+          : base;
+      return {
+        success: false,
+        error,
+        ...(process.platform === 'darwin' ? { errorCode: 'screen_capture_permission' } : {}),
+      };
     }
   });
 }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -20,6 +20,12 @@ if (fs_env.existsSync(dotenvPath)) {
   }
 }
 
+// Child processes read NODE_OPTIONS before JS runs far enough for app.isPackaged; strip it when this
+// file is loaded from the packaged asar (not from the dev repo path).
+if (process.env.NODE_OPTIONS && __dirname.includes('app.asar')) {
+  delete process.env.NODE_OPTIONS;
+}
+
 const {
   app,
   BrowserWindow,

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -8,6 +8,77 @@ console.log('[Preload] Electron version:', process.versions.electron);
 console.log('[Preload] Chrome version:', process.versions.chrome);
 
 /**
+ * Dictation toggle from main may arrive before React registers a listener (overlay cold start).
+ * Buffer one toggle per preload context until onToggleRecording runs.
+ */
+const transcriptionToggleCallbacks = new Set();
+let pendingTranscriptionToggle = false;
+ipcRenderer.on('transcription:toggle-recording', () => {
+  if (transcriptionToggleCallbacks.size === 0) {
+    pendingTranscriptionToggle = true;
+    return;
+  }
+  for (const cb of transcriptionToggleCallbacks) {
+    try {
+      cb();
+    } catch (_) {
+      /* ignore renderer callback errors */
+    }
+  }
+});
+
+/**
+ * Many Voice (STS / Realtime) overlay: toolbar & global shortcut send toggle before React mounts.
+ */
+const manyVoiceToggleCallbacks = new Set();
+let pendingManyVoiceToggle = false;
+ipcRenderer.on('many-voice-assistant:toggle', () => {
+  if (manyVoiceToggleCallbacks.size === 0) {
+    pendingManyVoiceToggle = true;
+    return;
+  }
+  for (const cb of manyVoiceToggleCallbacks) {
+    try {
+      cb();
+    } catch (_) {
+      /* ignore */
+    }
+  }
+});
+
+const manyVoicePttStartCallbacks = new Set();
+let pendingManyVoicePttStart = false;
+ipcRenderer.on('many-voice-assistant:ptt-start', () => {
+  if (manyVoicePttStartCallbacks.size === 0) {
+    pendingManyVoicePttStart = true;
+    return;
+  }
+  for (const cb of manyVoicePttStartCallbacks) {
+    try {
+      cb();
+    } catch (_) {
+      /* ignore */
+    }
+  }
+});
+
+const manyVoicePttEndCallbacks = new Set();
+let pendingManyVoicePttEnd = false;
+ipcRenderer.on('many-voice-assistant:ptt-end', () => {
+  if (manyVoicePttEndCallbacks.size === 0) {
+    pendingManyVoicePttEnd = true;
+    return;
+  }
+  for (const cb of manyVoicePttEndCallbacks) {
+    try {
+      cb();
+    } catch (_) {
+      /* ignore */
+    }
+  }
+});
+
+/**
  * Electron Handler
  * Expone APIs de Electron de manera segura usando contextBridge
  * Basado en las mejores prácticas de Pile
@@ -1444,9 +1515,18 @@ const electronHandler = {
     getPermissionsStatus: () => ipcRenderer.invoke('transcription:get-permissions-status'),
     requestScreenAccess: () => ipcRenderer.invoke('transcription:request-screen-access'),
     onToggleRecording: (callback) => {
-      const subscription = () => callback();
-      ipcRenderer.on('transcription:toggle-recording', subscription);
-      return () => ipcRenderer.removeListener('transcription:toggle-recording', subscription);
+      transcriptionToggleCallbacks.add(callback);
+      if (pendingTranscriptionToggle) {
+        pendingTranscriptionToggle = false;
+        try {
+          callback();
+        } catch (_) {
+          /* ignore */
+        }
+      }
+      return () => {
+        transcriptionToggleCallbacks.delete(callback);
+      };
     },
   },
 
@@ -1465,19 +1545,46 @@ const electronHandler = {
 
   manyVoice: {
     onToggle: (callback) => {
-      const subscription = () => callback();
-      ipcRenderer.on('many-voice-assistant:toggle', subscription);
-      return () => ipcRenderer.removeListener('many-voice-assistant:toggle', subscription);
+      manyVoiceToggleCallbacks.add(callback);
+      if (pendingManyVoiceToggle) {
+        pendingManyVoiceToggle = false;
+        try {
+          callback();
+        } catch (_) {
+          /* ignore */
+        }
+      }
+      return () => {
+        manyVoiceToggleCallbacks.delete(callback);
+      };
     },
     onPttStart: (callback) => {
-      const subscription = () => callback();
-      ipcRenderer.on('many-voice-assistant:ptt-start', subscription);
-      return () => ipcRenderer.removeListener('many-voice-assistant:ptt-start', subscription);
+      manyVoicePttStartCallbacks.add(callback);
+      if (pendingManyVoicePttStart) {
+        pendingManyVoicePttStart = false;
+        try {
+          callback();
+        } catch (_) {
+          /* ignore */
+        }
+      }
+      return () => {
+        manyVoicePttStartCallbacks.delete(callback);
+      };
     },
     onPttEnd: (callback) => {
-      const subscription = () => callback();
-      ipcRenderer.on('many-voice-assistant:ptt-end', subscription);
-      return () => ipcRenderer.removeListener('many-voice-assistant:ptt-end', subscription);
+      manyVoicePttEndCallbacks.add(callback);
+      if (pendingManyVoicePttEnd) {
+        pendingManyVoicePttEnd = false;
+        try {
+          callback();
+        } catch (_) {
+          /* ignore */
+        }
+      }
+      return () => {
+        manyVoicePttEndCallbacks.delete(callback);
+      };
     },
     relaySend: (args) => ipcRenderer.invoke('many-voice:relay-send', args),
     pushStateToOverlay: (payload) =>

--- a/electron/security.cjs
+++ b/electron/security.cjs
@@ -100,10 +100,18 @@ function validateUrl(url) {
 
   try {
     const parsed = new URL(url);
-    
-    // Only allow http and https protocols
-    if (!['http:', 'https:'].includes(parsed.protocol)) {
-      throw new Error(`Unsafe URL protocol: ${parsed.protocol}. Only http: and https: are allowed`);
+
+    const allowed = ['http:', 'https:'];
+    if (process.platform === 'darwin') {
+      allowed.push('x-apple.systempreferences:');
+    }
+
+    if (!allowed.includes(parsed.protocol)) {
+      const hint =
+        process.platform === 'darwin'
+          ? 'Only http:, https:, and x-apple.systempreferences: are allowed'
+          : 'Only http: and https: are allowed';
+      throw new Error(`Unsafe URL protocol: ${parsed.protocol}. ${hint}`);
     }
 
     return url;

--- a/electron/whatsapp/message-handler.cjs
+++ b/electron/whatsapp/message-handler.cjs
@@ -14,7 +14,6 @@ const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
 const { app } = require('electron');
-const aiToolsHandler = require('../ai-tools-handler.cjs');
 const { chatWithToolsInMain, getWhatsAppToolDefinitions } = require('../ai-chat-with-tools.cjs');
 
 // Dependencias que se inyectan


### PR DESCRIPTION
## Summary
- Fix cold-start race where main sent `transcription:toggle-recording` and Many Voice `many-voice-assistant:*` events before React registered preload listeners; buffer pending toggles in `preload.cjs`.
- Defer hiding the Many Voice overlay briefly so OpenAI Realtime (STS) can transition `hudOpen` before `overlaySetVisible(false)` runs.
- Fix WhatsApp service load failure from duplicate `aiToolsHandler` binding in `message-handler.cjs`.
- Allow `x-apple.systempreferences:` for `open-external-url` on macOS (screen recording settings links).
- Strip `NODE_OPTIONS` before `require('electron')` when running from `app.asar` to avoid packaged-app child-process warnings.
- Reduce duplicate init log noise (`console.debug`); improve macOS desktop capture error hint and optional `errorCode` in types.

## Flag
Flag: none

## Type
- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs/config

## Checklist
- [x] typecheck passes
- [x] lint passes
- [x] build passes
- [x] i18n keys in all 4 languages (if new strings) — N/A (no new UI strings)
- [x] No hardcoded colors