### PR TITLE
fix: replace hardcoded status colors with CSS variables

### DIFF
--- a/app/lib/automations/run-status.ts
+++ b/app/lib/automations/run-status.ts
@@ -9,10 +9,10 @@ export function statusLabel(status: string): string {
 
 /** Color de acento para badges / chips de estado de ejecución. */
 export function statusColor(status: string): string {
-  if (status === 'completed') return '#10b981';
+  if (status === 'completed') return 'var(--success)';
   if (status === 'failed') return 'var(--error)';
   if (status === 'running') return 'var(--accent)';
-  if (status === 'queued' || status === 'waiting_approval') return '#f59e0b';
+  if (status === 'queued' || status === 'waiting_approval') return 'var(--warning)';
   if (status === 'cancelled') return 'var(--tertiary-text)';
   return 'var(--secondary-text)';
 }


### PR DESCRIPTION
## Summary
- Fixed `app/lib/automations/run-status.ts` - replaced hardcoded hex colors `#10b981` and `#f59e0b` with semantic CSS variables `var(--success)` and `var(--warning)` respectively

## Flag
none

## Type
- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs/config

## Checklist
- [x] typecheck passes
- [x] lint passes (0 errors, 181 warnings)
- [x] build passes
- [ ] i18n keys in all 4 languages (if new strings)
- [x] No hardcoded colors (fix applied to run-status.ts)