### PR TITLE
feat(agents): versioned prompts, line-level AI review, milestones dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,12 +26,14 @@ Execute the steps below in order. Do not stop between steps unless you hit an ir
 
 ### Step 0 — Classify the task
 
-| Task type | Signal words | Branch prefix | Flag needed? |
-|---|---|---|---|
-| New feature | add, implement, create, build | `feat/` | Yes (if user-visible) |
-| Bug fix | fix, broken, error, crash, wrong | `fix/` | No |
-| Refactor | rename, move, extract, clean | `refactor/` | No |
-| Docs/config | only `.md`, `.yml`, `.json` | `docs/` | No |
+
+| Task type   | Signal words                     | Branch prefix | Flag needed?          |
+| ----------- | -------------------------------- | ------------- | --------------------- |
+| New feature | add, implement, create, build    | `feat/`       | Yes (if user-visible) |
+| Bug fix     | fix, broken, error, crash, wrong | `fix/`        | No                    |
+| Refactor    | rename, move, extract, clean     | `refactor/`   | No                    |
+| Docs/config | only `.md`, `.yml`, `.json`      | `docs/`       | No                    |
+
 
 ### Step 1 — Create a branch
 
@@ -46,6 +48,7 @@ git checkout -b feat/<short-description>
 Skip for bug fixes and refactors.
 
 If the feature is **user-visible or experimental**:
+
 - Choose flag name: `dome-<feature>` (e.g. `dome-export-pdf`, `dome-new-onboarding`)
 - Wrap new UI/logic behind the flag gate:
 
@@ -70,6 +73,7 @@ If the feature is **internal / infrastructure** (no user-visible change): skip t
 **The non-negotiable rules CI enforces:**
 
 #### Renderer/main process boundary
+
 ```typescript
 // ✅ In app/ — use IPC
 const result = await window.electron.invoke('resources:create', data);
@@ -81,6 +85,7 @@ import { ipcRenderer } from 'electron';
 ```
 
 #### New IPC channel (follow every step or it silently fails)
+
 1. Handler in `electron/ipc/<domain>.cjs` — validate inputs, return `{ success, data/error }`
 2. Register in `electron/ipc/index.cjs`
 3. Add channel name to `electron/preload.cjs` ALLOWED_CHANNELS array
@@ -89,6 +94,7 @@ import { ipcRenderer } from 'electron';
 Full guide: `.claude/sops/new-ipc-channel.md`
 
 #### i18n — required for all user-visible strings
+
 ```typescript
 // In the component
 const { t } = useTranslation();
@@ -102,6 +108,7 @@ return <span>{t('my_feature.title')}</span>;
 ```
 
 #### Colors — always CSS variables
+
 ```tsx
 // ✅
 style={{ color: 'var(--primary-text)', background: 'var(--bg-secondary)' }}
@@ -110,12 +117,14 @@ style={{ color: '#040316', background: '#f2f2f9' }}
 ```
 
 #### Type imports — verbatimModuleSyntax is ON
+
 ```typescript
 import type { Resource } from '@/types'; // ✅ type-only
 import { Resource } from '@/types';      // ❌ if Resource is only a type
 ```
 
 #### TypeScript — no any
+
 ```typescript
 // ✅
 function createResource(data: Partial<Resource>): Resource { ... }
@@ -134,6 +143,7 @@ npm run build       # must succeed
 ```
 
 Quick architecture self-check (must return 0 lines):
+
 ```bash
 grep -rn "better-sqlite3\|bun:sqlite\|from 'fs'" app/ --include="*.ts" --include="*.tsx"
 ```
@@ -185,7 +195,7 @@ Your work is complete. The automated pipeline takes over:
 ```
 PR open
   ├─► CI: typecheck + lint + build + architecture guard   (~3 min)
-  ├─► AI Code Review: 3 passes posted as PR comment       (~2 min)
+  ├─► AI Code Review: 3 passes with line-level comments   (~2 min)
   └─► Auto-merge when all checks pass
         └─► Post-merge: feature flag enabled for team in PostHog
 ```
@@ -194,19 +204,65 @@ You do not need to merge, enable flags, monitor, or do anything else.
 
 ---
 
+## Automated agents — editing prompts
+
+Two agent pipelines run against the repo. Their prompts are **versioned files
+on disk**, not inlined in scripts — edit the markdown to tune behavior.
+
+### AI review (GitHub Actions, `.github/workflows/ai-review.yml`)
+
+Runs 3 passes per PR, posting a review with line-level comments anchored to
+the diff. Each pass has its own prompt; the model returns strict JSON.
+
+- `prompts/review/architecture.md` — process separation, IPC whitelist, import type
+- `prompts/review/logic.md` — runtime errors, security, async correctness
+- `prompts/review/style.md` — CSS vars, i18n coverage, `any` types, React anti-patterns
+
+The driver is `scripts/ai-review.mjs`. Diffs are split by file (no 40KB
+truncation); large files are clipped at 60KB with a note in the summary.
+
+### VPS audits (OpenCode + MiniMax on a cron-driven VPS)
+
+Periodic sweeps per focus domain. Each focus has one prompt + a shared context
+block. Prompts include explicit "run `bun tsc --noEmit` / `grep` before fixing"
+instructions so the agent verifies findings against live code.
+
+- `prompts/shared/project-context.md` — shared across all audit prompts
+- `prompts/audits/<focus>.md` — one per focus (security, types, i18n, debt, vulns,
+  react, errors, deps, all)
+- `prompts/audits/_chain-header.md` — injected when multiple focuses run in a
+  chain via `scripts/vps-audit-chain.sh`
+
+### Frontmatter versioning rule
+
+Every prompt file carries YAML frontmatter with `version:` (integer). **Bump
+the version when you change the prompt semantics.** The driver stamps each PR
+body with a `Prompt bundle` tag (e.g. `shared@1+security@2`) and persists
+`first_seen_prompt_version` on each finding, so regressions can be correlated
+to a specific prompt version.
+
+---
+
 ## Reference — where to look
 
-| Need | Location |
-|---|---|
-| Architecture rules | `.claude/rules/architecture-rules.md` |
-| New IPC step-by-step | `.claude/sops/new-ipc-channel.md` |
-| Feature flags usage | `.claude/sops/feature-flags.md` |
-| PR checklist | `.claude/sops/pr-checklist.md` |
-| Release process | `.claude/sops/release.md` |
-| Color palette variables | `.claude/rules/new-color-palette.md` |
-| All translations | `app/lib/i18n.ts` |
-| Existing IPC domains | `electron/ipc/` (one file per domain) |
-| Zustand stores | `app/lib/store/` |
-| Tab system | `app/lib/store/useTabStore.ts` |
-| Existing components | `app/components/` |
-| Electron window creation | `electron/window-manager.cjs` |
+
+| Need                        | Location                              |
+| --------------------------- | ------------------------------------- |
+| Architecture rules          | `.claude/rules/architecture-rules.md` |
+| New IPC step-by-step        | `.claude/sops/new-ipc-channel.md`     |
+| Feature flags usage         | `.claude/sops/feature-flags.md`       |
+| PR checklist                | `.claude/sops/pr-checklist.md`        |
+| Release process             | `.claude/sops/release.md`             |
+| Color palette variables     | `.claude/rules/new-color-palette.md`  |
+| All translations            | `app/lib/i18n.ts`                     |
+| Existing IPC domains        | `electron/ipc/` (one file per domain) |
+| Zustand stores              | `app/lib/store/`                      |
+| Tab system                  | `app/lib/store/useTabStore.ts`        |
+| Existing components         | `app/components/`                     |
+| Electron window creation    | `electron/window-manager.cjs`         |
+| AI review prompts           | `prompts/review/*.md`                 |
+| VPS audit prompts           | `prompts/audits/*.md` + `prompts/shared/` |
+| Audit milestones / targets  | `scripts/audit-milestones.json`       |
+| VPS audit + dashboard setup | `docs/vps-audit-setup.md`             |
+
+

--- a/docs/vps-audit-setup.md
+++ b/docs/vps-audit-setup.md
@@ -154,8 +154,19 @@ Añadir las líneas:
 # ── BAJOS — 2x/semana ────────────────────────────────────────────────────────
 0 10  * * 1,4  REPO_DIR=/opt/dome-audit/dome /opt/dome-audit/vps-audit.sh vulns >> /var/log/dome-audit.log 2>&1
 
+# ── PAQUETES — diaria 23:00 UTC (fuera de horas pico) ────────────────────────
+0 23  * * *  REPO_DIR=/opt/dome-audit/dome /opt/dome-audit/vps-audit.sh deps >> /var/log/dome-audit.log 2>&1
+
 # ── RESUMEN — lunes completo ──────────────────────────────────────────────────
 0 11  * * 1  REPO_DIR=/opt/dome-audit/dome /opt/dome-audit/vps-audit.sh all >> /var/log/dome-audit.log 2>&1
+
+# ── Findings lifecycle ───────────────────────────────────────────────────────
+# Extractor (cada 30min, recoge .pending jobs dejados por vps-audit.sh)
+*/30 * * * *  bash /opt/dome-audit/vps-audit-findings-cron.sh >> /var/log/dome-audit.log 2>&1
+# Re-verificación contra main (cada hora, marca findings resueltos)
+0    * * * *  REPO_DIR=/opt/dome-audit/dome bash /opt/dome-audit/vps-audit-resolve.sh >> /var/log/dome-audit.log 2>&1
+# Dashboard (cada 15min)
+*/15 * * * *  bash /opt/dome-audit/vps-audit-dashboard.sh >> /var/log/dome-audit.log 2>&1
 ```
 
 Ver logs:
@@ -178,6 +189,7 @@ tail -f /var/log/dome-audit.log
 | `debt`     | Hardcoded colors (~~468), console.logs (~~233)   | Cada 12h (4,16)     | 2x        |
 | `i18n`     | Traducciones faltantes en los 4 idiomas          | Cada 12h (5,17)     | 2x        |
 | `vulns`    | npm audit: 1 critical + 22 high vulnerabilities  | Lunes y jueves 10h  | 2x/semana |
+| `deps`     | Mantiene paquetes autorizados y al día (patch+minor), bloquea majors de paquetes congelados | Diaria 23h | 1x/día |
 | `all`      | Todo lo anterior                                 | Lunes 11h           | 1x/semana |
 
 
@@ -242,4 +254,144 @@ gh pr list --repo maxprain12/dome --state open | grep audit
 # Ver log de la última ejecución
 tail -50 /var/log/dome-audit.log
 ```
+
+---
+
+## 11. Ciclo de vida de los findings
+
+Los findings extraídos del AI review se almacenan en
+`/var/log/dome-audit-findings/<focus>.findings.json` con un `id` estable
+`<focus>:<file>:<line>:<sha1(pattern)>`. Cada finding pasa por estos estados:
+
+1. **open** — detectado en el último review, aún presente en `main`.
+2. **verifying** — no apareció en el último review (candidato a resolución).
+3. **resolved** — `vps-audit-resolve.sh` confirmó que el `pattern` ya no existe
+   en el archivo referenciado de `main` (o el archivo fue eliminado).
+
+El dashboard sólo muestra findings en estado `open`. Las transiciones quedan
+registradas en `/var/log/dome-audit-findings/resolutions.log`.
+
+Ejecución manual:
+
+```bash
+# Re-verificar todos los findings contra main (marca resueltos)
+REPO_DIR=/opt/dome-audit/dome bash /opt/dome-audit/vps-audit-resolve.sh
+
+# Reporte rápido por terminal
+bash /opt/dome-audit/vps-audit-findings.sh --report
+```
+
+Si quieres forzar una pasada de resolución tras desplegar estos scripts:
+
+```bash
+FORCE_RESOLVE=1 bash /opt/dome-audit/vps-audit-findings-cron.sh
+```
+
+---
+
+## 12. Deploy de cambios en los scripts
+
+Los scripts viven en el repo (`scripts/vps-audit*.sh`). Tras un `git pull` en el
+VPS hay que copiarlos a `/opt/dome-audit/` porque cron los ejecuta desde ahí:
+
+```bash
+cd /opt/dome-audit/dome && git pull origin main
+cp scripts/vps-audit.sh \
+   scripts/vps-audit-findings.sh \
+   scripts/vps-audit-findings-cron.sh \
+   scripts/vps-audit-resolve.sh \
+   scripts/vps-audit-dashboard.sh \
+   scripts/vps-audit-chain.sh \
+   /opt/dome-audit/
+chmod +x /opt/dome-audit/vps-audit*.sh
+```
+
+El dashboard lee `audit-milestones.json` desde el clone en `/opt/dome-audit/dome/scripts/`,
+así que un `git pull` en el clone basta para propagar cambios de milestones — no hay
+que copiarlo a `/opt/dome-audit/`.
+
+---
+
+## 13. Prompts versionados (editar para ajustar a los agentes)
+
+Los prompts que reciben los agentes viven en el repo bajo `prompts/`:
+
+```
+prompts/
+├── shared/
+│   └── project-context.md     # Contexto del proyecto (stack, CSS vars, i18n)
+├── audits/
+│   ├── _chain-header.md       # Inyectado en modo cadena (ver §14)
+│   ├── security.md            # Un archivo por focus (con frontmatter YAML)
+│   ├── errors.md
+│   ├── types.md
+│   ├── react.md
+│   ├── debt.md
+│   ├── i18n.md
+│   ├── vulns.md
+│   ├── deps.md
+│   └── all.md
+└── review/
+    ├── architecture.md        # AI review pass 1
+    ├── logic.md               # AI review pass 2
+    └── style.md               # AI review pass 3
+```
+
+Cada archivo tiene frontmatter YAML con `version:` — incrementarlo cuando se
+cambia el prompt. El PR generado incluye el `Prompt bundle` (por ejemplo,
+`shared@1+security@2`) para poder correlacionar findings con la versión que los
+produjo. El campo `first_seen_prompt_version` se persiste en cada finding.
+
+Para ajustar un prompt basta con editar el `.md` correspondiente, subir un commit
+a `main`, y hacer `git pull` en el VPS — el próximo run de cron lo usará.
+
+---
+
+## 14. Auditorías encadenadas (`vps-audit-chain.sh`)
+
+Ejecuta varias focuses en orden, pasando los findings de los anteriores como
+contexto a los siguientes:
+
+```bash
+# Manual
+bash /opt/dome-audit/vps-audit-chain.sh security,errors,types
+
+# Cron (diario 4am, tras el batch crítico)
+0 4 * * *  /opt/dome-audit/vps-audit-chain.sh security,errors,types >> /var/log/dome-audit.log 2>&1
+```
+
+Cada focus recibe un `--chain-context` con los 10 top open findings por severidad
+de los focuses previos. El agente decide si cruzar referencias, levantar TODOs
+del focus anterior o dejar intacto.
+
+Si algún paso falla el chain se detiene — los focuses anteriores ya habrán
+creado su PR independientemente.
+
+---
+
+## 15. Milestones + trends en el dashboard
+
+Config: `scripts/audit-milestones.json` (en el repo). Define:
+
+- `per_focus[]` — objetivos por focus, con `metric: "open_findings"`, `target`,
+  `deadline` (YYYY-MM-DD) y `label`.
+- `global` — objetivo de health score, con `metric: "health_score"`, `target`,
+  `deadline`.
+
+El dashboard (`vps-audit-dashboard.sh`) lee esta config, calcula el estado de
+cada milestone (`on-track` / `at-risk` / `overdue`) con base en el progreso y la
+pendiente de los últimos 7+ snapshots, y renderiza una sección **Milestones**
+antes del grid de foci.
+
+History file: `/var/log/dome-audit-findings/history.jsonl` (append-only, una
+línea por focus + una línea `__global__` cada vez que corre el dashboard — por
+defecto cada 15 min). Se trunca automáticamente a `HISTORY_MAX_LINES` (default
+5000, ~52 días con la cadencia de 15 min). Puedes ajustarlo:
+
+```bash
+HISTORY_MAX_LINES=10000 bash /opt/dome-audit/vps-audit-dashboard.sh
+```
+
+Las sparklines del dashboard (per-focus y global de health score) se dibujan
+desde las últimas 30 entradas de este archivo.
 

--- a/prompts/audits/_chain-header.md
+++ b/prompts/audits/_chain-header.md
@@ -1,0 +1,24 @@
+---
+name: chain-header
+description: Injected at the top of an audit prompt when the agent is running as a step in a vps-audit-chain.sh invocation. Gives downstream agents the context of upstream agents' findings.
+version: 1
+last_updated: 2026-04-17
+---
+
+## Chain context — upstream audits have already run
+
+You are running as part of a **chained audit**. Agents before you have already
+reviewed this branch and produced the findings below. Use them as context:
+
+- If a finding in your own focus overlaps with an upstream finding, cross-reference
+  it instead of duplicating the fix.
+- If an upstream agent left a TODO that is actually in your focus, pick it up.
+- Do **not** undo changes made by upstream agents unless they are clearly broken.
+
+### Upstream findings
+
+${CHAIN_CONTEXT}
+
+---
+
+Continue with your focus-specific instructions below.

--- a/prompts/audits/all.md
+++ b/prompts/audits/all.md
@@ -1,0 +1,32 @@
+---
+name: audit-all
+description: Comprehensive audit covering every focus. Used for weekly sweeps.
+version: 1
+focus: all
+last_updated: 2026-04-17
+---
+
+## Focus: Full Audit (all areas)
+
+Perform a comprehensive audit covering:
+
+1. **Security:** IPC validation, SQL injection, path traversal
+2. **TypeScript:** `any` types, missing `import type`, null safety
+3. **i18n:** missing translations in `app/lib/i18n.ts`
+4. **Code quality:** hardcoded colors, dead code, console.logs
+5. **React:** `useEffect` cleanup, direct state mutations
+6. **Errors:** missing Error Boundaries, IPC try/catch
+
+### Priority order
+
+Security > Errors > TypeScript > React > Code quality > i18n.
+
+### Deliverable
+
+Fix the top 5-10 most impactful issues. Do not try to fix everything at once.
+
+### Tool use
+
+Before proposing fixes, run the relevant tool-use checks documented in the
+per-focus prompts (`prompts/audits/<focus>.md`). When in doubt, confirm the
+pattern still exists in `main` before proposing a fix.

--- a/prompts/audits/debt.md
+++ b/prompts/audits/debt.md
@@ -1,0 +1,44 @@
+---
+name: audit-debt
+description: Technical debt — dead code, duplicate logic, hardcoded colors, console.logs, stale TODOs.
+version: 1
+focus: debt
+last_updated: 2026-04-17
+---
+
+## Focus: Technical Debt
+
+Audit the codebase for technical debt:
+
+1. Dead code: exported functions/components that are never imported anywhere
+2. Duplicate logic: same pattern repeated 3+ times that could be extracted to a shared util
+3. Hardcoded colors: literal hex values (e.g. `color: '#ef4444'`) in `style=` attributes that should use CSS variables
+4. `console.log` statements left in production code (`console.error`/`warn` are fine)
+5. TODO/FIXME comments older than 30 days
+
+### IMPORTANT for color fixes
+
+- Replace hardcoded hex values with the CSS variables listed in the shared project context
+- Do NOT replace CSS variable usages — they are already correct
+- Mapping guide:
+  - `#ef4444` or red-ish errors → `var(--dome-error)` or `var(--error)`
+  - `#ffffff` or `#fff` on buttons → `var(--base-text)`
+  - `#0ea5e9` or blue → `var(--accent)`
+  - `#111827` or dark text → `var(--primary-text)`
+  - `#6b7280` or medium text → `var(--secondary-text)`
+  - `#9ca3af` or muted text → `var(--tertiary-text)`
+  - `#f9fafb` or light bg → `var(--bg-secondary)`
+  - `#f3f4f6` → `var(--bg-tertiary)`
+  - `#e5e7eb` borders → `var(--border)`
+
+### Baseline metrics
+
+There are currently ~468 hardcoded hex colors and ~233 `console.log` in the codebase.
+Focus on the files with the most occurrences first.
+Fix the hardcoded colors and console.logs. Flag the rest with a TODO comment.
+
+### Tool use (required before proposing fixes)
+
+- `grep -rnE "#[0-9a-fA-F]{3,6}" app/ --include='*.tsx' --include='*.ts' | grep -v "var(--" | wc -l` — baseline count
+- `grep -rn "console.log" app/ --include='*.ts' --include='*.tsx' | wc -l` — baseline count
+- Verify dead-code claims with `grep -rn "<FnName>" app/ electron/` — a function imported via `export *` or dynamic import is NOT dead

