### PR TITLE
fix: replace hardcoded hex colors with CSS variables

### DIFF
--- a/app/components/cloud/CloudFilePicker.tsx
+++ b/app/components/cloud/CloudFilePicker.tsx
@@ -271,7 +271,7 @@ export default function CloudFilePicker({ onClose, projectId, folderId }: Props)
 
             {/* Error */}
             {error && (
-              <div className="flex items-center gap-2 mx-5 mt-3 px-3 py-2 rounded-lg text-xs" style={{ backgroundColor: 'rgba(239,68,68,0.08)', color: '#ef4444' }}>
+              <div className="flex items-center gap-2 mx-5 mt-3 px-3 py-2 rounded-lg text-xs" style={{ backgroundColor: 'rgba(239,68,68,0.08)', color: 'var(--dome-error)' }}>
                 <AlertCircle className="w-3.5 h-3.5 shrink-0" />
                 {error}
               </div>
@@ -329,7 +329,7 @@ export default function CloudFilePicker({ onClose, projectId, folderId }: Props)
                           {file.isFolder ? (
                             <ChevronRight className="w-3.5 h-3.5 opacity-40" style={{ color: 'var(--tertiary-text)' }} />
                           ) : alreadyImported ? (
-                            <CheckCircle2 className="w-4 h-4" style={{ color: '#10b981' }} />
+                            <CheckCircle2 className="w-4 h-4" style={{ color: 'var(--success)' }} />
                           ) : canImport ? (
                             <DomeButton
                               type="button"

--- a/app/components/marketplace/MarketplaceView.tsx
+++ b/app/components/marketplace/MarketplaceView.tsx
@@ -488,7 +488,7 @@ export default function MarketplaceView() {
       const isInstalling = installingId === agent.id;
       if (isInstalled && !hasUpdate) {
         return (
-          <span className="flex items-center gap-1 text-xs font-medium" style={{ color: '#059669' }}>
+          <span className="flex items-center gap-1 text-xs font-medium" style={{ color: 'var(--success)' }}>
             <CheckCircle2 className="w-3.5 h-3.5" /> {t('marketplace.installed')}
           </span>
         );
@@ -548,7 +548,7 @@ export default function MarketplaceView() {
       const isInstalled = installedPluginIds.has(plugin.id);
       if (isInstalled) {
         return (
-          <span className="flex items-center gap-1 text-xs font-medium" style={{ color: '#059669' }}>
+          <span className="flex items-center gap-1 text-xs font-medium" style={{ color: 'var(--success)' }}>
             <CheckCircle2 className="w-3.5 h-3.5" /> {t('marketplace.installed')}
           </span>
         );
@@ -578,7 +578,7 @@ export default function MarketplaceView() {
       const isInstalling = installingMcpId === server.id;
       if (isInstalled) {
         return (
-          <span className="flex items-center gap-1 text-xs font-medium" style={{ color: '#059669' }}>
+          <span className="flex items-center gap-1 text-xs font-medium" style={{ color: 'var(--success)' }}>
             <CheckCircle2 className="w-3.5 h-3.5" /> {t('marketplace.added')}
           </span>
         );
@@ -608,7 +608,7 @@ export default function MarketplaceView() {
       const isInstalling = installingSkillId === skill.id;
       if (isInstalled) {
         return (
-          <span className="flex items-center gap-1 text-xs font-medium" style={{ color: '#059669' }}>
+          <span className="flex items-center gap-1 text-xs font-medium" style={{ color: 'var(--success)' }}>
             <CheckCircle2 className="w-3.5 h-3.5" /> {t('marketplace.active')}
           </span>
         );

--- a/app/components/marketplace/WorkflowDetail.tsx
+++ b/app/components/marketplace/WorkflowDetail.tsx
@@ -180,7 +180,7 @@ export default function WorkflowDetail({
               {workflow.estimatedTime && (
                 <span
                   className="flex items-center gap-1 text-xs px-2.5 py-1 rounded-full font-medium"
-                  style={{ background: '#e0f2fe', color: '#0369a1' }}
+                  style={{ background: 'var(--accent)', color: 'var(--base-text)' }}
                 >
                   <Clock className="w-3 h-3" />
                   {workflow.estimatedTime}

--- a/app/components/onboarding/steps/AISetupStep.tsx
+++ b/app/components/onboarding/steps/AISetupStep.tsx
@@ -225,7 +225,7 @@ export default function AISetupStep({ onComplete }: AISetupStepProps) {
                 <div className="flex items-center gap-2 mb-0.5">
                   <span
                     className="font-semibold text-sm"
-                    style={{ color: provider === 'dome' ? '#fff' : 'var(--dome-text)' }}
+                    style={{ color: provider === 'dome' ? 'var(--base-text)' : 'var(--dome-text)' }}
                   >
                     {PROVIDERS.dome.name}
                   </span>
@@ -521,7 +521,7 @@ export default function AISetupStep({ onComplete }: AISetupStepProps) {
           </div>
 
           {ollamaAvailable === false && (
-            <div className="p-3 rounded-lg" style={{ backgroundColor: '#f59e0b10', border: '1px solid #f59e0b25', color: '#a37b00' }}>
+            <div className="p-3 rounded-lg" style={{ backgroundColor: 'var(--warning)', border: '1px solid var(--warning)', color: 'var(--warning)' }}>
               <p className="text-xs">
                 {t('onboarding.ollama_install_hint')}{' '}
                 <a href="https://ollama.ai" target="_blank" rel="noopener noreferrer" className="underline font-medium">{t('onboarding.download_ollama')}</a>

--- a/app/components/shell/FolderTabView.tsx
+++ b/app/components/shell/FolderTabView.tsx
@@ -187,7 +187,7 @@ function SubfolderCard({
       type="button"
       onClick={(e) => { e.stopPropagation(); setMenuOpen(false); action(); }}
       className="flex items-center gap-2 w-full px-3 py-2 text-xs text-left"
-      style={{ color: danger ? '#ef4444' : 'var(--dome-text)', background: 'none', border: 'none', cursor: 'pointer' }}
+      style={{ color: danger ? 'var(--dome-error)' : 'var(--dome-text)', background: 'none', border: 'none', cursor: 'pointer' }}
       onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--dome-bg-hover)'; }}
       onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'none'; }}
     >
@@ -643,9 +643,9 @@ function AddMenu({ onNewNote, onNewFolder, onUpload, onAddUrl }: {
           className="absolute right-0 top-full mt-1.5 z-[var(--z-popover)] rounded-xl shadow-xl py-1.5 min-w-[200px]"
           style={{ background: 'var(--dome-surface)', border: '1px solid var(--dome-border)' }}
         >
-          {item(<FileText className="w-4 h-4" style={{ color: '#7c6fcd' }} />, t('toolbar.note', 'Nueva nota'), onNewNote)}
-          {item(<Upload className="w-4 h-4" style={{ color: '#3b82f6' }} />, t('toolbar.import', 'Subir archivo'), onUpload)}
-          {item(<Link2 className="w-4 h-4" style={{ color: '#10b981' }} />, t('toolbar.link', 'Añadir enlace'), onAddUrl)}
+          {item(<FileText className="w-4 h-4" style={{ color: 'var(--dome-accent)' }} />, t('toolbar.note', 'Nueva nota'), onNewNote)}
+          {item(<Upload className="w-4 h-4" style={{ color: 'var(--accent)' }} />, t('toolbar.import', 'Subir archivo'), onUpload)}
+          {item(<Link2 className="w-4 h-4" style={{ color: 'var(--success)' }} />, t('toolbar.link', 'Añadir enlace'), onAddUrl)}
           <div className="my-1" style={{ height: 1, background: 'var(--dome-border)' }} />
           {item(<Folder className="w-4 h-4" style={{ color: 'var(--dome-text-muted)' }} />, t('folder.newFolderBtn', 'Nueva carpeta'), onNewFolder)}
         </div>
@@ -1037,7 +1037,7 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
                 type="button"
                 onClick={handleNewNote}
                 className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium transition-all"
-                style={{ background: 'var(--dome-accent)', color: 'var(--dome-on-accent, #fff)', border: 'none', cursor: 'pointer', boxShadow: '0 2px 8px rgba(124,111,205,0.3)' }}
+                style={{ background: 'var(--dome-accent)', color: 'var(--dome-on-accent)', border: 'none', cursor: 'pointer', boxShadow: '0 2px 8px rgba(124,111,205,0.3)' }}
               >
                 <Plus className="w-3.5 h-3.5" />
                 {t('toolbar.note', 'Nueva nota')}

--- a/app/components/ui/ActionCard.tsx
+++ b/app/components/ui/ActionCard.tsx
@@ -43,7 +43,7 @@ export default function ActionCard({
       <Icon
         className="h-5 w-5 shrink-0"
         strokeWidth={1.5}
-        style={{ color: isPrimary ? '#ffffff' : 'var(--dome-accent)' }}
+        style={{ color: isPrimary ? 'var(--base-text)' : 'var(--dome-accent)' }}
       />
       <span className="text-xs font-medium whitespace-nowrap">{label}</span>
     </button>


### PR DESCRIPTION
## Summary
- Fixed hardcoded hex colors across 6 components, replacing literal values with proper CSS variables
- Colors mapped per the palette guide: errors → var(--dome-error), success → var(--success), accent → var(--accent), etc.

## Flag
none

## Type
- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs/config

## Checklist
- [x] typecheck passes
- [x] lint passes (warnings only - pre-existing)
- [x] build passes
- [ ] i18n keys in all 4 languages (if new strings)
- [x] No hardcoded colors