### PR TITLE
fix: improve error handling in IPC handlers

### DIFF
--- a/electron/ipc/agent-team.cjs
+++ b/electron/ipc/agent-team.cjs
@@ -211,7 +211,8 @@ function register({ ipcMain, windowManager, database, aiCloudService, ollamaServ
         console.error('[AgentTeam] Validation error:', errorMsg, err);
         return { success: false, error: errorMsg };
       }
-      throw err;
+      console.error('[AgentTeam] Unexpected error during destructuring:', err);
+      return { success: false, error: err.message || 'Unexpected error during payload processing' };
     }
 
     if (typeof streamId !== 'string' || !streamId) {

--- a/electron/ipc/plugins.cjs
+++ b/electron/ipc/plugins.cjs
@@ -179,43 +179,47 @@ function register({ ipcMain, windowManager, validateSender, sanitizePath }) {
           if (err) return reject(err);
           zipfile.readEntry();
           zipfile.on('entry', (entry) => {
-            const sanitizeEntryPath = (entryFileName) => {
-              const normalized = path.normalize(entryFileName);
-              if (normalized.includes('\0')) {
-                throw new Error('Path contains null byte');
-              }
-              // Note: '..' is allowed through here because resolveWithinExtractDir
-              // catches path traversal via containment check (startsWith baseDir + sep).
-              // This is secure because path.resolve normalizes '..' components.
-              return normalized;
-            };
+            try {
+              const sanitizeEntryPath = (entryFileName) => {
+                const normalized = path.normalize(entryFileName);
+                if (normalized.includes('\0')) {
+                  throw new Error('Path contains null byte');
+                }
+                return normalized;
+              };
 
-            const resolveWithinExtractDir = (fileName) => {
-              const sanitized = sanitizeEntryPath(fileName);
-              const joined = path.join(extractDir, sanitized);
-              const resolved = path.resolve(joined);
-              const resolvedExtractDir = path.resolve(extractDir);
-              if (!resolved.startsWith(resolvedExtractDir + path.sep)) {
-                throw new Error('Path traversal detected: ' + fileName);
-              }
-              return resolved;
-            };
+              const resolveWithinExtractDir = (fileName) => {
+                const sanitized = sanitizeEntryPath(fileName);
+                const joined = path.join(extractDir, sanitized);
+                const resolved = path.resolve(joined);
+                const resolvedExtractDir = path.resolve(extractDir);
+                if (!resolved.startsWith(resolvedExtractDir + path.sep)) {
+                  throw new Error('Path traversal detected: ' + fileName);
+                }
+                return resolved;
+              };
 
-            if (/\/$/.test(entry.fileName)) {
-              const dirPath = resolveWithinExtractDir(entry.fileName);
-              fs.mkdirSync(dirPath, { recursive: true });
-              zipfile.readEntry();
-              return;
+              if (/\/$/.test(entry.fileName)) {
+                const dirPath = resolveWithinExtractDir(entry.fileName);
+                fs.mkdirSync(dirPath, { recursive: true });
+                zipfile.readEntry();
+                return;
+              }
+              zipfile.openReadStream(entry, (openErr, readStream) => {
+                if (openErr) {
+                  reject(openErr);
+                  return;
+                }
+                const destPath = resolveWithinExtractDir(entry.fileName);
+                fs.mkdirSync(path.dirname(destPath), { recursive: true });
+                const writeStream = fs.createWriteStream(destPath);
+                readStream.pipe(writeStream);
+                writeStream.on('finish', () => zipfile.readEntry());
+                writeStream.on('error', reject);
+              });
+            } catch (err) {
+              reject(err);
             }
-            zipfile.openReadStream(entry, (openErr, readStream) => {
-              if (openErr) return reject(openErr);
-              const destPath = resolveWithinExtractDir(entry.fileName);
-              fs.mkdirSync(path.dirname(destPath), { recursive: true });
-              const writeStream = fs.createWriteStream(destPath);
-              readStream.pipe(writeStream);
-              writeStream.on('finish', () => zipfile.readEntry());
-              writeStream.on('error', reject);
-            });
           });
           zipfile.on('end', () => resolve());
           zipfile.on('error', reject);

--- a/electron/ipc/sync.cjs
+++ b/electron/ipc/sync.cjs
@@ -119,46 +119,50 @@ function register({ ipcMain, windowManager, database, fileStorage, validateSende
 
           zipfile.readEntry();
           zipfile.on('entry', (entry) => {
-            const sanitizeEntryPath = (entryFileName) => {
-              const normalized = path.normalize(entryFileName);
-              if (normalized.includes('\0')) {
-                throw new Error('Path contains null byte');
-              }
-              // Note: '..' is allowed through here because resolveWithinTempDir
-              // catches path traversal via containment check (startsWith baseDir + sep).
-              // This is secure because path.resolve normalizes '..' components.
-              return normalized;
-            };
+            try {
+              const sanitizeEntryPath = (entryFileName) => {
+                const normalized = path.normalize(entryFileName);
+                if (normalized.includes('\0')) {
+                  throw new Error('Path contains null byte');
+                }
+                return normalized;
+              };
 
-            const resolveWithinTempDir = (fileName) => {
-              const sanitized = sanitizeEntryPath(fileName);
-              const joined = path.join(tempDir, sanitized);
-              const resolved = path.resolve(joined);
-              const resolvedTempDir = path.resolve(tempDir);
-              if (!resolved.startsWith(resolvedTempDir + path.sep)) {
-                throw new Error('Path traversal detected: ' + fileName);
-              }
-              return resolved;
-            };
+              const resolveWithinTempDir = (fileName) => {
+                const sanitized = sanitizeEntryPath(fileName);
+                const joined = path.join(tempDir, sanitized);
+                const resolved = path.resolve(joined);
+                const resolvedTempDir = path.resolve(tempDir);
+                if (!resolved.startsWith(resolvedTempDir + path.sep)) {
+                  throw new Error('Path traversal detected: ' + fileName);
+                }
+                return resolved;
+              };
 
-            if (/\/$/.test(entry.fileName)) {
-              const dirPath = resolveWithinTempDir(entry.fileName);
-              fs.mkdirSync(dirPath, { recursive: true });
-              zipfile.readEntry();
-              return;
-            }
-
-            zipfile.openReadStream(entry, (openErr, readStream) => {
-              if (openErr) return reject(openErr);
-              const destPath = resolveWithinTempDir(entry.fileName);
-              fs.mkdirSync(path.dirname(destPath), { recursive: true });
-              const writeStream = fs.createWriteStream(destPath);
-              readStream.pipe(writeStream);
-              writeStream.on('finish', () => {
+              if (/\/$/.test(entry.fileName)) {
+                const dirPath = resolveWithinTempDir(entry.fileName);
+                fs.mkdirSync(dirPath, { recursive: true });
                 zipfile.readEntry();
+                return;
+              }
+
+              zipfile.openReadStream(entry, (openErr, readStream) => {
+                if (openErr) {
+                  reject(openErr);
+                  return;
+                }
+                const destPath = resolveWithinTempDir(entry.fileName);
+                fs.mkdirSync(path.dirname(destPath), { recursive: true });
+                const writeStream = fs.createWriteStream(destPath);
+                readStream.pipe(writeStream);
+                writeStream.on('finish', () => {
+                  zipfile.readEntry();
+                });
+                writeStream.on('error', reject);
               });
-              writeStream.on('error', reject);
-            });
+            } catch (err) {
+              reject(err);
+            }
           });
           zipfile.on('end', () => resolve());
           zipfile.on('error', reject);


### PR DESCRIPTION
## Summary
- Fix unhandled rejections in `agent-team.cjs` by replacing `throw err` with proper error return in destructuring try-catch
- Fix unhandled exceptions in `plugins.cjs` by wrapping `zipfile.on('entry')` EventEmitter callback in try-catch and using `reject()` instead of `throw`
- Fix same issue in `sync.cjs` for consistency

## Flag
none

## Type
- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs/config

## Checklist
- [x] typecheck passes (pre-existing reactflow/dagre errors unrelated to this PR)
- [x] lint passes
- [x] build fails due to pre-existing missing module issue (not caused by this PR)
- [ ] i18n keys in all 4 languages (if new strings)
- [x] No hardcoded colors