### PR TITLE
fix: React useEffect cleanup audit fixes

### DIFF
--- a/app/components/viewers/VideoPlayer.tsx
+++ b/app/components/viewers/VideoPlayer.tsx
@@ -229,18 +229,18 @@ function VideoPlayerComponent({ resource }: VideoPlayerProps) {
       }
     };
 
+    const onMouseLeave = () => { if (isPlaying) setShowControls(false); };
     const container = containerRef.current;
     if (container) {
       container.addEventListener('mousemove', handleMouseMove);
-      container.addEventListener('mouseleave', () => {
-        if (isPlaying) setShowControls(false);
-      });
+      container.addEventListener('mouseleave', onMouseLeave);
     }
 
     return () => {
       clearTimeout(timeout);
       if (container) {
         container.removeEventListener('mousemove', handleMouseMove);
+        container.removeEventListener('mouseleave', onMouseLeave);
       }
     };
   }, [isPlaying]);


### PR DESCRIPTION
## Summary
- Fixed VideoPlayer.tsx: missing `mouseleave` event listener cleanup — was causing memory leak since the inline handler `() => { if (isPlaying) setShowControls(false); }` was never removed on unmount

## Flag
none

## Type
- [ ] Bug fix

## Checklist
- [x] typecheck passes
- [x] lint passes (297 pre-existing warnings)
- [x] build passes
- [x] No hardcoded colors