### PR TITLE
chore(ai-review): load shared project-context into every pass

### DIFF
--- a/scripts/ai-review.mjs
+++ b/scripts/ai-review.mjs
@@ -7,6 +7,8 @@
  * comments anchored to the diff.
  *
  * Prompts live in `prompts/review/*.md` (externalized — previously inline).
+ * Shared project context (`prompts/shared/project-context.md`) is prepended to
+ * every pass's system prompt so severity/quality rules apply to PR reviews too.
  * Diffs are split by file so large PRs are fully covered (no 40KB truncation).
  * Model replies are strict JSON (`{ findings: [...] }`); fallbacks are robust.
  *
@@ -216,6 +218,18 @@ function loadPrompt(name) {
   }
 }
 
+function loadSharedContext() {
+  const path = join(REPO_ROOT, 'prompts', 'shared', 'project-context.md');
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const version = readFrontmatterField(raw, 'version') || '0';
+    const body = stripFrontmatter(raw);
+    return { body, version, source: path };
+  } catch {
+    return { body: '', version: 'missing', source: 'none' };
+  }
+}
+
 // ── AI call with retry/timeout ────────────────────────────────────────────────
 
 async function callAI(systemPrompt, userContent, { wantJson = true } = {}) {
@@ -315,8 +329,12 @@ const PASSES = [
 ];
 
 async function main() {
+  const sharedContext = loadSharedContext();
   const prompts = Object.fromEntries(PASSES.map((p) => [p.key, loadPrompt(p.key)]));
-  const promptVersions = PASSES.map((p) => `${p.key}@${prompts[p.key].version}`).join(', ');
+  const promptVersions = [
+    `shared@${sharedContext.version}`,
+    ...PASSES.map((p) => `${p.key}@${prompts[p.key].version}`),
+  ].join(', ');
 
   const allFiles = splitDiffByFile(diff);
   const reviewedFiles = [];
@@ -346,8 +364,11 @@ async function main() {
   const taskFn = async ({ file, pass }) => {
     if (DRY_RUN) return { pass: pass.key, file: file.path, findings: [{ file: file.path, line: [...file.newLineSet][0] || 1, severity: 'warn', comment: `[dry-run fake finding from ${pass.key} pass]` }] };
     const userContent = `Review this file's diff chunk.\n\nFile: ${file.path}\n\n\`\`\`diff\n${file.diff}\n\`\`\``;
+    const systemPrompt = sharedContext.body
+      ? `${sharedContext.body}\n\n---\n\n${prompts[pass.key].body}`
+      : prompts[pass.key].body;
     try {
-      const raw = await callAI(prompts[pass.key].body, userContent);
+      const raw = await callAI(systemPrompt, userContent);
       const { findings, parseError } = parseFindings(raw);
       return { pass: pass.key, file: file.path, findings, parseError };
     } catch (err) {


### PR DESCRIPTION
## Problem

\`scripts/ai-review.mjs\` (the PR review pipeline, run by \`vps-pr-review.sh\` per PR #70) loads \`prompts/review/{architecture,logic,style}.md\` but **not** \`prompts/shared/project-context.md\`.

The shared file defines:
- Valid CSS variables (so agents stop flagging \`var(--dome-text)\` as unknown)
- Architecture boundary rules (\`app/\` must not import Node)
- Severity criteria (❌ error / ⚠️ warn / ℹ️ info — see PR #72)
- Finding-quality rules (concrete path, line from diff, 6–10 char distinctive substring — PR #72)
- Known non-issues (CSS var fallbacks, \`--base-text\` hardcoded hex, Mantine internals, \`app/lib/i18n.ts\` strings, public PostHog keys, etc. — PR #72)

Without it, PR reviews drift away from the scheduled-audit pipeline: they flag intentional patterns and emit findings with empty/ambiguous \`pattern\` fields that the resolver can't grep.

## Change

- New \`loadSharedContext()\` helper (mirrors \`loadPrompt()\`) that reads \`prompts/shared/project-context.md\`, strips its frontmatter, and returns \`{ body, version, source }\`.
- \`main()\` now loads the shared context once at startup and prepends its body to each pass's system prompt, separated by \`---\`.
- Version log line now reports the shared version alongside per-pass versions: \`shared@2, architecture@1, logic@1, style@1\`.
- Graceful fallback: if the shared file is missing, behaviour is unchanged (just the per-pass prompt, with \`shared@missing\` in the log).

## Test plan

- [x] \`node -c scripts/ai-review.mjs\` → syntax OK
- [x] Dry-run with a small diff: log line shows \`shared@1\` and all 3 pass versions; review body lists the same in its prompts footer
- [ ] After merge: next PR review on a real PR should show \`shared@2\` (once PR #72 is also merged) in the review comment footer
- [ ] After merge: spot-check that PR reviews stop flagging CSS var fallbacks and \`--base-text\`

## Related

- PR #70 — moved the AI review pipeline from GitHub Actions to VPS cron
- PR #72 — v2 of \`project-context.md\` with severity + finding-quality rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)