### PR TITLE
docs: fix broken link in dome-provider-integration.md

### DIFF
--- a/docs/features/dome-provider-integration.md
+++ b/docs/features/dome-provider-integration.md
@@ -186,7 +186,3 @@ Si `VITE_ENABLE_DOME_PROVIDER` no es `true`, la opción de Dome Provider no apar
 - El `code_verifier` NUNCA se envía al server (solo el `code_challenge`)
 - El deep link `dome://` solo acepta callbacks de `dome-auth` — otros paths son ignorados
 - El Provider valida la firma JWT en cada request con el `TOKEN_HMAC_SECRET` del servidor
-
----
-
-*Ver también: [dome-provider/docs/api-reference.md](../../dome-provider/docs/api-reference.md) para la referencia de endpoints del Provider.*


### PR DESCRIPTION
## Summary
- Removed broken reference to `dome-provider/docs/api-reference.md` which points to an external repository not present in this codebase.

## Audit findings (no action needed)
- IPC inventory: OK (405 channels, matches code)
- AGENTS.md Electron version (41) matches package.json (^41.3.0)
- P-001 through P-010 all defined in docs/principles.md
- ADR-0001 (accepted), ADR-0002 (proposed) - frontmatter status OK