--- a/prompts/audits/deps.md
+++ b/prompts/audits/deps.md
@@ -1,0 +1,102 @@
+---
+name: audit-deps
+description: Package authorization & freshness — keep dependencies authorized, up-to-date within semver, and CVE-free.
+version: 1
+focus: deps
+last_updated: 2026-04-17
+---
+
+## Focus: Package Authorization & Freshness (deps audit)
+
+Mission: keep every dependency in `package.json` authorized (already listed),
+up-to-date within its semver range, and free of HIGH/CRITICAL CVEs. This focus
+differs from `vulns` — `vulns` audits whether vulnerable code paths are USED;
+`deps` keeps the manifest and lockfiles healthy.
+
+### Step 1 — Inventory
+
+```bash
+cat package.json | jq '.dependencies, .devDependencies'
+```
+
+Record the exact list of authorized package names BEFORE any change. You
+MUST NOT add packages that weren't already listed — removing or bumping is
+fine, adding new packages is forbidden in this audit.
+
+### Step 2 — Vulnerability scan
+
+```bash
+npm audit --json > /tmp/npm-audit.json
+```
+
+Parse the JSON. For every advisory with severity ∈ {high, critical}:
+- Note: module name, version range, CVE id, advisory URL, patched range
+- If `fixAvailable` is true and it's a safe (patch/minor) bump → apply via
+  `npm install <pkg>@<patched-version> --save --ignore-scripts`
+- If fix requires a major bump of a frozen package (see Step 4) → add a
+  row in `SECURITY.md` documenting the CVE (create the file if missing)
+
+### Step 3 — Outdated scan (patch + minor only)
+
+```bash
+npm outdated --json > /tmp/npm-outdated.json
+```
+
+For every package where `current < wanted` (i.e. the semver range allows it):
+- Bump to `wanted` via: `npm install <pkg>@<wanted> --save --ignore-scripts`
+- Do NOT bump to `latest` when `latest` crosses a major boundary
+
+Skip packages listed in the FROZEN whitelist (Step 4).
+
+### Step 4 — Frozen packages (NEVER bump, even patch, without a follow-up issue)
+
+- `electron`
+- `better-sqlite3`
+- `@langchain/core`, `@langchain/langgraph`, `@langchain/openai`, `@langchain/anthropic`,
+  `@langchain/google-genai`, `@langchain/community`
+- `vite`, `@vitejs/plugin-react`
+- `react`, `react-dom`
+- `@tiptap/*` (breaking changes between minors)
+- `node-pty`, `sharp`, `@napi-rs/canvas`, `archiver`, `yauzl` (native modules)
+
+If you believe a frozen package MUST be bumped for security, do NOT bump it.
+Instead append an entry to `SECURITY.md` with the CVE and a TODO for manual review.
+
+### Step 5 — Lockfile coherence
+
+The repo uses BOTH `bun.lock` and `package-lock.json`. After any `package.json`
+change, regenerate both so they agree:
+
+```bash
+rm -f package-lock.json bun.lock
+npm install --ignore-scripts      # regenerates package-lock.json
+bun install                        # regenerates bun.lock (if bun is available)
+```
+
+If `bun` is not available on the VPS, only regenerate `package-lock.json` and
+leave a note in the PR body: "bun.lock regeneration skipped — bun not available on VPS".
+
+### Step 6 — Validate
+
+```bash
+npm run typecheck
+npm run lint
+npm run build
+```
+
+If any fails, revert the specific package that caused the regression and
+flag it in `SECURITY.md`.
+
+### Step 7 — Summary report
+
+After fixes, write a short bulleted summary at the top of the PR body
+describing: N CVEs auto-fixed, M packages bumped (patch+minor), K frozen
+packages deferred, exact list of bumped packages with from→to versions.
+
+### HARD RULES
+
+- NEVER add a package not already in `package.json`.
+- NEVER remove a package that's still imported in the codebase.
+- NEVER bump a frozen package.
+- NEVER run `npm audit fix --force` — it ignores semver constraints.
+- If in doubt, do less and document in `SECURITY.md`.

--- a/prompts/audits/errors.md
+++ b/prompts/audits/errors.md
@@ -1,0 +1,39 @@
+---
+name: audit-errors
+description: Error handling & resilience — Error Boundaries, IPC try/catch, renderer .catch().
+version: 1
+focus: errors
+last_updated: 2026-04-17
+---
+
+## Focus: Error Handling & Resilience
+
+Audit the codebase for missing error handling that causes silent failures or crashes.
+
+1. **React Error Boundaries** — if the codebase has ZERO, that is the #1 priority.
+   Add an `ErrorBoundary` component at `app/components/ErrorBoundary.tsx`:
+   - Wrap each major tab/view in AppShell with it
+   - Show a friendly fallback UI instead of crashing the whole app
+   - Log the error to `console.error` (and PostHog if available)
+
+2. **IPC handlers that throw instead of returning `{ success: false, error }`:**
+   - Bad: `ipcMain.handle('x', () => { throw new Error('...') })`
+   - Good: `ipcMain.handle('x', () => { try {...} catch(e) { return { success: false, error: e.message } } })`
+   - Scan `electron/ipc/*.cjs` for handlers missing try/catch.
+
+3. **`window.electron.invoke()` calls in the renderer with no `.catch()` or try/catch:**
+   - Bad: `const result = await window.electron.invoke('x', data)`
+   - Good: `const result = await window.electron.invoke('x', data).catch(e => ({ success: false, error: e.message }))`
+
+4. **Zustand store actions** that call IPC without error handling — the store should never crash
+   silently; log errors and optionally show a toast.
+
+### Priority
+
+ErrorBoundary first (highest impact), then IPC try/catch, then renderer catch.
+
+### Tool use (required before proposing fixes)
+
+- `grep -rn "ErrorBoundary" app/` — confirm before claiming "ZERO exist"
+- `grep -rn "ipcMain.handle" electron/ipc/ | wc -l` — total handlers
+- `grep -L "try {" electron/ipc/*.cjs` — files missing try/catch entirely

--- a/prompts/audits/i18n.md
+++ b/prompts/audits/i18n.md
@@ -1,0 +1,34 @@
+---
+name: audit-i18n
+description: i18n completeness — missing keys across en/es/fr/pt, hardcoded user-visible strings.
+version: 1
+focus: i18n
+last_updated: 2026-04-17
+---
+
+## Focus: i18n Completeness
+
+Audit the codebase for i18n issues:
+
+1. User-visible strings hardcoded in components instead of using `t()`
+2. Translation keys that exist in `en` but are missing in `es`, `fr`, or `pt` in `app/lib/i18n.ts`
+3. Components that import `useTranslation` but don't use `t()` for user-facing strings
+
+### Deliverable
+
+Fix all missing translation keys in `app/lib/i18n.ts`.
+For hardcoded strings: wrap them with `t()` and add the key to all 4 languages.
+
+### IMPORTANT rules for i18n.ts edits
+
+- Do NOT reformat, reindent, or reorder existing keys — only add/change values
+- The default language is Spanish (es) — Spanish strings should be natural, not machine-translated
+- French (fr) and Portuguese (pt) translations should be grammatically correct
+- Use the same key nesting structure as existing keys for consistency
+- Never add a key in one language without adding it in all 4 (en/es/fr/pt)
+
+### Tool use (required before proposing fixes)
+
+- Open `app/lib/i18n.ts` and diff the key set of each language before asserting a key is missing
+- `grep -rn "t('" app/components/ app/pages/` to find t() call sites
+- Do not flag strings that are already wrapped in `t()`

--- a/prompts/audits/react.md
+++ b/prompts/audits/react.md
@@ -1,0 +1,41 @@
+---
+name: audit-react
+description: React patterns & performance — useEffect cleanup, state mutations, missing deps, oversized components.
+version: 1
+focus: react
+last_updated: 2026-04-17
+---
+
+## Focus: React Patterns & Performance
+
+Audit the codebase for React anti-patterns that cause bugs and performance issues.
+
+1. `useEffect` with `addEventListener`/`setTimeout`/`setInterval` that has NO cleanup return:
+   - Bad: `useEffect(() => { window.addEventListener('x', fn) }, [])`
+   - Good: `useEffect(() => { window.addEventListener('x', fn); return () => window.removeEventListener('x', fn) }, [])`
+
+2. Direct state mutations in Zustand stores or React state:
+   - Bad: `state.items.push(item)`
+   - Good: `set(s => ({ items: [...s.items, item] }))`
+
+3. `useEffect` with missing dependency array (runs on every render):
+   - Bad: `useEffect(() => { fetchData() })`
+   - Good: `useEffect(() => { fetchData() }, [id])`
+
+4. Components that re-render unnecessarily because they receive new object/array literals as props:
+   - Bad: `<Component options={{ key: val }} />`
+   - Good: `const options = useMemo(() => ({ key: val }), [val]); <Component options={options} />`
+
+5. Large components over 400 lines that mix data fetching + business logic + rendering.
+
+### Tool use (required before proposing fixes)
+
+- `grep -rn "useEffect" app/components/ | wc -l` — baseline count
+- `find app/components -name '*.tsx' -exec wc -l {} \; 2>/dev/null | awk '$1 > 400 {print "   " $1 " lines: " $2}' | sort -rn | head -8` — find the biggest components
+- For direct-mutation claims: open the actual call site — don't flag based on a name match alone
+
+### Priority
+
+Fix the `useEffect` cleanup issues first (they cause memory leaks).
+For large components: only split if you can identify a clear sub-component boundary.
+Do NOT refactor working logic just to reduce line count.

--- a/prompts/audits/security.md
+++ b/prompts/audits/security.md
@@ -1,0 +1,43 @@
+---
+name: audit-security
+description: Security audit — IPC validation, SQL injection, path traversal, hardcoded secrets, preload surface.
+version: 1
+focus: security
+last_updated: 2026-04-17
+---
+
+## Focus: Security Audit
+
+Audit the codebase for security issues:
+
+1. IPC handlers in `electron/ipc/` that don't validate sender or sanitize inputs
+2. SQL injection risks (string concatenation in queries instead of prepared statements)
+3. Path traversal vulnerabilities (user-provided paths used without `sanitizePath()`)
+4. Hardcoded secrets, API keys, or credentials in source files
+5. `electron/preload.cjs` exposing APIs that shouldn't be exposed to renderer
+6. Missing input validation on IPC channels
+
+### CRITICAL path traversal rules
+
+- ALWAYS use `sanitizePath(filePath, true)` — never use `.replace(/\.\.\//g, '')`
+- The `replace()` approach is bypassable with `....//` and does not handle Windows paths
+- After sanitization, always validate containment with:
+  ```js
+  const resolved = path.resolve(baseDir, userInput);
+  if (!resolved.startsWith(path.resolve(baseDir) + path.sep)) throw new Error('Path traversal');
+  ```
+- Check BOTH source and destination paths in copy/move operations
+
+### Tool use (required before proposing fixes)
+
+Before proposing fixes, confirm each finding is real:
+
+- `grep -rn "ipcMain.handle" electron/ipc/` — to map every IPC handler
+- `grep -rn "event.sender" electron/ipc/` — to see which ones validate sender
+- Read `electron/preload.cjs` to confirm a channel is actually exposed before flagging it
+- Do not propose fixes for patterns that no longer exist in main
+
+### Deliverable
+
+For each issue found: create a fix. If the fix is straightforward, implement it.
+If the fix is complex, create a TODO comment with the specific issue described.

--- a/prompts/audits/types.md
+++ b/prompts/audits/types.md
@@ -1,0 +1,29 @@
+---
+name: audit-types
+description: TypeScript quality — remove `any`, add `import type`, clean non-null assertions.
+version: 1
+focus: types
+last_updated: 2026-04-17
+---
+
+## Focus: TypeScript Quality
+
+Audit the codebase for TypeScript issues:
+
+1. Files using `any` type where a proper type can be inferred
+2. Missing `import type` for type-only imports (`verbatimModuleSyntax` is ON)
+3. Non-null assertions (`!`) that could be replaced with proper null checks
+4. Inconsistent return types on functions
+5. Missing types on exported functions/components
+
+### Tool use (required before proposing fixes)
+
+- `grep -rn ': any' app/ --include='*.ts' --include='*.tsx' | wc -l` — record count before/after
+- `bun tsc --noEmit` — must pass after every change. Do not commit if it doesn't.
+- `bun run lint` — catches most missing `import type` issues automatically
+- If a file has 10+ `any`, prioritize it; don't spread attention over many files
+
+### Scope
+
+Scan ALL of: `app/lib/`, `app/components/`, `electron/ipc/`.
+Fix what you can. Focus on files with the most `any` types first.

--- a/prompts/audits/vulns.md
+++ b/prompts/audits/vulns.md
@@ -1,0 +1,35 @@
+---
+name: audit-vulns
+description: Dependency vulnerability scan — npm audit HIGH/CRITICAL, safer alternatives.
+version: 1
+focus: vulns
+last_updated: 2026-04-17
+---
+
+## Focus: Dependency Vulnerabilities
+
+Audit npm dependencies for security vulnerabilities and outdated packages.
+
+### Step 1 — Run npm audit and read the output
+
+```bash
+npm audit --json
+```
+
+### Step 2 — For each HIGH or CRITICAL vulnerability
+
+- Read the advisory to understand the attack vector
+- Check if Dome actually uses the vulnerable code path
+- If a safe fix exists (`npm audit fix --dry-run` shows it): apply it
+- If it requires a major version bump: add a TODO comment in `package.json` with the issue
+
+### Step 3 — Check for packages with known safer alternatives
+
+- Any `request` package → should be `node-fetch` or native fetch
+- Any `node-uuid` → should be `crypto.randomUUID()`
+
+### IMPORTANT
+
+- Run `npm install --ignore-scripts` after any `package.json` change
+- Do NOT bump major versions of `electron`, `better-sqlite3`, or `@langchain/*` — these have breaking changes
+- Do NOT run `npm audit fix --force` — apply fixes selectively

--- a/prompts/review/architecture.md
+++ b/prompts/review/architecture.md
@@ -1,0 +1,42 @@
+---
+name: review-architecture
+description: PR review pass 1 — architecture & process separation (renderer/main boundary, IPC whitelist, import type).
+version: 1
+pass: architecture
+last_updated: 2026-04-17
+---
+
+You are a senior code reviewer for Dome, an Electron + React desktop app.
+
+## Your job
+
+Review the diff ONLY for architecture violations. Be direct — no preamble, no summaries.
+
+## Critical rules to enforce
+
+1. Code in `app/` (renderer) must NEVER import Node.js modules: `fs`, `path`, `better-sqlite3`, `bun:sqlite`, `electron`, `child_process`, etc.
+2. New IPC channels must be whitelisted in `electron/preload.cjs` `ALLOWED_CHANNELS`.
+3. IPC handlers in `electron/ipc/*.cjs` must validate the sender (`event.sender`) and sanitize inputs.
+4. ALL type-only imports must use `import type { }` (`verbatimModuleSyntax` is ON).
+5. File system and database access must go through IPC from the renderer — never directly.
+
+## Response format — STRICT JSON
+
+Return exactly one JSON object matching this schema, nothing else (no markdown, no prose):
+
+```json
+{
+  "findings": [
+    { "file": "path/to/file.ts", "line": 42, "severity": "error", "comment": "Short, actionable description of the violation." }
+  ]
+}
+```
+
+Rules:
+
+- `findings` is an array. Use an empty array `[]` when the diff is clean.
+- `severity` is one of: `"error"` (must-fix violation), `"warn"` (risky, not blocking).
+- `file` must be the exact path shown in the diff header (e.g. `app/components/Foo.tsx`).
+- `line` must be a line number present in the diff. If you cannot point at a line, omit the finding.
+- Maximum 10 findings per response.
+- `comment` is one sentence, actionable, no emoji.

--- a/prompts/review/logic.md
+++ b/prompts/review/logic.md
@@ -1,0 +1,43 @@
+---
+name: review-logic
+description: PR review pass 2 — logic bugs, runtime errors, security issues.
+version: 1
+pass: logic
+last_updated: 2026-04-17
+---
+
+You are a senior code reviewer for Dome, an Electron + React desktop app.
+
+## Your job
+
+Review the diff for logic bugs, runtime errors, and security issues. Be direct — no preamble, no summaries.
+
+## Focus on
+
+- Unhandled promise rejections or async operations without try/catch where a crash would occur
+- Race conditions in React hooks (stale closures, missing cleanup in `useEffect`)
+- SQL injection risks (string concatenation in queries instead of parameterized statements)
+- Null/undefined dereferences that would throw at runtime
+- Incorrect Zustand store mutations (direct array/object mutation instead of returning new state)
+- IPC handlers that throw errors to the renderer instead of returning `{ success: false, error }`
+
+## Response format — STRICT JSON
+
+Return exactly one JSON object matching this schema, nothing else (no markdown, no prose):
+
+```json
+{
+  "findings": [
+    { "file": "path/to/file.ts", "line": 42, "severity": "error", "comment": "Short, actionable description of the bug or risk." }
+  ]
+}
+```
+
+Rules:
+
+- `findings` is an array. Use an empty array `[]` when the diff is clean.
+- `severity` is one of: `"error"` (bug / crash risk), `"warn"` (risky pattern).
+- `file` must be the exact path shown in the diff header.
+- `line` must be a line number present in the diff. If you cannot point at a line, omit the finding.
+- Maximum 10 findings. Skip minor style opinions.
+- `comment` is one sentence, actionable, no emoji.

--- a/prompts/review/style.md
+++ b/prompts/review/style.md
@@ -1,0 +1,59 @@
+---
+name: review-style
+description: PR review pass 3 — style & conventions (hardcoded colors, i18n, any types, React anti-patterns).
+version: 1
+pass: style
+last_updated: 2026-04-17
+---
+
+You are a senior code reviewer for Dome, an Electron + React desktop app.
+
+## Your job
+
+Review the diff for style and convention issues. Be direct — no preamble, no summaries.
+
+## Known valid CSS variables (defined in app/globals.css)
+
+These are ALL valid — never flag them as "undocumented" or "undefined":
+
+Text colors: `--primary-text`, `--secondary-text`, `--tertiary-text`, `--dome-text` (→ `--primary-text`), `--dome-text-secondary` (→ `--secondary-text`), `--dome-text-muted` (→ `--tertiary-text`), `--base-text`.
+
+Backgrounds: `--bg`, `--bg-secondary`, `--bg-tertiary`, `--bg-hover`, `--dome-bg`, `--dome-bg-hover`, `--dome-accent-bg`.
+
+Interactive / accent: `--accent`, `--accent-hover`, `--dome-accent`, `--dome-accent-hover`.
+
+Semantic: `--dome-error`, `--error`, `--warning`, `--success`.
+
+Borders: `--border`, `--border-hover`, `--dome-border`.
+
+Only flag LITERAL hex values (`#rrggbb` / `#rgb` / `rgb()`) that appear OUTSIDE of a CSS `var()` wrapper.
+Fallback values inside `var(--x, fallback)` are acceptable.
+
+## Check for
+
+1. Literal hex color values hardcoded in `style=` or `className=` attributes OUTSIDE of a `var()` wrapper (e.g. `style={{ color: '#ff0000' }}`)
+2. User-visible strings in JSX that are NOT wrapped in `t()` from react-i18next
+3. Translation keys added to one language but missing from others (`en`/`es`/`fr`/`pt`) in `app/lib/i18n.ts`
+4. TypeScript `any` types where a proper type is clearly derivable
+5. React anti-patterns: `useEffect` missing dependencies, inline object/array literals as props that cause re-renders
+
+## Response format — STRICT JSON
+
+Return exactly one JSON object matching this schema, nothing else (no markdown, no prose):
+
+```json
+{
+  "findings": [
+    { "file": "path/to/file.ts", "line": 42, "severity": "warn", "comment": "Short, actionable description of the issue." }
+  ]
+}
+```
+
+Rules:
+
+- `findings` is an array. Use an empty array `[]` when the diff is clean.
+- `severity` is one of: `"error"` (must-fix), `"warn"` (suggestion).
+- `file` must be the exact path shown in the diff header.
+- `line` must be a line number present in the diff. If you cannot point at a line, omit the finding.
+- Maximum 10 findings.
+- `comment` is one sentence, actionable, no emoji.

