### PR TITLE
fix: replace hardcoded hex colors with CSS variables

### DIFF
--- a/app/components/agents/AgentChatInput.tsx
+++ b/app/components/agents/AgentChatInput.tsx
@@ -240,7 +240,7 @@ export default memo(function AgentChatInput({
                 onClick={onAbort}
                 className="flex h-7 w-7 items-center justify-center rounded transition-colors hover:bg-[var(--dome-bg)]"
                 style={{
-                  color: '#ef4444',
+                  color: 'var(--error)',
                   backgroundColor: 'transparent',
                 }}
                 title="Stop"

--- a/app/components/chat/ChatToolCard.tsx
+++ b/app/components/chat/ChatToolCard.tsx
@@ -569,7 +569,7 @@ export default function ChatToolCard({ toolCall, className = '' }: ChatToolCardP
               ) : toolCall.status === 'error' ? (
                 <XCircle className="w-[13px] h-[13px] text-[var(--error)]" />
               ) : toolCall.status === 'success' ? (
-                <CheckCircle2 className="w-[13px] h-[13px] text-[#10b981]" />
+                <CheckCircle2 className="w-[13px] h-[13px] text-[var(--success)]" />
               ) : (
                 <Icon className="w-[13px] h-[13px] text-[var(--tertiary-text)]" />
               )}
@@ -656,7 +656,7 @@ export function ChatToolCardGroup({ name, calls, className = '' }: ChatToolCardG
               ) : hasError ? (
                 <XCircle className="w-[13px] h-[13px] text-[var(--error)]" />
               ) : allSuccess ? (
-                <CheckCircle2 className="w-[13px] h-[13px] text-[#10b981]" />
+                <CheckCircle2 className="w-[13px] h-[13px] text-[var(--success)]" />
               ) : (
                 <Icon className="w-[13px] h-[13px] text-[var(--tertiary-text)]" />
               )}

--- a/app/components/home/ResourceCard.tsx
+++ b/app/components/home/ResourceCard.tsx
@@ -94,14 +94,14 @@ export default memo(function ResourceCard({
   const getTypeColor = () => {
     if (resource.type === 'excel') {
       switch (excelSubType) {
-        case 'xlsx': return '#217346';
+        case 'xlsx': return 'var(--success)';
         default: return 'var(--tertiary-text)';
       }
     }
     switch (resource.type) {
       case 'note': return 'var(--accent)';
       case 'notebook': return 'var(--success)';
-      case 'ppt': return '#D24726';
+      case 'ppt': return 'var(--warning)';
       case 'image': return 'var(--brand-accent)';
       case 'video': return 'var(--info)';
       case 'audio': return 'var(--warning)';

--- a/app/components/marketplace/MarketplaceView.tsx
+++ b/app/components/marketplace/MarketplaceView.tsx
@@ -104,11 +104,11 @@ export default function MarketplaceView() {
     });
     return {
       all: row('all', Store, 'var(--dome-surface)', 'var(--dome-text-muted)'),
-      agents: row('agents', Bot, '#ede9fe', '#7c3aed'),
-      workflows: row('workflows', Workflow, '#d1fae5', '#059669'),
-      mcp: row('mcp', FolderCog, '#fef3c7', '#d97706'),
-      skills: row('skills', Sparkles, '#fce7f3', '#db2777'),
-      plugins: row('plugins', Plug, '#e0f2fe', '#0284c7'),
+      agents: row('agents', Bot, 'var(--dome-accent-bg)', 'var(--dome-accent)'),
+      workflows: row('workflows', Workflow, 'var(--success)', 'var(--dome-surface)'),
+      mcp: row('mcp', FolderCog, 'var(--warning)', 'var(--dome-surface)'),
+      skills: row('skills', Sparkles, 'var(--dome-accent)', 'var(--dome-surface)'),
+      plugins: row('plugins', Plug, 'var(--info)', 'var(--dome-surface)'),
     } satisfies Record<FilterType, { label: string; Icon: React.ElementType; badge: string; bgColor: string; textColor: string }>;
   }, [t]);
 

--- a/app/components/marketplace/WorkflowDetail.tsx
+++ b/app/components/marketplace/WorkflowDetail.tsx
@@ -23,9 +23,9 @@ const NODE_TYPE_META: Record<string, { label: string; color: string; Icon: React
 };
 
 const DIFFICULTY_STYLES = {
-  beginner: { bg: '#f0fdf4', text: '#15803d', label: 'Básico', icon: '🟢' },
-  intermediate: { bg: '#fffbeb', text: '#92400e', label: 'Medio', icon: '🟡' },
-  advanced: { bg: '#fef2f2', text: '#991b1b', label: 'Avanzado', icon: '🔴' },
+  beginner: { bg: 'var(--bg-secondary)', text: 'var(--success)', label: 'Básico', icon: '🟢' },
+  intermediate: { bg: 'var(--bg-secondary)', text: 'var(--warning)', label: 'Medio', icon: '🟡' },
+  advanced: { bg: 'var(--bg-secondary)', text: 'var(--error)', label: 'Avanzado', icon: '🔴' },
 };
 
 export default function WorkflowDetail({

--- a/app/components/shell/FolderTabView.tsx
+++ b/app/components/shell/FolderTabView.tsx
@@ -1016,7 +1016,7 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
         {colorPickerPos && (
           <ColorPickerPopover
             pos={colorPickerPos}
-            currentColor={folderColorHex ?? '#596037'}
+            currentColor={folderColorHex ?? 'var(--accent)'}
             onSave={handleCurrentFolderColor}
             onClose={() => setColorPickerPos(null)}
           />

--- a/app/components/ui/ActionCard.tsx
+++ b/app/components/ui/ActionCard.tsx
@@ -27,7 +27,7 @@ export default function ActionCard({
       style={{
         background: isPrimary ? 'var(--dome-accent)' : 'var(--dome-surface)',
         borderColor: isPrimary ? 'var(--dome-accent)' : 'var(--dome-border)',
-        color: isPrimary ? '#ffffff' : 'var(--dome-text)',
+        color: isPrimary ? 'var(--base-text)' : 'var(--dome-text)',
       }}
       onMouseEnter={(e) => {
         if (!isPrimary) {


### PR DESCRIPTION
## Summary
- Replaced hardcoded hex colors with CSS variables in 7 files: ActionCard, AgentChatInput, ChatToolCard, FolderTabView, MarketplaceView, ResourceCard, WorkflowDetail
- Fixed: \`#10b981\` → \`var(--success)\`, \`#ef4444\` → \`var(--error)\`, \`#ffffff\` → \`var(--base-text)\`, \`#D24726\` → \`var(--warning)\`, \`#217346\` → \`var(--success)\`

## Flag
none

## Type
- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs/config

## Checklist
- [x] typecheck passes
- [x] lint passes (warnings only, no errors)
- [x] build passes