### PR TITLE
fix: restore try-catch around payload destructuring in ai:team:stream

### DIFF
--- a/electron/ipc/agent-team.cjs
+++ b/electron/ipc/agent-team.cjs
@@ -189,21 +189,30 @@ function register({ ipcMain, windowManager, database, aiCloudService, ollamaServ
     }
 
     let streamId, teamId, messages, memberAgentIds, supervisorInstructions, currentResourceId, currentResourceTitle, currentFolderId, pathname, homeSidebarSection, teamToolIds, teamMcpServerIds, projectId;
-    ({
-      streamId,
-      teamId,
-      messages,
-      memberAgentIds,
-      supervisorInstructions,
-      currentResourceId,
-      currentResourceTitle,
-      currentFolderId,
-      pathname,
-      homeSidebarSection,
-      teamToolIds,
-      teamMcpServerIds,
-      projectId,
-    } = payload);
+    try {
+      ({
+        streamId,
+        teamId,
+        messages,
+        memberAgentIds,
+        supervisorInstructions,
+        currentResourceId,
+        currentResourceTitle,
+        currentFolderId,
+        pathname,
+        homeSidebarSection,
+        teamToolIds,
+        teamMcpServerIds,
+        projectId,
+      } = payload);
+    } catch (err) {
+      if (err instanceof TypeError) {
+        const errorMsg = 'Invalid payload: could not read required properties';
+        console.error('[AgentTeam] Validation error:', errorMsg, err);
+        return { success: false, error: errorMsg };
+      }
+      throw err;
+    }
 
     if (typeof streamId !== 'string' || !streamId) {
       const errorMsg = 'Invalid payload: streamId must be a non-empty string';


### PR DESCRIPTION
## Summary
- Reverted problematic change that removed try-catch around payload destructuring in `ai:team:stream` handler (electron/ipc/agent-team.cjs:192)
- If payload is null/undefined, the TypeError now properly returns `{ success: false, error }` instead of propagating unhandled to the renderer

## Flag
none

## Type
- [x] Bug fix

## Checklist
- [x] typecheck passes
- [x] lint passes
- [x] build passes