--- a/prompts/shared/project-context.md
+++ b/prompts/shared/project-context.md
@@ -1,0 +1,51 @@
+---
+name: project-context
+description: Shared project context injected into all audit and review prompts. Defines valid CSS variables, stack specifics, and i18n rules so agents don't produce false positives.
+version: 1
+last_updated: 2026-04-17
+---
+
+## Project-specific context
+
+### Valid CSS variables (defined in app/globals.css)
+
+The following CSS custom properties ARE defined and valid. NEVER flag them as "unknown", "undocumented",
+or "should be replaced". They are real variables used throughout the codebase:
+
+Text colors:
+  `--primary-text`, `--secondary-text`, `--tertiary-text`
+  `--dome-text` (→ `--primary-text`), `--dome-text-secondary` (→ `--secondary-text`), `--dome-text-muted` (→ `--tertiary-text`)
+  `--base-text` ← text on accent-colored buttons (#FFFFFF light / #121212 dark — intentionally hardcoded in globals.css)
+
+Backgrounds:
+  `--bg`, `--bg-secondary`, `--bg-tertiary`, `--bg-hover`
+  `--dome-bg` (→ `--bg`), `--dome-bg-hover` (→ `--bg-hover`), `--dome-accent-bg` (translucent accent)
+
+Interactive:
+  `--accent`, `--accent-hover`
+  `--dome-accent` (→ `--accent`), `--dome-accent-hover` (→ `--accent-hover`)
+
+Semantic:
+  `--error`, `--warning`, `--success`
+  `--dome-error` (→ `--error`)
+
+Borders:
+  `--border`, `--border-hover`, `--dome-border` (→ `--border`)
+
+Only flag LITERAL hex values (e.g. `color: '#ef4444'`) that appear in style= attributes or TSX WITHOUT
+being wrapped in a CSS var(). Fallback values inside `var(--x, fallback)` are acceptable.
+
+### Stack clarification
+
+- Runtime: Bun for dev/build; Electron uses Node.js (better-sqlite3, NOT bun:sqlite)
+- Frontend: Vite + React 18 (NOT Next.js — ignore any Next.js references in style guides)
+- Routes: React Router v7 (client-side SPA), entry: `app/main.tsx`
+- i18n: react-i18next, all translations inline in `app/lib/i18n.ts` (en/es/fr/pt), default language: es
+- `verbatimModuleSyntax: true` → ALL type-only imports MUST use `import type { }`
+
+### Architecture boundary (enforced in every audit)
+
+- Code in `app/` (renderer) must NEVER import Node.js modules (`fs`, `path`, `better-sqlite3`, `bun:sqlite`, `electron`, `child_process`, …).
+- New IPC channels MUST be whitelisted in `electron/preload.cjs` `ALLOWED_CHANNELS`.
+- IPC handlers in `electron/ipc/*.cjs` MUST validate sender (`event.sender`) and sanitize inputs.
+- File system and database access from the renderer goes through IPC — never direct.

--- a/scripts/ai-review.mjs
+++ b/scripts/ai-review.mjs
@@ -2,22 +2,33 @@
 /**
  * AI Code Review Script for Dome
  *
- * Reads a git diff from stdin, runs 3 review passes via AI, and posts
- * a review comment on the PR via GitHub API.
+ * Reads a git diff from stdin, runs 3 structured review passes (architecture,
+ * logic, style) per file, and posts a GitHub PR review with line-level
+ * comments anchored to the diff.
  *
- * Multi-provider: works with MiniMax, DeepSeek, OpenAI, Anthropic-compatible,
- * or any OpenAI-compatible endpoint.
+ * Prompts live in `prompts/review/*.md` (externalized — previously inline).
+ * Diffs are split by file so large PRs are fully covered (no 40KB truncation).
+ * Model replies are strict JSON (`{ findings: [...] }`); fallbacks are robust.
  *
  * Config via env vars:
- *   AI_REVIEW_API_KEY    - API key (required)
- *   AI_REVIEW_BASE_URL   - Base URL (default: https://api.openai.com/v1)
- *   AI_REVIEW_MODEL      - Model name (default: gpt-4o)
- *   GITHUB_TOKEN         - GitHub token for posting review (required in CI)
- *   PR_NUMBER            - PR number (set by GitHub Actions)
- *   REPO                 - owner/repo (set by GitHub Actions)
+ *   AI_REVIEW_API_KEY       - API key (required)
+ *   AI_REVIEW_BASE_URL      - Base URL (default: https://api.openai.com/v1)
+ *   AI_REVIEW_MODEL         - Model name (default: gpt-4o)
+ *   AI_REVIEW_CONCURRENCY   - Max concurrent AI calls (default: 5)
+ *   AI_REVIEW_MAX_FILE_KB   - Max size per file chunk before per-file truncation (default: 60)
+ *   AI_REVIEW_IGNORE_GLOBS  - Comma-separated file patterns to skip
+ *   AI_REVIEW_DRY_RUN       - "1" prints the review body without posting
+ *   GITHUB_TOKEN            - GitHub token for posting review (required in CI)
+ *   PR_NUMBER               - PR number (set by GitHub Actions)
+ *   REPO                    - owner/repo (set by GitHub Actions)
  */
 
 import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
 
 const API_KEY = process.env.AI_REVIEW_API_KEY;
 const BASE_URL = (process.env.AI_REVIEW_BASE_URL || 'https://api.openai.com/v1').replace(/\/$/, '');
@@ -26,19 +37,50 @@ const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const PR_NUMBER = process.env.PR_NUMBER;
 const REPO = process.env.REPO;
 
-// Timeout per AI call (ms) — 50s is generous, avoids hanging forever
+const CONCURRENCY = Math.max(1, parseInt(process.env.AI_REVIEW_CONCURRENCY || '5', 10));
+const MAX_FILE_KB = Math.max(10, parseInt(process.env.AI_REVIEW_MAX_FILE_KB || '60', 10));
+const MAX_FILE_BYTES = MAX_FILE_KB * 1024;
+const DRY_RUN = process.env.AI_REVIEW_DRY_RUN === '1' || process.argv.includes('--dry-run');
+
+const DEFAULT_IGNORE = [
+  'package-lock.json',
+  'bun.lock',
+  'bun.lockb',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'dist/',
+  'out/',
+  'build/',
+  'node_modules/',
+  '.min.js',
+  '.min.css',
+  '.map',
+  '.ico',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.webp',
+  '.pdf',
+  '.woff',
+  '.woff2',
+];
+const IGNORE_GLOBS = (process.env.AI_REVIEW_IGNORE_GLOBS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+const IGNORE = [...DEFAULT_IGNORE, ...IGNORE_GLOBS];
+
 const CALL_TIMEOUT_MS = 50_000;
-// Retries per pass before giving up
 const MAX_RETRIES = 2;
-// Delay between retries (ms) — doubles each attempt
 const RETRY_BASE_DELAY_MS = 6_000;
 
-if (!API_KEY) {
-  console.error('❌ AI_REVIEW_API_KEY is required');
+if (!API_KEY && !DRY_RUN) {
+  console.error('❌ AI_REVIEW_API_KEY is required (or set AI_REVIEW_DRY_RUN=1)');
   process.exit(1);
 }
 
-// Read diff from stdin
+// ── Read diff from stdin ──────────────────────────────────────────────────────
+
 let diff = '';
 try {
   diff = readFileSync('/dev/stdin', 'utf-8');
@@ -51,16 +93,8 @@ if (!diff || diff.trim().length < 50) {
   process.exit(0);
 }
 
-// Truncate diff if too large (context window limit)
-const MAX_DIFF_CHARS = 40_000;
-const truncated = diff.length > MAX_DIFF_CHARS;
-const diffContent = truncated
-  ? diff.slice(0, MAX_DIFF_CHARS) + '\n\n[... diff truncated for length ...]'
-  : diff;
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-/** Strip <think>…</think> blocks emitted by reasoning models (e.g. MiniMax-M2.7). */
 function stripThinking(text) {
   return text
     .replace(/<think>[\s\S]*?<\/think>/gi, '')
@@ -68,226 +102,409 @@ function stripThinking(text) {
     .trim();
 }
 
-/** Sleep for ms milliseconds. */
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/**
- * Call the AI API (OpenAI-compatible format) with timeout and retries.
- * Returns the model's text content, with <think> blocks stripped.
- * Throws only if all retries are exhausted.
- */
-async function callAI(systemPrompt, userContent) {
-  let lastError;
+function isIgnored(path) {
+  return IGNORE.some((pattern) => {
+    if (pattern.endsWith('/')) return path.startsWith(pattern) || path.includes(`/${pattern}`);
+    return path.endsWith(pattern) || path.includes(pattern);
+  });
+}
 
+/**
+ * Split a unified diff into per-file chunks.
+ * Returns [{ path, diff, newLineSet: Set<number>, isBinary }].
+ */
+function splitDiffByFile(raw) {
+  const files = [];
+  const lines = raw.split('\n');
+  let current = null;
+
+  const flush = () => {
+    if (!current) return;
+    const lineSet = new Set();
+    let newLine = 0;
+    let inHunk = false;
+    for (const l of current.lines) {
+      const hunk = l.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (hunk) {
+        newLine = parseInt(hunk[1], 10);
+        inHunk = true;
+        continue;
+      }
+      if (!inHunk) continue;
+      if (l.startsWith('+') && !l.startsWith('+++')) {
+        lineSet.add(newLine);
+        newLine += 1;
+      } else if (l.startsWith('-') && !l.startsWith('---')) {
+        // deletion — old-side line, don't advance new-side counter
+      } else if (l.startsWith(' ')) {
+        lineSet.add(newLine);
+        newLine += 1;
+      } else if (l.startsWith('\\')) {
+        // "\ No newline at end of file"
+      }
+    }
+    current.newLineSet = lineSet;
+    current.diff = current.lines.join('\n');
+    delete current.lines;
+    files.push(current);
+    current = null;
+  };
+
+  for (const l of lines) {
+    const header = l.match(/^diff --git a\/(.+) b\/(.+)$/);
+    if (header) {
+      flush();
+      current = { path: header[2], oldPath: header[1], lines: [l], isBinary: false };
+      continue;
+    }
+    if (!current) continue;
+    if (l.startsWith('Binary files ') || l.startsWith('GIT binary patch')) {
+      current.isBinary = true;
+    }
+    current.lines.push(l);
+  }
+  flush();
+
+  return files;
+}
+
+function truncateFileDiff(fileChunk) {
+  if (fileChunk.diff.length <= MAX_FILE_BYTES) return { truncated: false, chunk: fileChunk };
+  const truncated = {
+    ...fileChunk,
+    diff: fileChunk.diff.slice(0, MAX_FILE_BYTES) + '\n\n[... file diff truncated for length ...]',
+  };
+  return { truncated: true, chunk: truncated };
+}
+
+// ── Prompt loading ────────────────────────────────────────────────────────────
+
+function stripFrontmatter(md) {
+  if (!md.startsWith('---')) return md;
+  const end = md.indexOf('\n---', 3);
+  if (end === -1) return md;
+  return md.slice(end + 4).replace(/^\n+/, '');
+}
+
+function readFrontmatterField(md, field) {
+  const match = md.match(new RegExp(`^${field}:\\s*(.+)$`, 'm'));
+  return match ? match[1].trim() : '';
+}
+
+const FALLBACK_PROMPTS = {
+  architecture:
+    'Review the diff for architecture violations. Respond with JSON: {"findings":[{"file":"","line":0,"severity":"error","comment":""}]}.',
+  logic:
+    'Review the diff for logic bugs and security issues. Respond with JSON: {"findings":[{"file":"","line":0,"severity":"error","comment":""}]}.',
+  style:
+    'Review the diff for style issues. Respond with JSON: {"findings":[{"file":"","line":0,"severity":"warn","comment":""}]}.',
+};
+
+function loadPrompt(name) {
+  const path = join(REPO_ROOT, 'prompts', 'review', `${name}.md`);
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const version = readFrontmatterField(raw, 'version') || '0';
+    const body = stripFrontmatter(raw);
+    return { body, version, source: path };
+  } catch {
+    return { body: FALLBACK_PROMPTS[name] || FALLBACK_PROMPTS.architecture, version: 'fallback', source: 'builtin' };
+  }
+}
+
+// ── AI call with retry/timeout ────────────────────────────────────────────────
+
+async function callAI(systemPrompt, userContent, { wantJson = true } = {}) {
+  let lastError;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     if (attempt > 0) {
       const delay = RETRY_BASE_DELAY_MS * attempt;
-      console.log(`    ↻ Retry ${attempt}/${MAX_RETRIES} after ${delay / 1000}s…`);
       await sleep(delay);
     }
-
     try {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(new Error('AI call timed out')), CALL_TIMEOUT_MS);
-
       let response;
       try {
+        const body = {
+          model: MODEL,
+          messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userContent },
+          ],
+          temperature: 0.2,
+          max_tokens: 1500,
+        };
+        if (wantJson) body.response_format = { type: 'json_object' };
         response = await fetch(`${BASE_URL}/chat/completions`, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${API_KEY}`,
-          },
-          body: JSON.stringify({
-            model: MODEL,
-            messages: [
-              { role: 'system', content: systemPrompt },
-              { role: 'user', content: userContent },
-            ],
-            temperature: 0.2,
-            max_tokens: 1200,
-          }),
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${API_KEY}` },
+          body: JSON.stringify(body),
           signal: controller.signal,
         });
       } finally {
         clearTimeout(timer);
       }
-
       if (!response.ok) {
         const text = await response.text().catch(() => '');
+        // Some providers reject response_format — retry without it
+        if (wantJson && (response.status === 400 || text.includes('response_format'))) {
+          wantJson = false;
+          throw new Error(`response_format unsupported, retrying plain (status ${response.status})`);
+        }
         throw new Error(`HTTP ${response.status}: ${text.slice(0, 300)}`);
       }
-
       const data = await response.json();
       const raw = data.choices?.[0]?.message?.content ?? '';
       if (!raw) throw new Error('Empty response from model');
       return stripThinking(raw);
     } catch (err) {
       lastError = err;
-      console.log(`    ✗ Attempt ${attempt + 1} failed: ${err.message}`);
     }
   }
-
   throw lastError;
 }
 
-// ─── Review Pass Prompts ──────────────────────────────────────────────────────
+/** Parse a model response into { findings: [...] }. Tolerant of markdown fences. */
+function parseFindings(text) {
+  if (!text) return { findings: [], parseError: 'empty' };
+  const tries = [text, text.match(/```(?:json)?\s*([\s\S]*?)```/)?.[1], text.match(/\{[\s\S]*\}/)?.[0]].filter(Boolean);
+  for (const candidate of tries) {
+    try {
+      const obj = JSON.parse(candidate);
+      const findings = Array.isArray(obj.findings) ? obj.findings : Array.isArray(obj) ? obj : [];
+      return { findings: findings.filter((f) => f && typeof f === 'object'), parseError: null };
+    } catch {
+      // try next
+    }
+  }
+  return { findings: [], parseError: 'invalid-json' };
+}
 
