### PR TITLE
fix: replace hardcoded #ffffff with var(--bg) in PptCapturePage

### DIFF
--- a/app/pages/PptCapturePage.tsx
+++ b/app/pages/PptCapturePage.tsx
@@ -179,7 +179,7 @@ export default function PptCapturePage() {
         width: SLIDE_W,
         height: SLIDE_H,
         overflow: 'hidden',
-        background: '#ffffff',
+        background: 'var(--bg)',
         margin: 0,
         padding: 0,
       }}


### PR DESCRIPTION
## Summary
- Replace hardcoded `#ffffff` in PptCapturePage JSX return with `var(--bg)` CSS variable

## Flag
none

## Type
- [ ] Bug fix

## Checklist
- [x] typecheck passes
- [x] lint passes  
- [x] build passes