### PR TITLE
fix(audit): read line-level AI review comments + fix stdin heredoc bug

### DIFF
--- a/scripts/vps-audit-findings.sh
+++ b/scripts/vps-audit-findings.sh
@@ -78,12 +78,27 @@ PR_LOG="$FINDINGS_DIR/${FOCUS}.history"
 
 echo "[$(date '+%Y-%m-%d %H:%M')] Extracting findings from PR #${PR_NUMBER} (focus: ${FOCUS})" >> "$PR_LOG"
 
-# Fetch AI review body from the PR
+# Fetch AI review body from the PR (legacy format — ai-review.mjs pre-v2
+# inlined findings in the body; the new version leaves only a summary table
+# there and puts findings as line-level comments on the diff).
 REVIEW_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO_SLUG" --json reviews \
-  --jq '.reviews[0].body // ""' 2>/dev/null || echo "")
+  --jq '[.reviews[].body] | join("\n") // ""' 2>/dev/null || echo "")
 
-# Extract raw finding lines (same regex as before — the parser below needs them)
-NEW_LINES=$(echo "$REVIEW_BODY" \
+# Fetch line-level comments from the PR and reformat each into the same
+# `❌/⚠️ **path:line** - body` shape the parser below already understands.
+# This is how ai-review.mjs (v2+) publishes findings.
+LINE_COMMENT_LINES=$(gh api "repos/${REPO_SLUG}/pulls/${PR_NUMBER}/comments" --paginate \
+  --jq '
+    .[]
+    | select(.body | test("^(❌|⚠️)"))
+    | (.body | split("\n")[0]) as $first
+    | ($first | sub("^(❌|⚠️)\\s*"; "")) as $rest
+    | (if ($first | test("^❌")) then "❌" else "⚠️" end) as $sev
+    | $sev + " **" + .path + ":" + ((.line // .original_line // 0) | tostring) + "** - " + $rest
+  ' 2>/dev/null || echo "")
+
+# Merge body + line comments, then filter noise.
+NEW_LINES=$(printf '%s\n%s\n' "$REVIEW_BODY" "$LINE_COMMENT_LINES" \
   | grep -E "^❌|^⚠️" \
   | grep -v "Review failed" \
   | grep -v "API error" \
@@ -96,7 +111,7 @@ NEW_LINES=$(echo "$REVIEW_BODY" \
   | sed 's/<\/think>//' \
   | awk 'length($0) > 20' \
   | sort -u \
-  | head -15 || true)
+  | head -30 || true)
 
 # ── Build the new set of findings as JSON ────────────────────────────────────
 # A python parser handles the upsert logic. It reads the current JSON file
@@ -104,8 +119,10 @@ NEW_LINES=$(echo "$REVIEW_BODY" \
 # run are marked status=open; previously-open findings NOT seen are marked
 # status=verifying (candidates for resolution in vps-audit-resolve.sh).
 
-export FOCUS PR_NUMBER FINDINGS_JSON PROMPT_VERSION
-echo "$NEW_LINES" | python3 - << 'PY'
+NEW_LINES_FILE=$(mktemp /tmp/findings-lines-XXXXXX.txt)
+printf '%s\n' "$NEW_LINES" > "$NEW_LINES_FILE"
+export FOCUS PR_NUMBER FINDINGS_JSON PROMPT_VERSION NEW_LINES_FILE
+python3 <<'PY'
 import hashlib
 import json
 import os
@@ -119,7 +136,8 @@ json_path = os.environ["FINDINGS_JSON"]
 prompt_version = os.environ.get("PROMPT_VERSION", "").strip() or None
 now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
-raw = sys.stdin.read().strip()
+with open(os.environ["NEW_LINES_FILE"]) as _f:
+    raw = _f.read().strip()
 new_lines = [l for l in raw.splitlines() if l.strip()]
 
 # Load existing
@@ -218,6 +236,7 @@ open_count = sum(1 for f in out if f.get("status") == "open")
 verifying_count = sum(1 for f in out if f.get("status") == "verifying")
 print(f"{open_count} {verifying_count} {len(new_lines)}")
 PY
+rm -f "$NEW_LINES_FILE"
 
 # Parse python output (last line: "<open> <verifying> <new>")
 STATS=$(python3 -c "


### PR DESCRIPTION
## Summary
Two pre-existing bugs prevented the findings tracker from ever extracting anything from AI reviewer output.

- **Bug A (post-upgrade regression):** `ai-review.mjs` v2 publishes findings as line-level diff comments (`/pulls/:n/comments`) — the review body holds only a summary table. The extractor was only reading `.reviews[0].body`, so every line-level finding was silently lost.
- **Bug B (latent since day 1):** `echo "\$NEW_LINES" | python3 - <<'PY'` has the heredoc override the pipe, so `sys.stdin.read()` returned `""`. The python parser always saw zero lines regardless of what the AI review contained.

## Fix
- Fetch `/pulls/:n/comments` via `gh api --paginate`, reshape each ❌/⚠️ entry into `sev **path:line** - body` (matches existing regex).
- Write `\$NEW_LINES` to a tmp file and pass the path via `NEW_LINES_FILE` env var — python reads it directly instead of depending on stdin.

## Verification
- Backfill over the last ~35 merged audit PRs populated all `*.findings.json` correctly.
- Resolver trimmed stale findings against `main`; **3 legitimate open findings remain** (`debt`: contrast issues in `app/components/chat/ArtifactCard.tsx`).
- Dashboard renders updated health score + sparklines.
- Next audit run will receive these as `Unresolved findings from the previous audit run`.

## Test plan
- [x] Re-run extractor against PR #57 (errors): captured 3 line-level comments ✓
- [x] Resolve pass against main: transitioned 9 findings to `resolved` ✓
- [x] Dashboard regeneration: 3 open, health=85 ✓
- [ ] Next scheduled audit injects `debt` findings into prompt (will verify at 16:00 UTC run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)