-// Shared CSS variable context injected into relevant passes to prevent false positives.
-const CSS_VAR_CONTEXT = `
-## Known valid CSS variables (defined in app/globals.css)
-These are ALL valid — never flag them as "undocumented" or "undefined":
+// ── Concurrency-limited mapper ────────────────────────────────────────────────
 
-Text colors:
-  --primary-text, --secondary-text, --tertiary-text
-  --dome-text (alias → --primary-text)
-  --dome-text-secondary (alias → --secondary-text)
-  --dome-text-muted (alias → --tertiary-text)
-  --base-text (#FFFFFF in light, #121212 in dark — for text ON colored backgrounds like buttons)
+async function mapConcurrent(items, limit, fn) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  async function worker() {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      try {
+        results[i] = { ok: true, value: await fn(items[i], i) };
+      } catch (err) {
+        results[i] = { ok: false, error: err };
+      }
+    }
+  }
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
 
-Backgrounds:
-  --bg, --bg-secondary, --bg-tertiary, --bg-hover
-  --dome-bg (alias → --bg)
-  --dome-bg-hover (alias → --bg-hover)
-  --dome-accent-bg (translucent accent for highlights)
+// ── Main ──────────────────────────────────────────────────────────────────────
 
-Interactive / accent:
-  --accent, --accent-hover
-  --dome-accent (alias → --accent)
-  --dome-accent-hover (alias → --accent-hover)
-
-Semantic:
-  --dome-error (alias → --error, maps to #ef4444-equivalent)
-  --error, --warning, --success
-
-Borders:
-  --border, --border-hover
-  --dome-border (alias → --border)
-
-Only flag LITERAL hex values (#rrggbb / #rgb / rgb()) that appear OUTSIDE of a CSS var() wrapper.
-Do NOT flag fallback values inside var(--x, fallback) as errors — fallbacks are acceptable.
-`.trim();
-
-const ARCH_PROMPT = `You are a senior code reviewer for Dome, an Electron + React desktop app.
-
-## Your job
-Review the diff ONLY for architecture violations. Be direct — no preamble, no summaries.
-
-## Critical rules to enforce
-1. Code in app/ (renderer) must NEVER import Node.js modules: fs, path, better-sqlite3, bun:sqlite, electron, child_process, etc.
-2. New IPC channels must be whitelisted in electron/preload.cjs ALLOWED_CHANNELS.
-3. IPC handlers in electron/ipc/*.cjs must validate the sender (event.sender) and sanitize inputs.
-4. ALL type-only imports must use \`import type { }\` (verbatimModuleSyntax is ON).
-5. File system and database access must go through IPC from the renderer — never directly.
-
-## Format
-- One bullet per finding: ✅ (ok) | ❌ (violation) | ⚠️ (warning)
-- If nothing wrong: a single line "✅ No architecture violations found."
-- Maximum 10 bullets. Be precise.`;
-
-const LOGIC_PROMPT = `You are a senior code reviewer for Dome, an Electron + React desktop app.
-
-## Your job
-Review the diff for logic bugs, runtime errors, and security issues. Be direct — no preamble, no summaries.
-
-## Focus on
-- Unhandled promise rejections or async operations without try/catch where a crash would occur
-- Race conditions in React hooks (stale closures, missing cleanup in useEffect)
-- SQL injection risks (string concatenation in queries instead of parameterized statements)
-- Null/undefined dereferences that would throw at runtime
-- Incorrect Zustand store mutations (direct array/object mutation instead of returning new state)
-- IPC handlers that throw errors to the renderer instead of returning \`{ success: false, error }\`
-
-## Format
-- One bullet per finding: ❌ (bug/crash risk) | ⚠️ (risk/warning) | ✅ (ok)
-- If nothing wrong: a single line "✅ No logic issues found."
-- Maximum 10 bullets. Be precise. Skip minor style opinions.`;
-
-const STYLE_PROMPT = `You are a senior code reviewer for Dome, an Electron + React desktop app.
-
-## Your job
-Review the diff for style and convention issues. Be direct — no preamble, no summaries.
-
-${CSS_VAR_CONTEXT}
-
-## Check for
-1. Literal hex color values hardcoded in style= or className= attributes OUTSIDE of a var() wrapper (e.g. style={{ color: '#ff0000' }})
-2. User-visible strings in JSX that are NOT wrapped in t() from react-i18next
-3. Translation keys added to one language but missing from others (en/es/fr/pt) in app/lib/i18n.ts
-4. TypeScript \`any\` types where a proper type is clearly derivable
-5. React anti-patterns: useEffect missing dependencies, inline object/array literals as props that cause re-renders
-
-## Format
-- One bullet per finding: ❌ (must fix) | ⚠️ (suggestion) | ✅ (ok)
-- If nothing wrong: a single line "✅ No style issues found."
-- Maximum 10 bullets. Be precise.`;
-
-// ─── Main ─────────────────────────────────────────────────────────────────────
+const PASSES = [
+  { key: 'architecture', label: 'Architecture & Process Separation' },
+  { key: 'logic', label: 'Logic & Security' },
+  { key: 'style', label: 'Style & Conventions' },
+];
 
 async function main() {
-  console.log(`🤖 Running AI code review`);
-  console.log(`   Model: ${MODEL}`);
-  console.log(`   Endpoint: ${BASE_URL}`);
-  console.log(`   Diff: ${diffContent.length} chars${truncated ? ' (truncated)' : ''}`);
+  const prompts = Object.fromEntries(PASSES.map((p) => [p.key, loadPrompt(p.key)]));
+  const promptVersions = PASSES.map((p) => `${p.key}@${prompts[p.key].version}`).join(', ');
 
-  const userContent = `Here is the PR diff to review:\n\n\`\`\`diff\n${diffContent}\n\`\`\``;
+  const allFiles = splitDiffByFile(diff);
+  const reviewedFiles = [];
+  const skipped = [];
+  const truncatedFiles = [];
 
-  const passes = [
-    { name: 'Architecture & Process Separation', prompt: ARCH_PROMPT },
-    { name: 'Logic & Security',                  prompt: LOGIC_PROMPT },
-    { name: 'Style & Conventions',               prompt: STYLE_PROMPT },
-  ];
+  for (const f of allFiles) {
+    if (f.isBinary) { skipped.push({ ...f, reason: 'binary' }); continue; }
+    if (isIgnored(f.path)) { skipped.push({ ...f, reason: 'ignored' }); continue; }
+    const { truncated, chunk } = truncateFileDiff(f);
+    if (truncated) truncatedFiles.push(chunk.path);
+    reviewedFiles.push(chunk);
+  }
 
-  const results = [];
+  console.log(`🤖 AI review — model=${MODEL}, concurrency=${CONCURRENCY}`);
+  console.log(`   prompts: ${promptVersions}`);
+  console.log(`   files: ${allFiles.length} total (${reviewedFiles.length} reviewed, ${skipped.length} skipped, ${truncatedFiles.length} clipped)`);
 
-  for (let i = 0; i < passes.length; i++) {
-    const { name, prompt } = passes[i];
-    console.log(`\n  Pass ${i + 1}/${passes.length}: ${name}…`);
-    try {
-      const text = await callAI(prompt, userContent);
-      results.push({ name, text, ok: true });
-      console.log(`  ✓ Done (${text.length} chars)`);
-    } catch (err) {
-      const errorMsg = `⚠️ Review pass failed after ${MAX_RETRIES + 1} attempts.\n**Error:** \`${err.message}\`\n\nThis pass will need to be re-run manually.`;
-      results.push({ name, text: errorMsg, ok: false });
-      console.error(`  ✗ Failed: ${err.message}`);
+  // Build one task per (file × pass)
+  const tasks = [];
+  for (const file of reviewedFiles) {
+    for (const pass of PASSES) {
+      tasks.push({ file, pass });
     }
   }
 
-  // Compute status line
-  const failedCount = results.filter((r) => !r.ok).length;
-  const statusLine = failedCount === 0
-    ? `✅ All 3 passes completed`
-    : `⚠️ ${failedCount}/3 pass${failedCount > 1 ? 'es' : ''} failed — API errors, see below`;
+  const taskFn = async ({ file, pass }) => {
+    if (DRY_RUN) return { pass: pass.key, file: file.path, findings: [{ file: file.path, line: [...file.newLineSet][0] || 1, severity: 'warn', comment: `[dry-run fake finding from ${pass.key} pass]` }] };
+    const userContent = `Review this file's diff chunk.\n\nFile: ${file.path}\n\n\`\`\`diff\n${file.diff}\n\`\`\``;
+    try {
+      const raw = await callAI(prompts[pass.key].body, userContent);
+      const { findings, parseError } = parseFindings(raw);
+      return { pass: pass.key, file: file.path, findings, parseError };
+    } catch (err) {
+      return { pass: pass.key, file: file.path, findings: [], callError: err.message };
+    }
+  };
 
-  const reviewBody = [
+  const taskResults = await mapConcurrent(tasks, CONCURRENCY, taskFn);
+
+  // Aggregate
+  const allFindings = [];
+  const passStats = Object.fromEntries(PASSES.map((p) => [p.key, { ok: 0, err: 0, findings: 0 }]));
+  const callErrors = [];
+  const parseErrors = [];
+
+  for (const r of taskResults) {
+    if (!r.ok) { callErrors.push(String(r.error)); continue; }
+    const { pass, file, findings, callError, parseError } = r.value;
+    if (callError) { passStats[pass].err++; callErrors.push(`${pass}:${file} — ${callError}`); continue; }
+    passStats[pass].ok++;
+    if (parseError) parseErrors.push(`${pass}:${file} — ${parseError}`);
+    for (const f of findings) {
+      allFindings.push({ ...f, pass, _file: file });
+    }
+    passStats[pass].findings += findings.length;
+  }
+
+  // Validate & shape findings
+  const fileIndex = Object.fromEntries(reviewedFiles.map((f) => [f.path, f]));
+  const reviewComments = [];
+  const droppedForInvalidLine = [];
+  const seenKey = new Set();
+
+  for (const f of allFindings) {
+    const path = typeof f.file === 'string' && f.file.trim() ? f.file.trim() : f._file;
+    const line = Number.isInteger(f.line) ? f.line : parseInt(f.line, 10);
+    const severity = f.severity === 'error' ? 'error' : 'warn';
+    const comment = typeof f.comment === 'string' ? f.comment.trim() : '';
+    if (!path || !comment) continue;
+    const meta = fileIndex[path];
+    if (!meta || !Number.isFinite(line) || !meta.newLineSet.has(line)) {
+      droppedForInvalidLine.push({ path, line, comment });
+      continue;
+    }
+    const dedupeKey = `${path}:${line}:${comment}`;
+    if (seenKey.has(dedupeKey)) continue;
+    seenKey.add(dedupeKey);
+    const icon = severity === 'error' ? '❌' : '⚠️';
+    const passLabel = PASSES.find((p) => p.key === f.pass)?.label || f.pass;
+    reviewComments.push({
+      path,
+      line,
+      side: 'RIGHT',
+      body: `${icon} **${passLabel}** — ${comment}`,
+    });
+  }
+
+  // Build summary body
+  const totalFindings = reviewComments.length;
+  const failedPasses = Object.entries(passStats).filter(([, s]) => s.err > 0);
+  const statusLine =
+    failedPasses.length === 0
+      ? `✅ All passes completed across ${reviewedFiles.length} file(s)`
+      : `⚠️ ${failedPasses.length}/${PASSES.length} pass(es) had errors — see below`;
+
+  const summaryLines = [
     `## 🤖 AI Code Review`,
     ``,
-    `> Model: \`${MODEL}\` | ${truncated ? '⚠️ Diff was truncated' : 'Full diff reviewed'} | ${statusLine}`,
+    `> Model: \`${MODEL}\` · Prompts: \`${promptVersions}\` · ${statusLine}`,
     ``,
-    ...results.flatMap(({ name }, idx) => [
-      `---`,
-      ``,
-      `### Pass ${idx + 1} — ${name}`,
-      ``,
-      results[idx].text,
-      ``,
-    ]),
-    `---`,
-    `<sub>This review is automated. Treat it as a helpful sanity check, not a final verdict.</sub>`,
-  ].join('\n');
+    `**Files:** ${reviewedFiles.length} reviewed · ${skipped.length} skipped · ${truncatedFiles.length} clipped`,
+    `**Findings:** ${totalFindings} total`,
+    ``,
+    `| Pass | Files OK | Files errored | Findings |`,
+    `| --- | --- | --- | --- |`,
+    ...PASSES.map((p) => `| ${p.label} | ${passStats[p.key].ok} | ${passStats[p.key].err} | ${passStats[p.key].findings} |`),
+    ``,
+  ];
 
-  console.log('\n📋 Review assembled.');
+  if (truncatedFiles.length) {
+    summaryLines.push(`<details><summary>Clipped files (${truncatedFiles.length})</summary>\n\n- ${truncatedFiles.join('\n- ')}\n\n</details>`, '');
+  }
+  if (skipped.length) {
+    summaryLines.push(
+      `<details><summary>Skipped files (${skipped.length})</summary>\n\n- ${skipped.map((s) => `${s.path} (${s.reason})`).join('\n- ')}\n\n</details>`,
+      ''
+    );
+  }
+  if (callErrors.length) {
+    summaryLines.push(
+      `<details><summary>API call errors (${callErrors.length})</summary>\n\n\`\`\`\n${callErrors.slice(0, 10).join('\n')}\n\`\`\`\n\n</details>`,
+      ''
+    );
+  }
+  if (parseErrors.length) {
+    summaryLines.push(
+      `<details><summary>Unparsable model responses (${parseErrors.length})</summary>\n\n\`\`\`\n${parseErrors.slice(0, 10).join('\n')}\n\`\`\`\n\n</details>`,
+      ''
+    );
+  }
+  if (droppedForInvalidLine.length) {
+    summaryLines.push(
+      `<details><summary>Dropped findings (line not in diff) — ${droppedForInvalidLine.length}</summary>\n\n` +
+        droppedForInvalidLine.slice(0, 15).map((d) => `- ❌ \`${d.path}:${d.line}\` — ${d.comment}`).join('\n') +
+        `\n\n</details>`,
+      ''
+    );
+  }
+  summaryLines.push(`---`, `<sub>Line-level comments anchored to the diff. Automated sanity check — not a final verdict.</sub>`);
 
-  // Post to GitHub PR
-  if (GITHUB_TOKEN && PR_NUMBER && REPO) {
-    let posted = false;
-    let postError = '';
+  const reviewBody = summaryLines.join('\n');
+
+  if (DRY_RUN || !GITHUB_TOKEN || !PR_NUMBER || !REPO) {
+    console.log('\n--- Review Output (dry run / local) ---\n');
+    console.log(reviewBody);
+    console.log(`\n--- ${reviewComments.length} line comments would be posted ---`);
+    for (const c of reviewComments.slice(0, 20)) {
+      console.log(`  ${c.path}:${c.line} — ${c.body}`);
+    }
+    if (reviewComments.length > 20) console.log(`  ... and ${reviewComments.length - 20} more`);
+    if (failedPasses.length === PASSES.length) process.exit(1);
+    return;
+  }
+
+  // Post the review with comments[]
+  const url = `https://api.github.com/repos/${REPO}/pulls/${PR_NUMBER}/reviews`;
+  let posted = false;
+  let postError = '';
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: JSON.stringify({ body: reviewBody, event: 'COMMENT', comments: reviewComments }),
+    });
+    if (res.ok) {
+      console.log(`✅ Review posted to PR #${PR_NUMBER} with ${reviewComments.length} line comments`);
+      posted = true;
+    } else {
+      const text = await res.text().catch(() => '');
+      postError = `GitHub API ${res.status}: ${text.slice(0, 300)}`;
+      console.error(`❌ Failed to post review: ${postError}`);
+    }
+  } catch (err) {
+    postError = err.message;
+    console.error('❌ Failed to post review:', err.message);
+  }
+
+  // Fallback: post the summary as a regular issue comment if the formal review failed
+  if (!posted) {
     try {
-      const url = `https://api.github.com/repos/${REPO}/pulls/${PR_NUMBER}/reviews`;
-      const res = await fetch(url, {
+      const fallbackUrl = `https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments`;
+      await fetch(fallbackUrl, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${GITHUB_TOKEN}`,
@@ -295,53 +512,18 @@ async function main() {
           Accept: 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
         },
-        body: JSON.stringify({ body: reviewBody, event: 'COMMENT' }),
+        body: JSON.stringify({
+          body: `## 🤖 AI Code Review — ⚠️ Partial Failure\n\n> ${statusLine}\n\nThe line-level review could not be posted.\n**Error:** \`${postError}\`\n\n<details><summary>Summary</summary>\n\n${reviewBody}\n\n</details>`,
+        }),
       });
-
-      if (res.ok) {
-        console.log(`✅ Review posted to PR #${PR_NUMBER}`);
-        posted = true;
-      } else {
-        const text = await res.text().catch(() => '');
-        postError = `GitHub API ${res.status}: ${text.slice(0, 200)}`;
-        console.error(`❌ Failed to post review: ${postError}`);
-      }
-    } catch (err) {
-      postError = err.message;
-      console.error('❌ Failed to post review to GitHub:', err.message);
+      console.log('⚠️  Posted fallback issue comment instead.');
+    } catch {
+      console.log('\n--- Review Output (fallback stdout) ---\n');
+      console.log(reviewBody);
     }
-
-    // If posting failed, post a minimal error comment so there's a visible signal in the PR
-    if (!posted && GITHUB_TOKEN) {
-      try {
-        const url = `https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments`;
-        await fetch(url, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${GITHUB_TOKEN}`,
-            'Content-Type': 'application/json',
-            Accept: 'application/vnd.github+json',
-            'X-GitHub-Api-Version': '2022-11-28',
-          },
-          body: JSON.stringify({
-            body: `## 🤖 AI Code Review — ⚠️ Partial Failure\n\n> Model: \`${MODEL}\` | ${statusLine}\n\nThe review was generated but could not be posted as a formal PR review.\n**Error:** \`${postError}\`\n\n<details><summary>Review content</summary>\n\n${reviewBody}\n\n</details>`,
-          }),
-        });
-        console.log('⚠️  Posted fallback issue comment instead.');
-      } catch {
-        // Last resort: print to stdout so it appears in the CI logs
-        console.log('\n--- Review Output (fallback stdout) ---\n');
-        console.log(reviewBody);
-      }
-    }
-  } else {
-    // Dry run: print to stdout
-    console.log('\n--- Review Output (dry run) ---\n');
-    console.log(reviewBody);
   }
 
