### PR TITLE
refactor: fix hardcoded white colors to use CSS variables

### DIFF
--- a/app/components/cloud/CloudFilePicker.tsx
+++ b/app/components/cloud/CloudFilePicker.tsx
@@ -201,7 +201,7 @@ export default function CloudFilePicker({ onClose, projectId, folderId }: Props)
                 className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
                 style={{
                   backgroundColor: selectedAccount?.accountId === acc.accountId ? 'var(--accent)' : 'var(--bg-secondary)',
-                  color: selectedAccount?.accountId === acc.accountId ? 'white' : 'var(--secondary-text)',
+                  color: selectedAccount?.accountId === acc.accountId ? 'var(--base-text)' : 'var(--secondary-text)',
                   border: '1px solid var(--border)',
                 }}
               >

--- a/app/components/learn/DeckModal.tsx
+++ b/app/components/learn/DeckModal.tsx
@@ -116,7 +116,7 @@ export default function DeckModal({ onClose }: DeckModalProps) {
             className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-2"
             style={{
               background: title.trim() ? 'var(--dome-accent)' : 'var(--dome-border)',
-              color: title.trim() ? 'white' : 'var(--dome-text-muted)',
+              color: title.trim() ? 'var(--base-text)' : 'var(--dome-text-muted)',
               cursor: title.trim() ? 'pointer' : 'not-allowed',
             }}
           >

--- a/app/components/learn/GenerateModal.tsx
+++ b/app/components/learn/GenerateModal.tsx
@@ -137,7 +137,7 @@ export default function GenerateModal({ onClose }: GenerateModalProps) {
             className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-2"
             style={{
               background: selectedType ? 'var(--dome-accent)' : 'var(--dome-border)',
-              color: selectedType ? 'white' : 'var(--dome-text-muted)',
+              color: selectedType ? 'var(--base-text)' : 'var(--dome-text-muted)',
               cursor: selectedType ? 'pointer' : 'not-allowed',
             }}
           >

--- a/app/components/marketplace/WorkflowDetail.tsx
+++ b/app/components/marketplace/WorkflowDetail.tsx
@@ -248,7 +248,7 @@ export default function WorkflowDetail({
               className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
               style={{
                 background: isInstalled ? 'var(--success-bg)' : 'var(--dome-accent)',
-                color: isInstalled ? 'var(--success)' : 'white',
+                color: isInstalled ? 'var(--success)' : 'var(--base-text)',
                 boxShadow: isInstalled ? 'none' : '0 2px 8px rgba(89, 96, 55, 0.3)',
               }}
             >

--- a/app/components/user/UserAvatar.tsx
+++ b/app/components/user/UserAvatar.tsx
@@ -92,7 +92,7 @@ export default function UserAvatar({ name, avatarData, avatarPath, size = 'md', 
       className={`${sizeClass} rounded-full flex items-center justify-center font-medium ${className}`}
       style={{
         backgroundColor: hasValidAvatar ? 'transparent' : 'var(--accent)',
-        color: hasValidAvatar ? 'transparent' : 'white',
+        color: hasValidAvatar ? 'transparent' : 'var(--base-text)',
       }}
     >
       {hasValidAvatar ? (

--- a/app/components/viewers/pdf/PDFPage.tsx
+++ b/app/components/viewers/pdf/PDFPage.tsx
@@ -107,7 +107,7 @@ export default function PDFPage({ page, scale, pageNumber }: PDFPageProps) {
   }, [page, scale, pageNumber]);
 
   return (
-    <div className="relative mb-4" style={{ background: 'white' }}>
+    <div className="relative mb-4" style={{ background: 'var(--bg)' }}>
       <canvas
         ref={canvasRef}
         className="block shadow-lg"

--- a/app/components/viewers/pdf/PDFThumbnails.tsx
+++ b/app/components/viewers/pdf/PDFThumbnails.tsx
@@ -65,7 +65,7 @@ function PDFThumbnailItem({ page, pageNumber, isActive, onClick }: PDFThumbnailI
         className="relative overflow-hidden rounded shadow-sm"
         style={{
           maxWidth: THUMBNAIL_MAX_WIDTH,
-          background: 'white',
+          background: 'var(--bg)',
         }}
       >
         <canvas ref={canvasRef} className="block" />

--- a/app/components/workspace/SidePanel.tsx
+++ b/app/components/workspace/SidePanel.tsx
@@ -525,7 +525,7 @@ function SearchTab({ resourceId }: { resourceId: string; resource: Resource }) {
                 className="px-2.5 py-1 rounded-full text-xs font-medium transition-all border cursor-pointer focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
                 style={{
                   background: isActive ? color : 'var(--bg-tertiary)',
-                  color: isActive ? 'white' : 'var(--secondary-text)',
+                  color: isActive ? 'var(--base-text)' : 'var(--secondary-text)',
                   borderColor: isActive ? color : 'transparent',
                 }}
               >


### PR DESCRIPTION
## Summary
- Fixed hardcoded 'white' colors in style attributes across multiple components to use CSS variables
- Components fixed: PDFPage, PDFThumbnails, UserAvatar, SidePanel, GenerateModal, DeckModal, WorkflowDetail, CloudFilePicker
- All use var(--base-text) or var(--bg) as appropriate

## Flag
none

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs/config

## Checklist
- [x] typecheck passes
- [x] lint passes
- [x] build passes