### PR TITLE
fix: resolve SidePanel double type assertion

### DIFF
--- a/app/components/workspace/SidePanel.tsx
+++ b/app/components/workspace/SidePanel.tsx
@@ -349,7 +349,7 @@ function BacklinksTab({ resourceId }: { resourceId: string }) {
       try {
         const result = await window.electron.db.resources.getBacklinks(resourceId);
         if (result?.success) {
-          setBacklinks((result.data || []) as unknown as BacklinkResult[]);
+          setBacklinks((result.data || []) as BacklinkResult[]);
         }
       } catch (error) {
         console.error('Error loading backlinks:', error);

--- a/app/types/global.d.ts
+++ b/app/types/global.d.ts
@@ -376,7 +376,7 @@ declare global {
           ) => Promise<DBResponse<{ movedIds: string[] }>>;
           removeFromFolder: (resourceId: string) => Promise<DBResponse<void>>;
           // Backlinks
-          getBacklinks: (resourceId: string) => Promise<DBResponse<Resource[]>>;
+          getBacklinks: (resourceId: string) => Promise<DBResponse<ResourceLink[]>>;
           // Search for mentions
           searchForMention: (query: string) => Promise<DBResponse<Resource[]>>;
         };


### PR DESCRIPTION
## Summary
- Fixed `getBacklinks` return type in `global.d.ts` from `Resource[]` to `ResourceLink[]` to match actual DB schema
- Removed `as unknown as BacklinkResult[]` double cast, replaced with single `as BacklinkResult[]`

Both issues flagged in previous audit run (types@1 focus).

## Flag
none

## Type
- [ ] Bug fix

## Checklist
- [x] typecheck passes
- [x] lint passes
- [x] build passes