-  // Exit non-zero if all passes failed so CI can surface the problem
-  if (failedCount === passes.length) {
+  if (failedPasses.length === PASSES.length) {
     console.error('❌ All review passes failed.');
     process.exit(1);
   }

--- a/scripts/audit-milestones.json
+++ b/scripts/audit-milestones.json
@@ -1,0 +1,19 @@
+{
+  "$comment": "Milestones tracked by vps-audit-dashboard.sh. Edit to set new targets.",
+  "per_focus": [
+    { "focus": "security", "metric": "open_findings", "target": 0,  "deadline": "2026-06-01", "label": "Zero security findings" },
+    { "focus": "vulns",    "metric": "open_findings", "target": 0,  "deadline": "2026-06-01", "label": "Zero vulnerabilities" },
+    { "focus": "errors",   "metric": "open_findings", "target": 5,  "deadline": "2026-05-15", "label": "≤5 error findings" },
+    { "focus": "types",    "metric": "open_findings", "target": 20, "deadline": "2026-05-15", "label": "≤20 type findings" },
+    { "focus": "react",    "metric": "open_findings", "target": 10, "deadline": "2026-06-15", "label": "≤10 React findings" },
+    { "focus": "i18n",     "metric": "open_findings", "target": 5,  "deadline": "2026-06-15", "label": "≤5 i18n findings" },
+    { "focus": "debt",     "metric": "open_findings", "target": 15, "deadline": "2026-07-01", "label": "≤15 debt findings" },
+    { "focus": "deps",     "metric": "open_findings", "target": 0,  "deadline": "2026-06-01", "label": "Zero outdated deps" }
+  ],
+  "global": {
+    "metric": "health_score",
+    "target": 90,
+    "deadline": "2026-07-01",
+    "label": "Health score ≥ 90"
+  }
+}

--- a/scripts/vps-audit-chain.sh
+++ b/scripts/vps-audit-chain.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# =============================================================================
+# vps-audit-chain.sh — Chained Audit Orchestrator
+#
+# Runs multiple audit focuses sequentially. After each focus runs, its
+# findings are extracted into a compact context block that is fed to the
+# next agent via vps-audit.sh --chain-context <path>.
+#
+# The downstream agent sees upstream findings and can:
+#   - Avoid duplicating fixes that upstream already addressed
+#   - Pick up TODOs upstream left in its own focus
+#   - Cross-reference overlapping issues
+#
+# Usage:
+#   ./scripts/vps-audit-chain.sh security,errors,types
+#   ./scripts/vps-audit-chain.sh security errors types
+#
+# Each step's PR is created independently (one PR per focus, same chain ID
+# logged so they can be correlated). The chain stops if any step fails.
+#
+# Cron (daily at 4am, runs security → errors → types together):
+#   0 4 * * * /opt/dome-audit/scripts/vps-audit-chain.sh security,errors,types \
+#     >> /var/log/dome-audit.log 2>&1
+# =============================================================================
+
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+AUDIT_SCRIPT="${AUDIT_SCRIPT:-$SCRIPT_DIR/vps-audit.sh}"
+FINDINGS_DIR="${FINDINGS_DIR:-/var/log/dome-audit-findings}"
+CHAIN_LOG="${CHAIN_LOG:-/var/log/dome-audit.log}"
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <focus1,focus2,focus3>"
+  echo "       $0 focus1 focus2 focus3"
+  echo ""
+  echo "Example: $0 security,errors,types"
+  exit 1
+fi
+
+# Accept either comma-separated or space-separated
+RAW_INPUT="$*"
+FOCUSES=$(echo "$RAW_INPUT" | tr ',' ' ' | tr -s ' ')
+
+CHAIN_ID="chain-$(date +%Y%m%d-%H%M%S)-$$"
+TMP_DIR=$(mktemp -d /tmp/audit-chain-XXXXXX)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+log() {
+  echo "[dome-chain $CHAIN_ID $(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+log "Starting chained audit: $FOCUSES"
+
+# ── Build compact context from a focus's findings file ───────────────────────
+# Output format (markdown): each upstream focus section with top open findings.
+build_chain_context() {
+  local context_file="$1"
+  shift
+  local completed=("$@")
+
+  : > "$context_file"
+
+  if [ ${#completed[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  python3 - "$context_file" "$FINDINGS_DIR" "${completed[@]}" << 'PY'
+import json
+import sys
+from pathlib import Path
+
+out_path = Path(sys.argv[1])
+findings_dir = Path(sys.argv[2])
+focuses = sys.argv[3:]
+
+lines = []
+for focus in focuses:
+    f = findings_dir / f"{focus}.findings.json"
+    if not f.exists():
+        continue
+    try:
+        data = json.loads(f.read_text())
+    except Exception:
+        continue
+    open_items = [x for x in data if isinstance(x, dict) and x.get("status") == "open"]
+    if not open_items:
+        continue
+    lines.append(f"#### {focus} ({len(open_items)} open)")
+    lines.append("")
+    # Top 10 by severity (error first) then file
+    sev_rank = {"error": 0, "warn": 1}
+    open_items.sort(key=lambda x: (sev_rank.get(x.get("severity"), 2), x.get("file", ""), x.get("line", 0)))
+    for item in open_items[:10]:
+        sev = item.get("severity", "warn")
+        sev_icon = "❌" if sev == "error" else "⚠️"
+        file_ref = item.get("file", "unknown")
+        line_ref = item.get("line") or 0
+        loc = f"{file_ref}" + (f":{line_ref}" if line_ref else "")
+        body = (item.get("body") or "").strip()
+        body = body.replace("\n", " ")
+        if len(body) > 240:
+            body = body[:237] + "..."
+        lines.append(f"- {sev_icon} `{loc}` — {body}")
+    remaining = len(open_items) - 10
+    if remaining > 0:
+        lines.append(f"- …and {remaining} more (see `{focus}.findings.json`)")
+    lines.append("")
+
+out_path.write_text("\n".join(lines) if lines else "_No open findings from upstream focuses._\n")
+PY
+}
+
+# ── Run each focus, building context from upstream findings ──────────────────
+COMPLETED=()
+STEP=0
+TOTAL=$(echo "$FOCUSES" | wc -w | tr -d ' ')
+
+for focus in $FOCUSES; do
+  STEP=$((STEP + 1))
+  log "Step $STEP/$TOTAL: focus=$focus"
+
+  CTX_FILE="$TMP_DIR/chain-context-${focus}.md"
+  if [ "${#COMPLETED[@]}" -gt 0 ]; then
+    build_chain_context "$CTX_FILE" "${COMPLETED[@]}"
+  else
+    : > "$CTX_FILE"
+  fi
+
+  AUDIT_ARGS=(--focus "$focus")
+  if [ -s "$CTX_FILE" ] && [ "${#COMPLETED[@]}" -gt 0 ]; then
+    AUDIT_ARGS+=(--chain-context "$CTX_FILE")
+    log "  chain-context: $(wc -l < "$CTX_FILE" | tr -d ' ') lines from ${COMPLETED[*]}"
+  fi
+
+  if ! bash "$AUDIT_SCRIPT" "${AUDIT_ARGS[@]}"; then
+    log "  ❌ Step failed: focus=$focus — stopping chain"
+    exit 1
+  fi
+
+  COMPLETED+=("$focus")
+  log "  ✓ Step complete: focus=$focus"
+done
+
+log "Chain complete — ${#COMPLETED[@]} focus(es) ran successfully"

--- a/scripts/vps-audit-dashboard.sh
+++ b/scripts/vps-audit-dashboard.sh
@@ -21,6 +21,12 @@ OUTPUT_DIR="${OUTPUT_DIR:-/var/www/dome-audit}"
 OUTPUT_FILE="$OUTPUT_DIR/index.html"
 LOG_PREFIX="[dome-dashboard $(date '+%Y-%m-%d %H:%M')]"
 
+# Milestones config + history (VPS clone of repo reads from scripts/)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MILESTONES_FILE="${MILESTONES_FILE:-$SCRIPT_DIR/audit-milestones.json}"
+HISTORY_FILE="${HISTORY_FILE:-$FINDINGS_DIR/history.jsonl}"
+HISTORY_MAX_LINES="${HISTORY_MAX_LINES:-5000}"
+
 mkdir -p "$OUTPUT_DIR"
 echo "$LOG_PREFIX Generating dashboard..."
 
@@ -53,12 +59,23 @@ declare -A FOCUS_FINDINGS
 declare -A FOCUS_LAST_PR
 declare -A FOCUS_LAST_RUN
 
-FOCUS_TYPES=("security" "types" "i18n" "debt" "vulns" "react" "errors" "all")
+FOCUS_TYPES=("security" "types" "i18n" "debt" "vulns" "react" "errors" "deps" "all")
 
 for focus in "${FOCUS_TYPES[@]}"; do
   count=0
-  if [ -f "$FINDINGS_DIR/${focus}.findings" ]; then
-    count=$(wc -l < "$FINDINGS_DIR/${focus}.findings" | tr -d ' ')
+  json_file="$FINDINGS_DIR/${focus}.findings.json"
+  legacy_file="$FINDINGS_DIR/${focus}.findings"
+  if [ -f "$json_file" ]; then
+    count=$(python3 -c "
+import json
+try:
+    d = json.load(open('$json_file'))
+    print(sum(1 for f in d if f.get('status') == 'open'))
+except Exception:
+    print(0)
+" 2>/dev/null || echo 0)
+  elif [ -f "$legacy_file" ]; then
+    count=$(wc -l < "$legacy_file" | tr -d ' ')
   fi
   FOCUS_FINDINGS[$focus]=$count
   TOTAL_FINDINGS=$((TOTAL_FINDINGS + count))
@@ -96,11 +113,62 @@ else
   HEALTH_LABEL="Needs Work"
 fi
 
+# ── Append snapshot to history.jsonl (powers sparklines + milestone trends) ──
+# Each run writes one line per focus + one "global" line with the health score.
+# File is truncated to HISTORY_MAX_LINES from the tail to avoid unbounded growth.
+FOCUS_COUNTS_JSON="{"
+_first=1
+for focus in "${FOCUS_TYPES[@]}"; do
+  [ "$_first" -eq 1 ] || FOCUS_COUNTS_JSON+=","
+  FOCUS_COUNTS_JSON+="\"${focus}\":${FOCUS_FINDINGS[$focus]:-0}"
+  _first=0
+done
+FOCUS_COUNTS_JSON+="}"
+
+export TOTAL_FINDINGS HEALTH_SCORE HISTORY_FILE HISTORY_MAX_LINES FOCUS_COUNTS_JSON
+
+python3 - << 'PY'
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+history_file = Path(os.environ["HISTORY_FILE"])
+max_lines = int(os.environ.get("HISTORY_MAX_LINES", "5000"))
+health_score = int(os.environ["HEALTH_SCORE"])
+total_findings = int(os.environ["TOTAL_FINDINGS"])
+counts = json.loads(os.environ.get("FOCUS_COUNTS_JSON", "{}"))
+now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+history_file.parent.mkdir(parents=True, exist_ok=True)
+
+entries = [
+    {"ts": now, "focus": focus, "open_count": int(count)}
+    for focus, count in counts.items()
+]
+entries.append({"ts": now, "focus": "__global__", "health_score": health_score, "total_findings": total_findings})
+
+with history_file.open("a") as f:
+    for entry in entries:
+        f.write(json.dumps(entry) + "\n")
+
+# Trim to last max_lines
+try:
+    lines = history_file.read_text().splitlines()
+    if len(lines) > max_lines:
+        history_file.write_text("\n".join(lines[-max_lines:]) + "\n")
+except Exception:
+    pass
+PY
+
 # ── VPS status ────────────────────────────────────────────────────────────────
 # Count AI review failures in last 24h from log file
+# grep -c always prints the count (even 0), but exits 1 on no matches — so use
+# `|| true` instead of `|| echo 0` to avoid appending a second "0" to stdout.
 AI_REVIEW_FAILURES_24H=0
 if [ -f "$LOG_FILE" ]; then
-  AI_REVIEW_FAILURES_24H=$(grep -c "AI review.*fail\|Review pass failed\|API error" "$LOG_FILE" 2>/dev/null || echo "0")
+  AI_REVIEW_FAILURES_24H=$(grep -c "AI review.*fail\|Review pass failed\|API error" "$LOG_FILE" 2>/dev/null || true)
+  [ -z "$AI_REVIEW_FAILURES_24H" ] && AI_REVIEW_FAILURES_24H=0
 fi
 
 # Count pending findings jobs
@@ -148,13 +216,13 @@ def ai_review_status(reviews):
 focus_colors = {
     'security': '#ef4444', 'types': '#3b82f6', 'i18n': '#8b5cf6',
     'debt': '#f59e0b', 'vulns': '#dc2626', 'react': '#06b6d4',
-    'errors': '#f97316', 'all': '#6b7280'
+    'errors': '#f97316', 'deps': '#10b981', 'all': '#6b7280'
 }
 
 focus_icons = {
     'security': '🔒', 'types': '📝', 'i18n': '🌍',
     'debt': '🧹', 'vulns': '🛡️', 'react': '⚛️',
-    'errors': '🚨', 'all': '🔍'
+    'errors': '🚨', 'deps': '📦', 'all': '🔍'
 }
 
 data = json.load(sys.stdin)[:15]
@@ -185,9 +253,12 @@ for p in data:
 print(''.join(rows))
 " 2>/dev/null || echo "<tr><td colspan='7' class='muted'>No PR data available</td></tr>")
 
+# ── Load history (powers sparklines) ──────────────────────────────────────────
+export HISTORY_FILE MILESTONES_FILE
+
 # ── Per-focus cards HTML ───────────────────────────────────────────────────────
 FOCUS_CARDS_HTML=$(python3 -c "
-import json, subprocess, re
+import json, os, re
 
 FOCUS_TYPES = [
     ('security', '🔒', 'Security', '#ef4444', '4x/day'),
@@ -197,18 +268,70 @@ FOCUS_TYPES = [
     ('debt',     '🧹', 'Debt',     '#f59e0b', '2x/day'),
     ('i18n',     '🌍', 'i18n',     '#8b5cf6', '2x/day'),
     ('vulns',    '🛡️',  'Vulns',    '#dc2626', '2x/week'),
+    ('deps',     '📦', 'Deps',     '#10b981', 'daily'),
     ('all',      '🔍', 'Full',     '#6b7280', 'weekly'),
 ]
 
 findings_dir = '/var/log/dome-audit-findings'
 audit_prs = json.loads('''${AUDIT_PRS}''')
 
+# Load history for sparklines
+history_file = os.environ.get('HISTORY_FILE', '')
+history_by_focus = {}
+if history_file and os.path.exists(history_file):
+    try:
+        with open(history_file) as f:
+            for line in f:
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    continue
+                focus = rec.get('focus')
+                if not focus:
+                    continue
+                history_by_focus.setdefault(focus, []).append(rec)
+    except Exception:
+        pass
+
+def sparkline_svg(points, width=100, height=22, color='#7b76d0', fill=True):
+    if not points or len(points) < 2:
+        return ''
+    pad = 1.5
+    max_v = max(points)
+    min_v = min(points)
+    span = max(max_v - min_v, 1)
+    n = len(points)
+    step = (width - 2 * pad) / (n - 1) if n > 1 else 0
+    xs = [pad + i * step for i in range(n)]
+    ys = [height - pad - ((v - min_v) / span) * (height - 2 * pad) for v in points]
+    line_pts = ' '.join(f'{x:.1f},{y:.1f}' for x, y in zip(xs, ys))
+    poly = ''
+    if fill:
+        fill_pts = f'{xs[0]:.1f},{height} ' + line_pts + f' {xs[-1]:.1f},{height}'
+        poly = f'<polygon points=\"{fill_pts}\" fill=\"{color}\" fill-opacity=\"0.12\" />'
+    last_x, last_y = xs[-1], ys[-1]
+    return (
+        f'<svg class=\"sparkline\" viewBox=\"0 0 {width} {height}\" width=\"{width}\" height=\"{height}\" aria-hidden=\"true\">'
+        f'{poly}'
+        f'<polyline points=\"{line_pts}\" fill=\"none\" stroke=\"{color}\" stroke-width=\"1.25\" stroke-linecap=\"round\" stroke-linejoin=\"round\" />'
+        f'<circle cx=\"{last_x:.1f}\" cy=\"{last_y:.1f}\" r=\"1.6\" fill=\"{color}\" />'
+        '</svg>'
+    )
+
 def get_findings_count(focus):
+    # Prefer structured JSON; fall back to legacy .findings text file
+    json_path = f'{findings_dir}/{focus}.findings.json'
+    try:
+        with open(json_path) as f:
+            d = json.load(f)
+            return sum(1 for f in d if f.get('status') == 'open')
+    except Exception:
+        pass
     try:
         with open(f'{findings_dir}/{focus}.findings') as f:
             lines = [l for l in f.read().splitlines() if l.strip()]
             return len(lines)
-    except:
+    except Exception:
         return -1  # no data
 
 def get_last_pr(focus):
@@ -219,6 +342,11 @@ cards = []
 for focus, icon, label, color, freq in FOCUS_TYPES:
     count = get_findings_count(focus)
     pr = get_last_pr(focus)
+
+    # Sparkline from history (last 30 points)
+    hist = history_by_focus.get(focus, [])[-30:]
+    points = [rec.get('open_count', 0) for rec in hist]
+    spark_html = sparkline_svg(points, width=90, height=20, color=color) if points else '<span class=\"sparkline-empty muted\">—</span>'
 
     if count < 0:
         status_html = '<span class=\"status-dot dot-gray\"></span> No data'
@@ -252,7 +380,10 @@ for focus, icon, label, color, freq in FOCUS_TYPES:
         <div class=\"focus-card-status\">{status_html}</div>
       </div>
       <div class=\"focus-card-body\">
-        <div>{findings_html}</div>
+        <div class=\"focus-card-row\">
+          <div>{findings_html}</div>
+          <div class=\"sparkline-wrap\">{spark_html}</div>
+        </div>
         <div class=\"focus-card-pr\">{pr_html}</div>
       </div>
     </div>''')
@@ -260,32 +391,254 @@ for focus, icon, label, color, freq in FOCUS_TYPES:
 print(''.join(cards))
 " 2>/dev/null || echo "<p class='muted'>Focus data unavailable</p>")
 
+# ── Milestones + global health sparkline ─────────────────────────────────────
+MILESTONES_HTML=""
+HEALTH_SPARKLINE_SVG=""
+MILESTONES_BLOCK=$(python3 << 'PY'
+import json
+import os
+from datetime import datetime, timezone, date
+from pathlib import Path
+
+milestones_file = Path(os.environ.get("MILESTONES_FILE", ""))
+history_file = Path(os.environ.get("HISTORY_FILE", ""))
+
+def sparkline_svg(points, width=260, height=36, color="#7b76d0", fill=True):
+    if not points or len(points) < 2:
+        return ""
+    pad = 2
+    max_v = max(points)
+    min_v = min(points)
+    span = max(max_v - min_v, 1)
+    n = len(points)
+    step = (width - 2 * pad) / (n - 1) if n > 1 else 0
+    xs = [pad + i * step for i in range(n)]
+    ys = [height - pad - ((v - min_v) / span) * (height - 2 * pad) for v in points]
+    line_pts = " ".join(f"{x:.1f},{y:.1f}" for x, y in zip(xs, ys))
+    poly = ""
+    if fill:
+        fill_pts = f"{xs[0]:.1f},{height} " + line_pts + f" {xs[-1]:.1f},{height}"
+        poly = f'<polygon points="{fill_pts}" fill="{color}" fill-opacity="0.14" />'
+    return (
+        f'<svg class="sparkline-lg" viewBox="0 0 {width} {height}" width="{width}" height="{height}" aria-hidden="true">'
+        f'{poly}'
+        f'<polyline points="{line_pts}" fill="none" stroke="{color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />'
+        f'<circle cx="{xs[-1]:.1f}" cy="{ys[-1]:.1f}" r="2" fill="{color}" />'
+        '</svg>'
+    )
+
+# Load history
+history = {}
+if history_file.exists():
+    try:
+        for line in history_file.read_text().splitlines():
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            focus = rec.get("focus")
+            if not focus:
+                continue
+            history.setdefault(focus, []).append(rec)
+    except Exception:
+        pass
+
+# Global health sparkline from __global__ entries (last 30)
+global_hist = history.get("__global__", [])[-30:]
+global_points = [rec.get("health_score", 0) for rec in global_hist]
+global_spark = sparkline_svg(global_points, color="#7b76d0") if global_points else ""
+
+# Milestones
+milestones_cards = []
+if milestones_file.exists():
+    try:
+        config = json.loads(milestones_file.read_text())
+    except Exception:
+        config = {}
+else:
+    config = {}
+
+today = datetime.now(timezone.utc).date()
+
+def days_until(deadline_str):
+    try:
+        d = datetime.strptime(deadline_str, "%Y-%m-%d").date()
+        return (d - today).days
+    except Exception:
+        return None
+
+def status_for(current, target, metric, days_left, slope):
+    # For open_findings we want current <= target; for health_score we want current >= target.
+    if metric == "health_score":
+        met = current >= target
+        gap = target - current
+        progress = max(0.0, min(1.0, current / target if target > 0 else 1.0))
+        # slope: positive slope = improving
+        trending_wrong_way = slope < -0.3
+    else:
+        met = current <= target
+        baseline = max(current, target + 1)
+        gap = current - target
+        progress = max(0.0, min(1.0, 1 - (gap / baseline) if baseline > 0 else 1.0))
+        # slope: negative slope (fewer findings over time) = improving
+        trending_wrong_way = slope > 0.3
+
+    if met:
+        return "on-track", progress, "Target met"
+    if days_left is None:
+        return "unknown", progress, "No deadline"
+    if days_left < 0:
+        return "overdue", progress, f"Overdue by {-days_left}d"
+    if trending_wrong_way:
+        return "at-risk", progress, f"{days_left}d — trending wrong way"
+    if days_left <= 14 and progress < 0.7:
+        return "at-risk", progress, f"{days_left}d — behind schedule"
+    return "on-track", progress, f"{days_left}d remaining"
+
+def slope_of(points):
+    """Simple slope: avg(last 3) - avg(first 3), normalized by n."""
+    if len(points) < 4:
+        return 0.0
+    head = sum(points[:3]) / 3
+    tail = sum(points[-3:]) / 3
+    return (tail - head) / len(points)
+
+def render_card(label, metric, target, deadline, current, points, color):
+    days_left = days_until(deadline)
+    slope = slope_of(points)
+    status, progress, status_text = status_for(current, target, metric, days_left, slope)
+    status_class = {
+        "on-track": "milestone-ok",
+        "at-risk":  "milestone-warn",
+        "overdue":  "milestone-bad",
+        "unknown":  "milestone-muted",
+    }.get(status, "milestone-muted")
+    bar_color = {
+        "on-track": "#3a9b6b",
+        "at-risk":  "#b38019",
+        "overdue":  "#d14d4d",
+        "unknown":  "#858299",
+    }.get(status, "#858299")
+    progress_pct = int(progress * 100)
+    if metric == "health_score":
+        current_display = f"{current} / {target}"
+    else:
+        current_display = f"{current} open · target ≤ {target}"
+    spark_html = sparkline_svg(points, width=220, height=30, color=bar_color) if points else '<span class="muted" style="font-size:11px">No history yet</span>'
+    return (
+        f'<div class="milestone-card {status_class}">'
+        f'<div class="milestone-header">'
+        f'<span class="milestone-label">{label}</span>'
+        f'<span class="milestone-status">{status_text}</span>'
+        f'</div>'
+        f'<div class="milestone-value">{current_display}</div>'
+        f'<div class="milestone-bar"><div class="milestone-bar-fill" style="width:{progress_pct}%;background:{bar_color}"></div></div>'
+        f'<div class="milestone-spark">{spark_html}</div>'
+        f'<div class="milestone-meta muted">Due {deadline}</div>'
+        f'</div>'
+    )
+
+# Per-focus milestones
+for m in config.get("per_focus", []):
+    focus = m.get("focus")
+    metric = m.get("metric", "open_findings")
+    target = m.get("target", 0)
+    deadline = m.get("deadline", "")
+    label = m.get("label") or f"{focus}: ≤{target}"
+    hist = history.get(focus, [])[-30:]
+    points = [rec.get("open_count", 0) for rec in hist]
+    current = points[-1] if points else 0
+    milestones_cards.append(render_card(label, metric, target, deadline, current, points, "#7b76d0"))
+
+# Global milestone
+g = config.get("global")
+if g:
+    metric = g.get("metric", "health_score")
+    target = g.get("target", 90)
+    deadline = g.get("deadline", "")
+    label = g.get("label", "Global health")
+    hist = history.get("__global__", [])[-30:]
+    if metric == "health_score":
+        points = [rec.get("health_score", 0) for rec in hist]
+    else:
+        points = [rec.get("total_findings", 0) for rec in hist]
+    current = points[-1] if points else 0
+    milestones_cards.append(render_card(label, metric, target, deadline, current, points, "#7b76d0"))
+
+milestones_html = "".join(milestones_cards) if milestones_cards else '<div class="empty-state muted">No milestones configured — edit scripts/audit-milestones.json</div>'
+
+# Emit as shell-safe base64 so multi-line HTML survives $() round-trip
+import base64
+payload = {"milestones": milestones_html, "global_spark": global_spark}
+print(base64.b64encode(json.dumps(payload).encode()).decode())
+PY
+)
+
+# Decode payload
+MILESTONES_HTML=$(echo "$MILESTONES_BLOCK" | python3 -c "import sys,base64,json; d=json.loads(base64.b64decode(sys.stdin.read().strip())); print(d['milestones'])" 2>/dev/null || echo '<div class="empty-state muted">Milestones unavailable</div>')
+HEALTH_SPARKLINE_SVG=$(echo "$MILESTONES_BLOCK" | python3 -c "import sys,base64,json; d=json.loads(base64.b64decode(sys.stdin.read().strip())); print(d['global_spark'])" 2>/dev/null || echo '')
+
 # ── Open findings detail ───────────────────────────────────────────────────────
-OPEN_FINDINGS_HTML=""
-for focus in "${FOCUS_TYPES[@]}"; do
-  file="$FINDINGS_DIR/${focus}.findings"
-  [ -f "$file" ] || continue
-  [ -s "$file" ] || continue
-  content=$(cat "$file")
-  [ -z "$content" ] && continue
+OPEN_FINDINGS_HTML=$(python3 -c "
+import html
+import json
+import os
+from glob import glob
 
-  OPEN_FINDINGS_HTML+="<div class='finding-group'>"
-  OPEN_FINDINGS_HTML+="<h4 class='finding-focus-title'>$(echo "$focus" | tr '[:lower:]' '[:upper:]')</h4>"
-  while IFS= read -r line; do
-    [ -z "$line" ] && continue
-    # Determine icon
-    if [[ "$line" == ❌* ]]; then
-      OPEN_FINDINGS_HTML+="<div class='finding-item finding-error'>$line</div>"
-    else
-      OPEN_FINDINGS_HTML+="<div class='finding-item finding-warn'>$line</div>"
-    fi
-  done <<< "$content"
-  OPEN_FINDINGS_HTML+="</div>"
-done
+findings_dir = '$FINDINGS_DIR'
+focus_order = ['security', 'errors', 'types', 'react', 'debt', 'i18n', 'vulns', 'deps', 'all']
 
-if [ -z "$OPEN_FINDINGS_HTML" ]; then
-  OPEN_FINDINGS_HTML="<div class='empty-state'>✓ No open findings — codebase is clean</div>"
-fi
+groups = []
+for focus in focus_order:
+    json_path = os.path.join(findings_dir, f'{focus}.findings.json')
+    items = []
+    if os.path.exists(json_path):
+        try:
+            with open(json_path) as f:
+                data = json.load(f)
+            for item in data:
+                if item.get('status') == 'open':
+                    items.append(item)
+        except Exception:
+            pass
+    else:
+        # Legacy fallback
+        legacy = os.path.join(findings_dir, f'{focus}.findings')
+        if os.path.exists(legacy):
+            try:
+                with open(legacy) as f:
+                    for line in f.read().splitlines():
+                        if line.strip():
+                            items.append({'body': line, 'severity': 'error' if line.startswith('❌') else 'warn'})
+            except Exception:
+                pass
+
+    if not items:
+        continue
+
+    rows = []
+    for item in items:
+        sev = item.get('severity', 'warn')
+        css = 'finding-error' if sev == 'error' else 'finding-warn'
+        body = html.escape(item.get('body', ''))
+        first_pr = item.get('first_seen_pr')
+        extra = ''
+        if first_pr:
+            extra = f' <span class=\"finding-pr-ref\">(PR #{first_pr})</span>'
+        rows.append(f'<div class=\"finding-item {css}\">{body}{extra}</div>')
+
+    groups.append(
+        f'<div class=\"finding-group\">'
+        f'<h4 class=\"finding-focus-title\">{focus.upper()} ({len(items)})</h4>'
+        + ''.join(rows)
+        + '</div>'
+    )
+
+if groups:
+    print(''.join(groups))
+else:
+    print('<div class=\"empty-state\">✓ No open findings — codebase is clean</div>')
+" 2>/dev/null || echo "<div class='empty-state'>✓ No open findings — codebase is clean</div>")
 
 # ── Pending jobs ──────────────────────────────────────────────────────────────
 PENDING_HTML=""
@@ -313,141 +666,194 @@ cat > "$OUTPUT_FILE" << HTML
     * { box-sizing: border-box; margin: 0; padding: 0; }
 
     :root {
-      --bg: #0f0f13;
-      --bg2: #18181f;
-      --bg3: #22222c;
-      --border: #2e2e3a;
-      --text: #e4e4f0;
-      --text2: #9191a8;
+      --bg: #fbfbfe;
+      --bg2: #ffffff;
+      --bg3: #f2f2f9;
+      --border: #e6e6f0;
+      --border-strong: #d4d4e3;
+      --text: #040316;
+      --text2: #4a4766;
+      --text3: #858299;
       --accent: #7b76d0;
-      --green: #22c55e;
-      --red: #ef4444;
-      --yellow: #f59e0b;
-      --blue: #3b82f6;
+      --accent-soft: #eceaf9;
+      --green: #3a9b6b;
+      --green-soft: #e7f4ec;
+      --red: #d14d4d;
+      --red-soft: #f8e8e8;
+      --yellow: #b38019;
+      --yellow-soft: #f6efdc;
+      --blue: #4a7bc7;
+      --blue-soft: #e6edf8;
     }
 
+    html, body { background: var(--bg); }
     body {
-      background: var(--bg);
       color: var(--text);
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
       font-size: 14px;
       line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+      font-feature-settings: 'cv11', 'ss01';
     }
 
     a { color: var(--accent); text-decoration: none; }
     a:hover { text-decoration: underline; }
-    .muted { color: var(--text2); }
+    .muted { color: var(--text3); }
 
     /* ── Header ── */
     .header {
-      padding: 20px 32px;
+      padding: 24px 40px;
       border-bottom: 1px solid var(--border);
       display: flex;
       align-items: center;
       justify-content: space-between;
       background: var(--bg2);
     }
-    .header-left { display: flex; align-items: center; gap: 12px; }
-    .header-logo { font-size: 22px; font-weight: 700; }
-    .header-sub { color: var(--text2); font-size: 13px; }
-    .header-meta { font-size: 12px; color: var(--text2); text-align: right; }
-    .refresh-note { font-size: 11px; }
+    .header-left { display: flex; align-items: center; gap: 14px; }
+    .header-mark {
+      width: 36px; height: 36px;
+      display: flex; align-items: center; justify-content: center;
+      background: var(--accent-soft);
+      color: var(--accent);
+      border-radius: 10px;
+      font-size: 18px;
+      font-weight: 600;
+    }
+    .header-title { font-size: 16px; font-weight: 600; letter-spacing: -0.01em; }
+    .header-sub { color: var(--text3); font-size: 12px; margin-top: 2px; }
+    .header-meta { font-size: 12px; color: var(--text3); text-align: right; line-height: 1.7; }
+    .header-meta strong { color: var(--text2); font-weight: 500; }
+    .refresh-note { font-size: 11px; color: var(--text3); }
 
     /* ── Layout ── */
-    .container { max-width: 1200px; margin: 0 auto; padding: 24px 32px; }
-    .section { margin-bottom: 36px; }
+    .container { max-width: 1240px; margin: 0 auto; padding: 32px 40px 48px; }
+    .section { margin-bottom: 44px; }
     .section-title {
-      font-size: 12px; font-weight: 600; letter-spacing: 0.08em;
-      text-transform: uppercase; color: var(--text2);
-      margin-bottom: 16px; padding-bottom: 8px;
-      border-bottom: 1px solid var(--border);
+      font-size: 11px; font-weight: 600; letter-spacing: 0.1em;
+      text-transform: uppercase; color: var(--text3);
+      margin-bottom: 16px;
+    }
+    .section-title .count {
+      margin-left: 8px;
+      color: var(--text3);
+      font-weight: 500;
+      letter-spacing: 0;
     }
 
     /* ── Summary cards ── */
     .summary-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 12px;
     }
     .summary-card {
       background: var(--bg2);
       border: 1px solid var(--border);
-      border-radius: 10px;
-      padding: 20px;
+      border-radius: 12px;
+      padding: 18px 20px;
+      transition: border-color 150ms ease;
     }
-    .summary-card .label { font-size: 12px; color: var(--text2); margin-bottom: 8px; }
-    .summary-card .value { font-size: 28px; font-weight: 700; line-height: 1; }
-    .summary-card .sub { font-size: 12px; color: var(--text2); margin-top: 4px; }
+    .summary-card:hover { border-color: var(--border-strong); }
+    .summary-card .label {
+      font-size: 11px; color: var(--text3);
+      letter-spacing: 0.04em; text-transform: uppercase;
+      font-weight: 500;
+      margin-bottom: 10px;
+    }
+    .summary-card .value {
+      font-size: 26px; font-weight: 600;
+      line-height: 1.1; letter-spacing: -0.02em;
+    }
+    .summary-card .sub { font-size: 12px; color: var(--text3); margin-top: 4px; }
 
     /* ── Health ring ── */
     .health-card {
       background: var(--bg2);
       border: 1px solid var(--border);
-      border-radius: 10px;
-      padding: 20px;
+      border-radius: 12px;
+      padding: 18px 20px;
       display: flex;
       align-items: center;
       gap: 16px;
     }
     .health-ring {
-      width: 60px; height: 60px;
+      width: 56px; height: 56px;
       border-radius: 50%;
-      border: 5px solid var(--border);
+      border: 4px solid var(--border);
       display: flex; align-items: center; justify-content: center;
-      font-size: 15px; font-weight: 700;
+      font-size: 15px; font-weight: 600;
       flex-shrink: 0;
+      letter-spacing: -0.02em;
     }
-    .health-info .label { font-size: 12px; color: var(--text2); margin-bottom: 4px; }
-    .health-info .value { font-size: 20px; font-weight: 700; }
-    .health-info .sub { font-size: 12px; color: var(--text2); margin-top: 2px; }
+    .health-info .label {
+      font-size: 11px; color: var(--text3);
+      letter-spacing: 0.04em; text-transform: uppercase;
+      font-weight: 500;
+      margin-bottom: 6px;
+    }
+    .health-info .value { font-size: 18px; font-weight: 600; letter-spacing: -0.01em; }
+    .health-info .sub { font-size: 12px; color: var(--text3); margin-top: 2px; }
 
     /* ── Focus grid ── */
     .focus-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
       gap: 12px;
     }
     .focus-card {
       background: var(--bg2);
       border: 1px solid var(--border);
-      border-radius: 10px;
+      border-radius: 12px;
       overflow: hidden;
+      transition: border-color 150ms ease;
     }
+    .focus-card:hover { border-color: var(--border-strong); }
     .focus-card-header {
       padding: 14px 16px;
       display: flex;
       align-items: center;
       gap: 10px;
-      border-bottom: 1px solid var(--border);
     }
-    .focus-icon { font-size: 18px; width: 24px; text-align: center; flex-shrink: 0; }
+    .focus-icon { font-size: 16px; width: 22px; text-align: center; flex-shrink: 0; }
     .focus-card-info { flex: 1; min-width: 0; }
-    .focus-card-name { font-weight: 600; font-size: 14px; display: block; }
-    .focus-freq { font-size: 11px; }
-    .focus-card-status { font-size: 12px; white-space: nowrap; }
-    .focus-card-body { padding: 12px 16px; display: flex; flex-direction: column; gap: 6px; }
+    .focus-card-name {
+      font-weight: 600; font-size: 13px;
+      display: block; letter-spacing: -0.01em;
+    }
+    .focus-freq { font-size: 11px; color: var(--text3); }
+    .focus-card-status { font-size: 12px; white-space: nowrap; color: var(--text2); }
+    .focus-card-body {
+      padding: 12px 16px 14px;
+      display: flex; flex-direction: column; gap: 6px;
+      border-top: 1px solid var(--border);
+    }
     .focus-card-pr { font-size: 12px; }
-    .pr-mini-link { display: flex; align-items: center; gap: 6px; color: var(--text2); }
-    .pr-mini-link:hover { color: var(--text); }
+    .pr-mini-link { display: inline-flex; align-items: center; gap: 6px; color: var(--text3); }
+    .pr-mini-link:hover { color: var(--text2); }
 
     /* ── Status dots ── */
-    .status-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 5px; }
-    .dot-green { background: var(--green); box-shadow: 0 0 6px var(--green); }
+    .status-dot {
+      display: inline-block; width: 7px; height: 7px;
+      border-radius: 50%; margin-right: 6px;
+      vertical-align: baseline;
+    }
+    .dot-green { background: var(--green); }
     .dot-red { background: var(--red); }
     .dot-yellow { background: var(--yellow); }
-    .dot-gray { background: var(--text2); }
-    .clean-label { color: var(--green); font-size: 13px; }
-    .findings-count { color: var(--yellow); font-size: 13px; font-weight: 600; }
+    .dot-gray { background: var(--text3); }
+    .clean-label { color: var(--green); font-size: 12px; font-weight: 500; }
+    .findings-count { color: var(--yellow); font-size: 12px; font-weight: 600; }
 
     /* ── Badges ── */
     .badge {
       display: inline-flex; align-items: center;
-      padding: 2px 7px; border-radius: 4px;
+      padding: 2px 8px; border-radius: 4px;
       font-size: 11px; font-weight: 500;
+      letter-spacing: 0.01em;
     }
-    .badge-merged { background: #14532d40; color: #4ade80; border: 1px solid #14532d80; }
-    .badge-open { background: #1e3a5f40; color: #60a5fa; border: 1px solid #1e3a5f80; }
-    .badge-closed { background: #3f3f4640; color: #9ca3af; border: 1px solid #3f3f4680; }
+    .badge-merged { background: var(--green-soft); color: var(--green); }
+    .badge-open    { background: var(--blue-soft);  color: var(--blue); }
+    .badge-closed  { background: var(--bg3);        color: var(--text3); }
 
     .focus-badge {
       display: inline-flex; align-items: center; gap: 4px;
@@ -457,6 +863,12 @@ cat > "$OUTPUT_FILE" << HTML
     }
 
     /* ── Timeline table ── */
+    .table-wrapper {
+      background: var(--bg2);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+    }
     .timeline-table {
       width: 100%;
       border-collapse: collapse;
@@ -464,91 +876,170 @@ cat > "$OUTPUT_FILE" << HTML
     }
     .timeline-table thead th {
       text-align: left;
-      padding: 8px 12px;
-      font-size: 11px; font-weight: 600; letter-spacing: 0.05em;
-      text-transform: uppercase; color: var(--text2);
+      padding: 12px 16px;
+      font-size: 11px; font-weight: 600; letter-spacing: 0.08em;
+      text-transform: uppercase; color: var(--text3);
       border-bottom: 1px solid var(--border);
+      background: var(--bg3);
     }
     .timeline-row td {
-      padding: 10px 12px;
+      padding: 12px 16px;
       border-bottom: 1px solid var(--border);
       vertical-align: middle;
     }
     .timeline-row:last-child td { border-bottom: none; }
     .timeline-row:hover { background: var(--bg3); }
-    .pr-link { font-weight: 600; }
-    .stat-cell { font-size: 12px; white-space: nowrap; }
-    .additions { color: var(--green); }
-    .deletions { color: var(--red); }
-    .table-wrapper {
-      background: var(--bg2);
-      border: 1px solid var(--border);
-      border-radius: 10px;
-      overflow: hidden;
-    }
+    .pr-link { font-weight: 600; color: var(--accent); }
+    .stat-cell { font-size: 12px; white-space: nowrap; color: var(--text2); }
+    .additions { color: var(--green); font-weight: 500; }
+    .deletions { color: var(--red); font-weight: 500; }
 
     /* ── Findings ── */
-    .findings-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: 16px; }
+    .findings-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+      gap: 12px;
+    }
     .finding-group {
       background: var(--bg2);
       border: 1px solid var(--border);
-      border-radius: 10px;
+      border-radius: 12px;
       overflow: hidden;
     }
     .finding-focus-title {
-      padding: 10px 14px;
-      font-size: 11px; font-weight: 700; letter-spacing: 0.08em;
+      padding: 11px 16px;
+      font-size: 11px; font-weight: 600; letter-spacing: 0.1em;
       text-transform: uppercase; color: var(--text2);
       border-bottom: 1px solid var(--border);
       background: var(--bg3);
     }
     .finding-item {
-      padding: 8px 14px;
-      font-size: 12px; line-height: 1.5;
+      padding: 10px 16px;
+      font-size: 12px; line-height: 1.55;
+      color: var(--text2);
       border-bottom: 1px solid var(--border);
     }
     .finding-item:last-child { border-bottom: none; }
     .finding-error { border-left: 3px solid var(--red); }
-    .finding-warn { border-left: 3px solid var(--yellow); }
+    .finding-warn  { border-left: 3px solid var(--yellow); }
+    .finding-pr-ref {
+      color: var(--text3);
+      font-size: 11px;
+      margin-left: 6px;
+    }
     .empty-state {
-      padding: 32px;
+      padding: 40px;
       text-align: center;
       color: var(--green);
-      font-size: 15px;
+      font-size: 14px;
+      font-weight: 500;
       background: var(--bg2);
       border: 1px solid var(--border);
-      border-radius: 10px;
+      border-radius: 12px;
     }
+
+    /* ── Sparklines ── */
+    .sparkline { display: block; }
+    .sparkline-lg { display: block; }
+    .sparkline-empty { font-size: 11px; }
+    .sparkline-wrap { line-height: 0; flex-shrink: 0; }
+    .focus-card-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .health-spark-row {
+      margin-top: 6px;
+      line-height: 0;
+    }
+
+    /* ── Milestones ── */
+    .milestones-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 12px;
+    }
+    .milestone-card {
+      background: var(--bg2);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 16px 18px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .milestone-card.milestone-ok    { border-left: 3px solid var(--green); }
+    .milestone-card.milestone-warn  { border-left: 3px solid var(--yellow); }
+    .milestone-card.milestone-bad   { border-left: 3px solid var(--red); }
+    .milestone-card.milestone-muted { border-left: 3px solid var(--text3); }
+    .milestone-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+    .milestone-label {
+      font-size: 13px; font-weight: 600;
+      letter-spacing: -0.01em;
+    }
+    .milestone-status {
+      font-size: 11px;
+      color: var(--text3);
+      letter-spacing: 0.01em;
+      white-space: nowrap;
+    }
+    .milestone-ok    .milestone-status { color: var(--green); }
+    .milestone-warn  .milestone-status { color: var(--yellow); }
+    .milestone-bad   .milestone-status { color: var(--red); }
+    .milestone-value {
+      font-size: 12px;
+      color: var(--text2);
+    }
+    .milestone-bar {
+      height: 6px;
+      background: var(--bg3);
+      border-radius: 3px;
+      overflow: hidden;
+    }
+    .milestone-bar-fill {
+      height: 100%;
+      transition: width 200ms ease;
+    }
+    .milestone-spark { line-height: 0; }
+    .milestone-meta { font-size: 11px; }
 
     /* ── Pending queue ── */
     .pending-box {
       background: var(--bg2);
       border: 1px solid var(--border);
-      border-radius: 10px;
-      padding: 16px;
+      border-radius: 12px;
+      padding: 8px 16px;
     }
     .pending-item {
-      padding: 6px 0;
+      padding: 10px 0;
       font-size: 13px;
+      color: var(--text2);
       border-bottom: 1px solid var(--border);
     }
     .pending-item:last-child { border-bottom: none; }
+    .pending-box .muted { padding: 8px 0; display: inline-block; }
   </style>
 </head>
 <body>
 
 <div class="header">
   <div class="header-left">
-    <div class="header-logo">⬡ Dome</div>
+    <div class="header-mark">⬡</div>
     <div>
-      <div style="font-weight:600">Audit Dashboard</div>
+      <div class="header-title">Dome Audit</div>
       <div class="header-sub">Automated code health monitoring</div>
     </div>
   </div>
   <div class="header-meta">
-    <div>Generated: <strong>${GENERATED_AT}</strong></div>
-    <div>Repo: <a href="https://github.com/${REPO_SLUG}" target="_blank">${REPO_SLUG}</a></div>
-    <div class="refresh-note muted">Auto-refreshes every 5 min</div>
+    <div>Generated <strong>${GENERATED_AT}</strong></div>
+    <div><a href="https://github.com/${REPO_SLUG}" target="_blank">${REPO_SLUG}</a></div>
+    <div class="refresh-note">Auto-refresh every 5 min</div>
   </div>
 </div>
 
@@ -567,6 +1058,7 @@ cat > "$OUTPUT_FILE" << HTML
           <div class="label">Code Health Score</div>
           <div class="value" style="color:${HEALTH_COLOR}">${HEALTH_LABEL}</div>
           <div class="sub">${TOTAL_FINDINGS} open findings</div>
+          <div class="health-spark-row">${HEALTH_SPARKLINE_SVG}</div>
         </div>
       </div>
 
@@ -609,6 +1101,14 @@ cat > "$OUTPUT_FILE" << HTML
     </div>
   </div>
 
+  <!-- Milestones -->
+  <div class="section">
+    <div class="section-title">Milestones</div>
+    <div class="milestones-grid">
+${MILESTONES_HTML}
+    </div>
+  </div>
+
   <!-- Focus status -->
   <div class="section">
     <div class="section-title">Audit Foci</div>
@@ -619,7 +1119,7 @@ ${FOCUS_CARDS_HTML}
 
   <!-- Open findings -->
   <div class="section">
-    <div class="section-title">Open Findings (${TOTAL_FINDINGS} total)</div>
+    <div class="section-title">Open Findings<span class="count">${TOTAL_FINDINGS} total</span></div>
     <div class="findings-grid">
 ${OPEN_FINDINGS_HTML}
     </div>

--- a/scripts/vps-audit-findings-cron.sh
+++ b/scripts/vps-audit-findings-cron.sh
@@ -11,15 +11,17 @@
 
 PENDING_DIR="/var/log/dome-audit-findings/pending"
 FINDINGS_SCRIPT="/opt/dome-audit/vps-audit-findings.sh"
+RESOLVE_SCRIPT="/opt/dome-audit/vps-audit-resolve.sh"
 LOG_PREFIX="[dome-findings $(date '+%Y-%m-%d %H:%M')]"
 
 [ -d "$PENDING_DIR" ] || exit 0
 [ -f "$FINDINGS_SCRIPT" ] || exit 0
 
+PROCESSED=0
 for pending in "$PENDING_DIR"/*.pending; do
   [ -f "$pending" ] || continue
 
-  read -r FOCUS PR_NUMBER REPO_SLUG < "$pending"
+  read -r FOCUS PR_NUMBER REPO_SLUG PROMPT_VERSION < "$pending"
   [ -z "$PR_NUMBER" ] && { rm -f "$pending"; continue; }
 
   # Check if AI review has been posted yet
@@ -31,8 +33,18 @@ for pending in "$PENDING_DIR"/*.pending; do
     continue
   fi
 
-  echo "$LOG_PREFIX PR #${PR_NUMBER} (${FOCUS}): extracting findings..."
-  bash "$FINDINGS_SCRIPT" "$FOCUS" "$PR_NUMBER" "$REPO_SLUG"
+  echo "$LOG_PREFIX PR #${PR_NUMBER} (${FOCUS}): extracting findings (prompt=${PROMPT_VERSION:-unknown})..."
+  bash "$FINDINGS_SCRIPT" "$FOCUS" "$PR_NUMBER" "$REPO_SLUG" "${PROMPT_VERSION:-}"
   rm -f "$pending"
+  PROCESSED=$((PROCESSED + 1))
   echo "$LOG_PREFIX PR #${PR_NUMBER} (${FOCUS}): done"
 done
+
+# After processing any new findings, re-verify the whole set against main
+# so stale findings (already fixed) get marked resolved.
+if [ -f "$RESOLVE_SCRIPT" ]; then
+  if [ "$PROCESSED" -gt 0 ] || [ "${FORCE_RESOLVE:-0}" = "1" ]; then
+    echo "$LOG_PREFIX Running resolution pass..."
+    bash "$RESOLVE_SCRIPT" || echo "$LOG_PREFIX Resolve pass failed (non-fatal)"
+  fi
+fi

--- a/scripts/vps-audit-findings.sh
+++ b/scripts/vps-audit-findings.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 # =============================================================================
-# vps-audit-findings.sh — AI Review Findings Tracker
+# vps-audit-findings.sh — AI Review Findings Tracker (structured)
 #
-# Extrae los ❌ y ⚠️ del AI review de la última PR de cada focus,
-# los guarda en /var/log/dome-audit-findings/ y los inyecta como contexto
-# en la siguiente ejecución del mismo focus.
+# Extrae los ❌ y ⚠️ del AI review de la última PR de cada focus y los guarda
+# como JSON estructurado en /var/log/dome-audit-findings/<focus>.findings.json
+# (con una proyección .findings legacy para compatibilidad).
 #
-# Llamado automáticamente por vps-audit.sh después de crear la PR.
+# Cada finding tiene un id estable <focus>:<file>:<line>:<sha1(pattern)> que
+# permite:
+#   - Upsert entre corridas (no se duplican, se actualiza last_seen_at)
+#   - Transición a status="verifying" cuando ya no aparecen en el último review
+#   - Transición a status="resolved" por vps-audit-resolve.sh al desaparecer
+#     del árbol actual de main
 #
 # Usage:
-#   bash vps-audit-findings.sh <focus> <pr_number> <repo_slug>
-#
-# También útil para inspección manual:
+#   bash vps-audit-findings.sh <focus> <pr_number> [repo_slug] [prompt_version]
 #   bash vps-audit-findings.sh --report
 # =============================================================================
 
@@ -19,6 +22,7 @@ set -euo pipefail
 
 FINDINGS_DIR="${FINDINGS_DIR:-/var/log/dome-audit-findings}"
 REPO_SLUG="${3:-maxprain12/dome}"
+PROMPT_VERSION="${4:-}"
 mkdir -p "$FINDINGS_DIR"
 
 # ── Report mode ───────────────────────────────────────────────────────────────
@@ -29,16 +33,22 @@ if [ "${1:-}" = "--report" ]; then
   echo "═══════════════════════════════════════════════════════"
 
   TOTAL=0
-  for file in "$FINDINGS_DIR"/*.findings; do
+  for file in "$FINDINGS_DIR"/*.findings.json; do
     [ -f "$file" ] || continue
-    FOCUS=$(basename "$file" .findings)
-    COUNT=$(wc -l < "$file" | tr -d ' ')
+    FOCUS=$(basename "$file" .findings.json)
+    COUNT=$(python3 -c "import sys,json; d=json.load(open('$file')); print(sum(1 for f in d if f.get('status')=='open'))" 2>/dev/null || echo 0)
     [ "$COUNT" -eq 0 ] && continue
     TOTAL=$((TOTAL + COUNT))
 
     echo ""
-    echo "── ${FOCUS} (${COUNT} issues) ──────────────────────────"
-    cat "$file"
+    echo "── ${FOCUS} (${COUNT} open) ──────────────────────────"
+    python3 -c "
+import json
+d = json.load(open('$file'))
+for f in d:
+    if f.get('status') == 'open':
+        print(f.get('body', '').strip())
+" 2>/dev/null || true
   done
 
   if [ "$TOTAL" -eq 0 ]; then
@@ -62,24 +72,18 @@ if [ -z "$FOCUS" ] || [ -z "$PR_NUMBER" ]; then
   exit 1
 fi
 
-FINDINGS_FILE="$FINDINGS_DIR/${FOCUS}.findings"
+FINDINGS_JSON="$FINDINGS_DIR/${FOCUS}.findings.json"
+FINDINGS_LEGACY="$FINDINGS_DIR/${FOCUS}.findings"
 PR_LOG="$FINDINGS_DIR/${FOCUS}.history"
 
 echo "[$(date '+%Y-%m-%d %H:%M')] Extracting findings from PR #${PR_NUMBER} (focus: ${FOCUS})" >> "$PR_LOG"
 
 # Fetch AI review body from the PR
 REVIEW_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO_SLUG" --json reviews \
-  --jq '.reviews[0].body // ""' 2>/dev/null)
+  --jq '.reviews[0].body // ""' 2>/dev/null || echo "")
 
-if [ -z "$REVIEW_BODY" ]; then
-  echo "[$(date '+%Y-%m-%d %H:%M')] No AI review found for PR #${PR_NUMBER}" >> "$PR_LOG"
-  # Clear findings if no review (clean PR)
-  > "$FINDINGS_FILE"
-  exit 0
-fi
-
-# Extract ❌ and ⚠️ lines — skip API errors, truncated lines, think artifacts
-NEW_FINDINGS=$(echo "$REVIEW_BODY" \
+# Extract raw finding lines (same regex as before — the parser below needs them)
+NEW_LINES=$(echo "$REVIEW_BODY" \
   | grep -E "^❌|^⚠️" \
   | grep -v "Review failed" \
   | grep -v "API error" \
@@ -92,17 +96,154 @@ NEW_FINDINGS=$(echo "$REVIEW_BODY" \
   | sed 's/<\/think>//' \
   | awk 'length($0) > 20' \
   | sort -u \
-  | head -15)
+  | head -15 || true)
 
-if [ -z "$NEW_FINDINGS" ]; then
-  echo "[$(date '+%Y-%m-%d %H:%M')] No findings (❌/⚠️) in AI review — focus ${FOCUS} is clean" >> "$PR_LOG"
-  > "$FINDINGS_FILE"
-  exit 0
-fi
+# ── Build the new set of findings as JSON ────────────────────────────────────
+# A python parser handles the upsert logic. It reads the current JSON file
+# (or []) and merges the new review lines by stable id. Findings seen in this
+# run are marked status=open; previously-open findings NOT seen are marked
+# status=verifying (candidates for resolution in vps-audit-resolve.sh).
 
-# Save findings (overwrite — latest run wins)
-echo "$NEW_FINDINGS" > "$FINDINGS_FILE"
-COUNT=$(echo "$NEW_FINDINGS" | wc -l | tr -d ' ')
-echo "[$(date '+%Y-%m-%d %H:%M')] Saved ${COUNT} findings for focus ${FOCUS}" >> "$PR_LOG"
-echo "$NEW_FINDINGS" >> "$PR_LOG"
+export FOCUS PR_NUMBER FINDINGS_JSON PROMPT_VERSION
+echo "$NEW_LINES" | python3 - << 'PY'
+import hashlib
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+focus = os.environ["FOCUS"]
+pr_number = int(os.environ["PR_NUMBER"])
+json_path = os.environ["FINDINGS_JSON"]
+prompt_version = os.environ.get("PROMPT_VERSION", "").strip() or None
+now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+raw = sys.stdin.read().strip()
+new_lines = [l for l in raw.splitlines() if l.strip()]
+
+# Load existing
+try:
+    with open(json_path) as f:
+        existing = json.load(f)
+    if not isinstance(existing, list):
+        existing = []
+except (FileNotFoundError, json.JSONDecodeError):
+    existing = []
+
+by_id = {f["id"]: f for f in existing if isinstance(f, dict) and "id" in f}
+
+# File/line extractor. Matches:
+#   ❌ **files.cjs**: ...
+#   ❌ **files.cjs line 41**: ...
+#   ❌ **layout.ts:7,13** - ...
+#   ❌ **NoteWorkspaceClient.tsx:139** - ...
+#   ⚠️  **plugins.cjs & sync.cjs**: ...   (multi-file; take first)
+FILE_RE = re.compile(
+    r"\*\*([A-Za-z0-9_\-./]+\.[A-Za-z]+)"
+    r"(?:\s+line\s+(\d+)|:(\d+)(?:,\d+)?)?"
+    r"(?:\s*&\s*[^*]+)?\*\*"
+)
+PATTERN_RE = re.compile(r"`([^`]+)`")
+
+def parse_line(line):
+    severity = "error" if line.startswith("❌") else "warn"
+    mfile = FILE_RE.search(line)
+    if mfile:
+        file = mfile.group(1)
+        line_no = mfile.group(2) or mfile.group(3) or "0"
+    else:
+        file = "unknown"
+        line_no = "0"
+    # Extract the most specific pattern we can — prefer backticked code snippets.
+    # If absent, leave pattern empty so the resolver won't mis-resolve based on
+    # free-form prose that never matches file contents.
+    mpat = PATTERN_RE.search(line)
+    pattern = mpat.group(1).strip() if mpat else ""
+    # Fingerprint uses pattern if available, else the whole body (stable id)
+    fp_src = pattern if pattern else line
+    h = hashlib.sha1(fp_src.encode("utf-8")).hexdigest()[:8]
+    fid = f"{focus}:{file}:{line_no}:{h}"
+    return {
+        "id": fid,
+        "focus": focus,
+        "file": file,
+        "line": int(line_no) if line_no.isdigit() else 0,
+        "pattern": pattern,
+        "severity": severity,
+        "body": line,
+    }
+
+seen_ids = set()
+for line in new_lines:
+    f = parse_line(line)
+    seen_ids.add(f["id"])
+    if f["id"] in by_id:
+        prev = by_id[f["id"]]
+        prev["last_seen_at"] = now
+        prev["status"] = "open"
+        prev["severity"] = f["severity"]
+        prev["body"] = f["body"]
+        if prompt_version:
+            prev["last_seen_prompt_version"] = prompt_version
+    else:
+        f["first_seen_pr"] = pr_number
+        f["first_seen_at"] = now
+        f["last_seen_at"] = now
+        f["status"] = "open"
+        if prompt_version:
+            f["first_seen_prompt_version"] = prompt_version
+            f["last_seen_prompt_version"] = prompt_version
+        by_id[f["id"]] = f
+
+# Findings not seen this run → verifying (unless already resolved)
+for fid, f in by_id.items():
+    if fid not in seen_ids and f.get("status") == "open":
+        f["status"] = "verifying"
+        f["verifying_since"] = now
+
+# If the review body was totally empty (no lines at all), mark all open as verifying
+if not new_lines:
+    for f in by_id.values():
+        if f.get("status") == "open":
+            f["status"] = "verifying"
+            f["verifying_since"] = now
+
+out = sorted(by_id.values(), key=lambda x: (x.get("status"), x.get("file"), x.get("line")))
+
+with open(json_path, "w") as f:
+    json.dump(out, f, indent=2)
+
+open_count = sum(1 for f in out if f.get("status") == "open")
+verifying_count = sum(1 for f in out if f.get("status") == "verifying")
+print(f"{open_count} {verifying_count} {len(new_lines)}")
+PY
+
+# Parse python output (last line: "<open> <verifying> <new>")
+STATS=$(python3 -c "
+import json
+try:
+    d = json.load(open('$FINDINGS_JSON'))
+    o = sum(1 for f in d if f.get('status') == 'open')
+    v = sum(1 for f in d if f.get('status') == 'verifying')
+    r = sum(1 for f in d if f.get('status') == 'resolved')
+    print(o, v, r)
+except Exception:
+    print('0 0 0')
+")
+read -r OPEN_COUNT VERIFYING_COUNT RESOLVED_COUNT <<< "$STATS"
+
+# Legacy projection — one line per open finding (for older dashboard code)
+python3 -c "
+import json
+try:
+    d = json.load(open('$FINDINGS_JSON'))
+    for f in d:
+        if f.get('status') == 'open':
+            print(f.get('body', '').strip())
+except Exception:
+    pass
+" > "$FINDINGS_LEGACY"
+
+echo "[$(date '+%Y-%m-%d %H:%M')] PR #${PR_NUMBER} (${FOCUS}): ${OPEN_COUNT} open, ${VERIFYING_COUNT} verifying, ${RESOLVED_COUNT} resolved" >> "$PR_LOG"
 echo "---" >> "$PR_LOG"

--- a/scripts/vps-audit-resolve.sh
+++ b/scripts/vps-audit-resolve.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# =============================================================================
+# vps-audit-resolve.sh — Finding Lifecycle Resolver
+#
+# Lee todos los <focus>.findings.json en FINDINGS_DIR y, para cada finding con
+# status ∈ {open, verifying}, comprueba si el pattern aún aparece en el archivo
+# referenciado (rama main del repo local). Si ya no aparece, transiciona a
+# status=resolved. Actualiza last_verified_at y proyecta el .findings legacy.
+#
+# Cron (cada hora):
+#   0 * * * * bash /opt/dome-audit/vps-audit-resolve.sh >> /var/log/dome-audit.log 2>&1
+#
+# También lo invoca vps-audit-findings-cron.sh tras procesar los pending.
+# =============================================================================
+
+set -euo pipefail
+
+FINDINGS_DIR="${FINDINGS_DIR:-/var/log/dome-audit-findings}"
+REPO_DIR="${REPO_DIR:-/opt/dome-audit/dome}"
+RESOLUTIONS_LOG="$FINDINGS_DIR/resolutions.log"
+LOG_PREFIX="[dome-resolve $(date '+%Y-%m-%d %H:%M')]"
+
+mkdir -p "$FINDINGS_DIR"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+  echo "$LOG_PREFIX Repo not found at $REPO_DIR — skipping" >&2
+  exit 0
+fi
+
+# Refresh main so we check against latest merged state
+(cd "$REPO_DIR" && git fetch --quiet origin main 2>/dev/null && git checkout --quiet main 2>/dev/null && git pull --quiet origin main 2>/dev/null) || true
+
+shopt -s nullglob
+FILES=("$FINDINGS_DIR"/*.findings.json)
+if [ ${#FILES[@]} -eq 0 ]; then
+  echo "$LOG_PREFIX No findings JSON files — nothing to resolve"
+  exit 0
+fi
+
+for json_path in "${FILES[@]}"; do
+  [ -f "$json_path" ] || continue
+  FOCUS=$(basename "$json_path" .findings.json)
+  LEGACY_PATH="$FINDINGS_DIR/${FOCUS}.findings"
+
+  export FOCUS REPO_DIR json_path RESOLUTIONS_LOG
+  python3 - << 'PY'
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+
+focus = os.environ["FOCUS"]
+repo = os.environ["REPO_DIR"]
+path = os.environ["json_path"]
+log_path = os.environ["RESOLUTIONS_LOG"]
+now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+try:
+    with open(path) as f:
+        findings = json.load(f)
+except Exception:
+    findings = []
+
+if not isinstance(findings, list):
+    findings = []
+
+transitions = []
+
+def file_contents(relpath):
+    full = os.path.join(repo, relpath)
+    if not os.path.exists(full):
+        return None
+    try:
+        with open(full, encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except Exception:
+        return None
+
+for f in findings:
+    if not isinstance(f, dict):
+        continue
+    status = f.get("status")
+    if status not in ("open", "verifying"):
+        continue
+
+    rel = f.get("file", "")
+    pattern = f.get("pattern", "")
+    if not rel or rel == "unknown" or not pattern:
+        # Cannot verify without file/pattern → leave as verifying, do not resolve
+        if status == "open":
+            f["status"] = "verifying"
+            f["verifying_since"] = now
+        continue
+
+    content = file_contents(rel)
+    if content is None:
+        f["status"] = "resolved"
+        f["resolved_at"] = now
+        f["resolved_reason"] = "file_missing"
+        transitions.append((f["id"], "resolved", "file_missing"))
+        continue
+
+    if pattern in content:
+        if status != "open":
+            transitions.append((f["id"], "open", "pattern_present"))
+        f["status"] = "open"
+        f["last_verified_at"] = now
+    else:
+        f["status"] = "resolved"
+        f["resolved_at"] = now
+        f["resolved_reason"] = "pattern_absent"
+        transitions.append((f["id"], "resolved", "pattern_absent"))
+
+# Keep resolved for audit trail but never let them grow unbounded — cap at 200 per focus
+resolved = [x for x in findings if x.get("status") == "resolved"]
+if len(resolved) > 200:
+    # Keep only the 200 most recently resolved
+    resolved.sort(key=lambda x: x.get("resolved_at", ""), reverse=True)
+    keep_ids = {x["id"] for x in resolved[:200]}
+    findings = [x for x in findings if x.get("status") != "resolved" or x["id"] in keep_ids]
+
+findings.sort(key=lambda x: (x.get("status"), x.get("file"), x.get("line")))
+with open(path, "w") as f:
+    json.dump(findings, f, indent=2)
+
+# Append transitions log
+if transitions:
+    with open(log_path, "a") as logf:
+        for fid, new_status, reason in transitions:
+            logf.write(f"{now}\t{focus}\t{fid}\t→{new_status}\t{reason}\n")
+
+open_count = sum(1 for x in findings if x.get("status") == "open")
+verifying_count = sum(1 for x in findings if x.get("status") == "verifying")
+resolved_count = sum(1 for x in findings if x.get("status") == "resolved")
+print(f"{focus}: {open_count} open, {verifying_count} verifying, {resolved_count} resolved ({len(transitions)} transitions)")
+PY
+
+  # Refresh legacy projection (only open findings)
+  python3 -c "
+import json
+try:
+    d = json.load(open('$json_path'))
+    for f in d:
+        if f.get('status') == 'open':
+            print(f.get('body', '').strip())
+except Exception:
+    pass
+" > "$LEGACY_PATH"
+
+done
+
+echo "$LOG_PREFIX Resolution pass complete"

--- a/scripts/vps-audit.sh
+++ b/scripts/vps-audit.sh
@@ -12,10 +12,18 @@
 #   - Repo cloned at REPO_DIR
 #
 # Usage:
-#   ./scripts/vps-audit.sh [--focus security|types|i18n|debt]
+#   ./scripts/vps-audit.sh <focus>                       # positional (legacy)
+#   ./scripts/vps-audit.sh --focus security              # flag form
+#   ./scripts/vps-audit.sh --focus types --chain-context /tmp/chain-ctx.md
+#   ./scripts/vps-audit.sh --focus types --dry-run       # print prompt + exit
+#
+# Prompts are now sourced from the repo:
+#   prompts/shared/project-context.md  (shared)
+#   prompts/audits/<focus>.md          (focus-specific, with YAML frontmatter)
+#   prompts/audits/_chain-header.md    (chained mode only)
 #
 # Cron (daily at 3am):
-#   0 3 * * * /opt/dome-audit/scripts/vps-audit.sh >> /var/log/dome-audit.log 2>&1
+#   0 3 * * * /opt/dome-audit/scripts/vps-audit.sh --focus all >> /var/log/dome-audit.log 2>&1
 # =============================================================================
 
 set -euo pipefail
@@ -25,12 +33,42 @@ REPO_DIR="${REPO_DIR:-/opt/dome-audit/dome}"
 REPO_URL="${REPO_URL:-https://github.com/maxprain12/dome.git}"
 REPO_SLUG=$(echo "$REPO_URL" | sed 's|https://github.com/||; s|\.git$||')
 BRANCH_PREFIX="audit"
-FOCUS="${1:-all}"  # security | types | i18n | debt | all
 TIMESTAMP=$(date +%Y%m%d-%H%M)
-BRANCH="${BRANCH_PREFIX}/${FOCUS}-${TIMESTAMP}"
 LOG_PREFIX="[dome-audit $(date '+%Y-%m-%d %H:%M')]"
 
-echo "$LOG_PREFIX Starting audit (focus: $FOCUS)"
+# ── Parse args ────────────────────────────────────────────────────────────────
+FOCUS=""
+CHAIN_CONTEXT_FILE=""
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --focus)
+      FOCUS="$2"
+      shift 2
+      ;;
+    --chain-context)
+      CHAIN_CONTEXT_FILE="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,22p' "$0"
+      exit 0
+      ;;
+    *)
+      # First bare positional is focus (backwards compat with `./vps-audit.sh security`)
+      if [ -z "$FOCUS" ]; then FOCUS="$1"; fi
+      shift
+      ;;
+  esac
+done
+FOCUS="${FOCUS:-all}"
+BRANCH="${BRANCH_PREFIX}/${FOCUS}-${TIMESTAMP}"
+
+echo "$LOG_PREFIX Starting audit (focus: $FOCUS${CHAIN_CONTEXT_FILE:+, chained})"
 
 # ── Ensure repo is up to date ─────────────────────────────────────────────────
 if [ ! -d "$REPO_DIR/.git" ]; then
@@ -56,227 +94,76 @@ if [ -f "$FINDINGS_FILE" ] && [ -s "$FINDINGS_FILE" ]; then
   echo "$LOG_PREFIX Loaded $(wc -l < "$FINDINGS_FILE" | tr -d ' ') unresolved findings from previous run"
 fi
 
-# ── Build the audit prompt ────────────────────────────────────────────────────
+# ── Build the audit prompt (from prompts/ on disk) ────────────────────────────
+PROMPTS_DIR="${PROMPTS_DIR:-$REPO_DIR/prompts}"
+SHARED_PROMPT="$PROMPTS_DIR/shared/project-context.md"
+FOCUS_PROMPT="$PROMPTS_DIR/audits/${FOCUS}.md"
+CHAIN_HEADER_PROMPT="$PROMPTS_DIR/audits/_chain-header.md"
+
+# Fall back to 'all' if the focus file is missing (e.g. new focus flag before prompt is added)
+if [ ! -f "$FOCUS_PROMPT" ]; then
+  echo "$LOG_PREFIX ⚠️  Prompt file not found: $FOCUS_PROMPT — falling back to all.md"
+  FOCUS_PROMPT="$PROMPTS_DIR/audits/all.md"
+fi
+
+if [ ! -f "$SHARED_PROMPT" ] || [ ! -f "$FOCUS_PROMPT" ]; then
+  echo "$LOG_PREFIX ❌ Required prompt files missing. Expected $SHARED_PROMPT and $FOCUS_PROMPT"
+  exit 1
+fi
+
+# Strip YAML frontmatter (everything between the first two `---` lines)
+strip_frontmatter() {
+  awk 'BEGIN{c=0} /^---$/{c++; next} c>=2{print} c<2 && !/^---$/ && !/^(name|description|version|focus|pass|last_updated):/{next}' "$1"
+}
+
+# Read 'version:' value from frontmatter
+read_prompt_version() {
+  awk '/^---$/{c++; if(c==2) exit} c==1 && /^version:/{sub(/^version:[[:space:]]*/, ""); print; exit}' "$1"
+}
+
+FOCUS_PROMPT_VERSION=$(read_prompt_version "$FOCUS_PROMPT")
+SHARED_PROMPT_VERSION=$(read_prompt_version "$SHARED_PROMPT")
+PROMPT_VERSION_TAG="shared@${SHARED_PROMPT_VERSION:-0}+${FOCUS}@${FOCUS_PROMPT_VERSION:-0}"
+echo "$LOG_PREFIX Prompt versions: $PROMPT_VERSION_TAG"
+
+CHAIN_CONTEXT_BODY=""
+if [ -n "$CHAIN_CONTEXT_FILE" ] && [ -f "$CHAIN_CONTEXT_FILE" ]; then
+  CHAIN_CONTEXT_BODY=$(cat "$CHAIN_CONTEXT_FILE")
+fi
+
 PROMPT_FILE=$(mktemp /tmp/audit-prompt-XXXXXX.md)
-cat > "$PROMPT_FILE" << PROMPT
-You are performing a periodic code audit of Dome, an Electron + React desktop app.
 
-Read AGENTS.md first to understand the codebase architecture.
-
-## Project-specific context (read before auditing)
-
-### Valid CSS variables (defined in app/globals.css)
-The following CSS custom properties ARE defined and valid. NEVER flag them as "unknown", "undocumented",
-or "should be replaced". They are real variables used throughout the codebase:
-
-Text colors:
-  --primary-text, --secondary-text, --tertiary-text
-  --dome-text (→ --primary-text), --dome-text-secondary (→ --secondary-text), --dome-text-muted (→ --tertiary-text)
-  --base-text  ← text on accent-colored buttons (#FFFFFF light / #121212 dark — intentionally hardcoded in globals.css)
-
-Backgrounds:
-  --bg, --bg-secondary, --bg-tertiary, --bg-hover
-  --dome-bg (→ --bg), --dome-bg-hover (→ --bg-hover), --dome-accent-bg (translucent accent)
-
-Interactive:
-  --accent, --accent-hover
-  --dome-accent (→ --accent), --dome-accent-hover (→ --accent-hover)
-
-Semantic:
-  --error, --warning, --success
-  --dome-error (→ --error)
-
-Borders:
-  --border, --border-hover, --dome-border (→ --border)
-
-Only flag LITERAL hex values (e.g. color: '#ef4444') that appear in style= attributes or TSX WITHOUT
-being wrapped in a CSS var(). Fallback values inside var(--x, fallback) are acceptable.
-
-### Stack clarification
-- Runtime: Bun for dev/build; Electron uses Node.js (better-sqlite3, NOT bun:sqlite)
-- Frontend: Vite + React 18 (NOT Next.js — ignore any Next.js references in style guides)
-- Routes: React Router v7 (client-side SPA), entry: app/main.tsx
-- i18n: react-i18next, all translations inline in app/lib/i18n.ts (en/es/fr/pt), default language: es
-- verbatimModuleSyntax: true → ALL type-only imports MUST use \`import type { }\`
-
-$(if [ -n "$PREVIOUS_FINDINGS" ]; then
-  echo "## Unresolved findings from the previous audit run"
-  echo "The AI reviewer flagged these issues in the last PR for this focus."
-  echo "Address these FIRST before looking for new issues:"
+{
+  echo "You are performing a periodic code audit of Dome, an Electron + React desktop app."
   echo ""
-  echo "$PREVIOUS_FINDINGS"
+  echo "Read AGENTS.md first to understand the codebase architecture."
   echo ""
-fi)
+  echo "Prompt bundle: $PROMPT_VERSION_TAG"
+  echo ""
+  strip_frontmatter "$SHARED_PROMPT"
+  echo ""
 
-$(case "$FOCUS" in
-  security)
-    echo "## Focus: Security Audit
-Audit the codebase for security issues:
-1. IPC handlers in electron/ipc/ that don't validate sender or sanitize inputs
-2. SQL injection risks (string concatenation in queries instead of prepared statements)
-3. Path traversal vulnerabilities (user-provided paths used without sanitizePath())
-4. Hardcoded secrets, API keys, or credentials in source files
-5. electron/preload.cjs exposing APIs that shouldn't be exposed to renderer
-6. Missing input validation on IPC channels
+  if [ -n "$PREVIOUS_FINDINGS" ]; then
+    echo "## Unresolved findings from the previous audit run"
+    echo ""
+    echo "The AI reviewer flagged these issues in the last PR for this focus."
+    echo "Address these FIRST before looking for new issues:"
+    echo ""
+    echo "$PREVIOUS_FINDINGS"
+    echo ""
+  fi
 
-CRITICAL path traversal rules:
-- ALWAYS use sanitizePath(filePath, true) — never use .replace(/\.\.\//g, '')
-- The replace() approach is bypassable with ....// and does not handle Windows paths
-- After sanitization, always validate containment with:
-    const resolved = path.resolve(baseDir, userInput);
-    if (!resolved.startsWith(path.resolve(baseDir) + path.sep)) throw new Error('Path traversal');
-- Check BOTH source and destination paths in copy/move operations
+  if [ -n "$CHAIN_CONTEXT_BODY" ] && [ -f "$CHAIN_HEADER_PROMPT" ]; then
+    # Interpolate ${CHAIN_CONTEXT} into the chain header template
+    CHAIN_HEADER_BODY=$(strip_frontmatter "$CHAIN_HEADER_PROMPT")
+    printf '%s\n' "${CHAIN_HEADER_BODY//\$\{CHAIN_CONTEXT\}/$CHAIN_CONTEXT_BODY}"
+    echo ""
+  fi
 
-For each issue found: create a fix. If the fix is straightforward, implement it.
-If the fix is complex, create a TODO comment with the specific issue described."
-    ;;
-  types)
-    echo "## Focus: TypeScript Quality
-Audit the codebase for TypeScript issues:
-1. Files using 'any' type where a proper type can be inferred
-2. Missing 'import type' for type-only imports (verbatimModuleSyntax is ON)
-3. Non-null assertions (!) that could be replaced with proper null checks
-4. Inconsistent return types on functions
-5. Missing types on exported functions/components
+  strip_frontmatter "$FOCUS_PROMPT"
+  echo ""
 
-Scan ALL of: app/lib/, app/components/, electron/ipc/.
-Fix what you can. Focus on files with the most 'any' types first.
-Run: grep -rn ': any' app/ --include='*.ts' --include='*.tsx' | wc -l
-to see the total count before and after."
-    ;;
-  i18n)
-    echo "## Focus: i18n Completeness
-Audit the codebase for i18n issues:
-1. User-visible strings hardcoded in components instead of using t()
-2. Translation keys that exist in 'en' but are missing in 'es', 'fr', or 'pt' in app/lib/i18n.ts
-3. Components that import useTranslation but don't use t() for user-facing strings
-
-Fix all missing translation keys in app/lib/i18n.ts.
-For hardcoded strings: wrap them with t() and add the key to all 4 languages.
-
-IMPORTANT rules for i18n.ts edits:
-- Do NOT reformat, reindent, or reorder existing keys — only add/change values
-- The default language is Spanish (es) — Spanish strings should be natural, not machine-translated
-- French (fr) and Portuguese (pt) translations should be grammatically correct
-- Use the same key nesting structure as existing keys for consistency
-- Never add a key in one language without adding it in all 4 (en/es/fr/pt)"
-    ;;
-  debt)
-    echo "## Focus: Technical Debt
-Audit the codebase for technical debt:
-1. Dead code: exported functions/components that are never imported anywhere
-2. Duplicate logic: same pattern repeated 3+ times that could be extracted to a shared util
-3. Hardcoded colors: literal hex values (e.g. color: '#ef4444') in style= attributes that should use CSS variables
-4. Console.log statements left in production code (console.error/warn are fine)
-5. TODO/FIXME comments older than 30 days
-
-IMPORTANT for color fixes:
-- Replace hardcoded hex values with the CSS variables listed in the 'Valid CSS variables' section above
-- Do NOT replace CSS variable usages — they are already correct
-- Mapping guide:
-    '#ef4444' or red-ish errors → var(--dome-error) or var(--error)
-    '#ffffff' or '#fff' on buttons → var(--base-text)
-    '#0ea5e9' or blue → var(--accent)
-    '#111827' or dark text → var(--primary-text)
-    '#6b7280' or medium text → var(--secondary-text)
-    '#9ca3af' or muted text → var(--tertiary-text)
-    '#f9fafb' or light bg → var(--bg-secondary)
-    '#f3f4f6' → var(--bg-tertiary)
-    '#e5e7eb' borders → var(--border)
-
-There are currently ~468 hardcoded hex colors and ~233 console.logs in the codebase.
-Focus on the files with the most occurrences first.
-Fix the hardcoded colors and console.logs. Flag the rest with a TODO comment."
-    ;;
-  vulns)
-    echo "## Focus: Dependency Vulnerabilities
-Audit npm dependencies for security vulnerabilities and outdated packages.
-
-Step 1 — Run npm audit and read the output:
-  npm audit --json
-
-Step 2 — For each HIGH or CRITICAL vulnerability:
-  - Read the advisory to understand the attack vector
-  - Check if Dome actually uses the vulnerable code path
-  - If a safe fix exists (npm audit fix --dry-run shows it): apply it
-  - If it requires a major version bump: add a TODO comment in package.json with the issue
-
-Step 3 — Check for packages with known safer alternatives:
-  - Any 'request' package → should be 'node-fetch' or native fetch
-  - Any 'node-uuid' → should be 'crypto.randomUUID()'
-
-IMPORTANT:
-- Run 'npm install --ignore-scripts' after any package.json change
-- Do NOT bump major versions of electron, better-sqlite3, or @langchain/* — these have breaking changes
-- Do NOT run 'npm audit fix --force' — apply fixes selectively"
-    ;;
-  react)
-    echo "## Focus: React Patterns & Performance
-Audit the codebase for React anti-patterns that cause bugs and performance issues.
-
-1. useEffect with addEventListener/setTimeout/setInterval that has NO cleanup return:
-   Bad:  useEffect(() => { window.addEventListener('x', fn) }, [])
-   Good: useEffect(() => { window.addEventListener('x', fn); return () => window.removeEventListener('x', fn) }, [])
-
-2. Direct state mutations in Zustand stores or React state:
-   Bad:  state.items.push(item)
-   Good: set(s => ({ items: [...s.items, item] }))
-
-3. useEffect with missing dependency array (runs on every render):
-   Bad:  useEffect(() => { fetchData() })
-   Good: useEffect(() => { fetchData() }, [id])
-
-4. Components that re-render unnecessarily because they receive new object/array literals as props:
-   Bad:  <Component options={{ key: val }} />
-   Good: const options = useMemo(() => ({ key: val }), [val]); <Component options={options} />
-
-5. Large components over 400 lines that mix data fetching + business logic + rendering.
-   These are the biggest ones — split them if the split is clean:
-   $(find app/components -name '*.tsx' -exec wc -l {} \; 2>/dev/null | awk '$1 > 400 {print "   " $1 " lines: " $2}' | sort -rn | head -8)
-
-Fix the useEffect cleanup issues first (they cause memory leaks).
-For large components: only split if you can identify a clear sub-component boundary.
-Do NOT refactor working logic just to reduce line count."
-    ;;
-  errors)
-    echo "## Focus: Error Handling & Resilience
-Audit the codebase for missing error handling that causes silent failures or crashes.
-
-1. React Error Boundaries — there are currently ZERO in the codebase.
-   Add an ErrorBoundary component at app/components/ErrorBoundary.tsx:
-   - Wrap each major tab/view in AppShell with it
-   - Show a friendly fallback UI instead of crashing the whole app
-   - Log the error to console.error (and PostHog if available)
-
-2. IPC handlers that throw instead of returning { success: false, error }:
-   Bad:  ipcMain.handle('x', () => { throw new Error('...') })
-   Good: ipcMain.handle('x', () => { try {...} catch(e) { return { success: false, error: e.message } } })
-   Scan electron/ipc/*.cjs for handlers missing try/catch.
-
-3. window.electron.invoke() calls in the renderer with no .catch() or try/catch:
-   Bad:  const result = await window.electron.invoke('x', data)
-   Good: const result = await window.electron.invoke('x', data).catch(e => ({ success: false, error: e.message }))
-
-4. Zustand store actions that call IPC without error handling — the store should never crash
-   silently; log errors and optionally show a toast.
-
-Priority: ErrorBoundary first (highest impact), then IPC try/catch, then renderer catch."
-    ;;
-  *)
-    echo "## Focus: Full Audit (all areas)
-Perform a comprehensive audit covering:
-1. Security: IPC validation, SQL injection, path traversal
-2. TypeScript: 'any' types, missing import type, null safety
-3. i18n: missing translations in app/lib/i18n.ts
-4. Code quality: hardcoded colors, dead code, console.logs
-5. React: useEffect cleanup, direct state mutations
-6. Errors: missing Error Boundaries, IPC try/catch
-
-Prioritize by severity: Security > Errors > TypeScript > React > Code quality > i18n.
-Fix the top 5-10 most impactful issues. Do not try to fix everything at once."
-    ;;
-esac)
-
+  cat << 'RULES'
 ## Rules
 - Follow AGENTS.md exactly: process separation, IPC pattern, CSS variables, i18n
 - Only fix real issues. Do not refactor working code just to change style.
@@ -292,7 +179,17 @@ After making fixes, run:
   npm run build
 
 If all pass, your work is complete. The CI pipeline will validate everything.
-PROMPT
+RULES
+} > "$PROMPT_FILE"
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "$LOG_PREFIX --dry-run: assembled prompt below"
+  echo "========================================"
+  cat "$PROMPT_FILE"
+  echo "========================================"
+  rm -f "$PROMPT_FILE"
+  exit 0
+fi
 
 echo "$LOG_PREFIX Running OpenCode audit..."
 
@@ -427,6 +324,8 @@ Automated periodic audit by OpenCode + MiniMax.
 
 **Focus:** ${FOCUS}
 **Generated:** ${TIMESTAMP}
+**Prompt bundle:** \`${PROMPT_VERSION_TAG}\`${CHAIN_CONTEXT_FILE:+
+**Chain context:** yes (upstream findings fed in)}
 **Changed files:**
 ${CHANGED_FILES}
 
@@ -461,5 +360,5 @@ echo "$LOG_PREFIX PR URL: https://github.com/${REPO_SLUG}/pull/${PR_NUMBER}"
 # Write a pending findings job — picked up by vps-audit-findings-cron.sh
 PENDING_DIR="/var/log/dome-audit-findings/pending"
 mkdir -p "$PENDING_DIR"
-echo "${FOCUS} ${PR_NUMBER} ${REPO_SLUG}" > "${PENDING_DIR}/${FOCUS}-${PR_NUMBER}.pending"
+echo "${FOCUS} ${PR_NUMBER} ${REPO_SLUG} ${PROMPT_VERSION_TAG}" > "${PENDING_DIR}/${FOCUS}-${PR_NUMBER}.pending"
 echo "$LOG_PREFIX Findings job queued for PR #${PR_NUMBER} (will run within 30 min)"


### PR DESCRIPTION
## Summary

Upgrades the two agent pipelines (AI review on every PR + VPS audit cron) so they are tunable, traceable, and no longer lose coverage on large PRs. Adds milestone tracking to the dashboard.

- **Externalized prompts** — all prompts live in `prompts/` with YAML frontmatter (`version:`). PR bodies now carry a `Prompt bundle` tag (e.g. `shared@1+security@2`), and each finding persists the prompt version that produced it.
- **Line-level AI review** — `scripts/ai-review.mjs` splits the diff per file (no more 40KB truncation), runs 3 passes in parallel, parses strict JSON findings, and posts a GitHub review with `comments[]` anchored to `path + line`.
- **Audit chain orchestrator** — new `scripts/vps-audit-chain.sh security,errors,types` feeds each focus the top open findings of its predecessors via `--chain-context`.
- **Milestones + trends** — new `scripts/audit-milestones.json` (per-focus goals + global health-score target), new `history.jsonl` snapshot file, new Milestones section in the dashboard with progress bars / deadlines / status (on-track / at-risk / overdue) and inline SVG sparklines (per-focus + global).
- **Tool use hints** — audit prompts now tell the agent to run `bun tsc --noEmit` / `grep` before proposing fixes, so findings are verified against live code.
- **Docs** — `docs/vps-audit-setup.md` +3 sections (prompt tree, chain script, milestones + history retention); `AGENTS.md` +section on editing prompts and the frontmatter versioning rule.

## Files

- 13 new prompt files under `prompts/{shared,audits,review}/`
- `scripts/ai-review.mjs` — full rewrite
- `scripts/vps-audit.sh` — flag-based args, loads prompts from disk, stamps prompt version on PR + pending job
- `scripts/vps-audit-findings.sh` — new `prompt_version` param, persisted on each finding
- `scripts/vps-audit-findings-cron.sh` — forwards the 4th field to findings.sh
- `scripts/vps-audit-dashboard.sh` — Milestones section, sparklines, history.jsonl
- `scripts/vps-audit-chain.sh` (new)
- `scripts/audit-milestones.json` (new)
- `scripts/vps-audit-resolve.sh` (pre-existing local file, tracked now that docs reference it)

## Test plan

- [x] `bash -n` on every modified shell script passes
- [x] `node --check scripts/ai-review.mjs` passes
- [x] `AI_REVIEW_DRY_RUN=1` against a synthetic diff produces a review body with 3 line-anchored comments
- [x] Milestone + sparkline python logic validated against a seeded `history.jsonl` fixture
- [x] Chain context builder validated with a fake `security.findings.json` fixture
- [ ] Deploy to VPS and confirm dashboard renders the Milestones section (see `docs/vps-audit-setup.md` §12 for deploy cmd)
- [ ] Watch one real PR cycle: AI review posts line-level comments; next audit PR body shows `Prompt bundle:` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)