### PR TITLE
fix: improve error handling in ai:team:stream handler

### DIFF
--- a/electron/ipc/agent-team.cjs
+++ b/electron/ipc/agent-team.cjs
@@ -182,16 +182,8 @@ function register({ ipcMain, windowManager, database, aiCloudService, ollamaServ
       return { success: false, error: 'Unauthorized' };
     }
 
-    const hasRequiredShape =
-      payload &&
-      typeof payload === 'object' &&
-      typeof payload.streamId === 'string' &&
-      typeof payload.teamId === 'string' &&
-      Array.isArray(payload.messages) &&
-      Array.isArray(payload.memberAgentIds);
-
-    if (!hasRequiredShape) {
-      const errorMsg = 'Invalid payload: streamId and teamId must be strings, messages and memberAgentIds must be arrays';
+    if (!payload || typeof payload !== 'object') {
+      const errorMsg = 'Invalid payload: must be an object';
       console.error('[AgentTeam] Validation error:', errorMsg);
       return { success: false, error: errorMsg };
     }
@@ -212,8 +204,23 @@ function register({ ipcMain, windowManager, database, aiCloudService, ollamaServ
       projectId,
     } = payload;
 
-    if (!streamId || !teamId) {
-      const errorMsg = 'Invalid payload: streamId and teamId are required';
+    if (typeof streamId !== 'string' || !streamId) {
+      const errorMsg = 'Invalid payload: streamId must be a non-empty string';
+      console.error('[AgentTeam] Validation error:', errorMsg);
+      return { success: false, error: errorMsg };
+    }
+    if (typeof teamId !== 'string' || !teamId) {
+      const errorMsg = 'Invalid payload: teamId must be a non-empty string';
+      console.error('[AgentTeam] Validation error:', errorMsg);
+      return { success: false, error: errorMsg };
+    }
+    if (!Array.isArray(messages)) {
+      const errorMsg = 'Invalid payload: messages must be an array';
+      console.error('[AgentTeam] Validation error:', errorMsg);
+      return { success: false, error: errorMsg };
+    }
+    if (!Array.isArray(memberAgentIds)) {
+      const errorMsg = 'Invalid payload: memberAgentIds must be an array';
       console.error('[AgentTeam] Validation error:', errorMsg);
       return { success: false, error: errorMsg };
     }

--- a/electron/ipc/agent-team.cjs
+++ b/electron/ipc/agent-team.cjs
@@ -188,21 +188,31 @@ function register({ ipcMain, windowManager, database, aiCloudService, ollamaServ
       return { success: false, error: errorMsg };
     }
 
-    const {
-      streamId,
-      teamId,
-      messages,
-      memberAgentIds,
-      supervisorInstructions,
-      currentResourceId,
-      currentResourceTitle,
-      currentFolderId,
-      pathname,
-      homeSidebarSection,
-      teamToolIds,
-      teamMcpServerIds,
-      projectId,
-    } = payload;
+    let streamId, teamId, messages, memberAgentIds, supervisorInstructions, currentResourceId, currentResourceTitle, currentFolderId, pathname, homeSidebarSection, teamToolIds, teamMcpServerIds, projectId;
+    try {
+      ({
+        streamId,
+        teamId,
+        messages,
+        memberAgentIds,
+        supervisorInstructions,
+        currentResourceId,
+        currentResourceTitle,
+        currentFolderId,
+        pathname,
+        homeSidebarSection,
+        teamToolIds,
+        teamMcpServerIds,
+        projectId,
+      } = payload);
+    } catch (err) {
+      if (err instanceof TypeError) {
+        const errorMsg = 'Invalid payload: could not read required properties';
+        console.error('[AgentTeam] Validation error:', errorMsg, err);
+        return { success: false, error: errorMsg };
+      }
+      throw err;
+    }
 
     if (typeof streamId !== 'string' || !streamId) {
       const errorMsg = 'Invalid payload: streamId must be a non-empty string';


### PR DESCRIPTION
## Summary
- Wrap payload destructuring in try/catch for `ai:team:stream` IPC handler to prevent unhandled TypeError when destructuring exotic objects
- Return `{ success: false, error }` for destructuring failures instead of crashing

## Flag
none

## Type
- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs/config

## Checklist
- [x] typecheck passes (pre-existing module errors unrelated to this change)
- [x] lint passes
- [x] build passes
- [ ] i18n keys in all 4 languages (if new strings)
- [ ] No hardcoded colors