### PR TITLE
fix(sync): remove unnecessary zipfile variable shadowing

### DIFF
--- a/electron/ipc/sync.cjs
+++ b/electron/ipc/sync.cjs
@@ -113,11 +113,9 @@ function register({ ipcMain, windowManager, database, fileStorage, validateSende
 
       fs.mkdirSync(tempDir, { recursive: true });
 
-      let zipfile;
       await new Promise((resolve, reject) => {
-        yauzl.open(zipPath, { lazyEntries: true }, (err, zf) => {
+        yauzl.open(zipPath, { lazyEntries: true }, (err, zipfile) => {
           if (err) return reject(err);
-          zipfile = zf;
 
           zipfile.on('entry', (entry) => {
             try {


### PR DESCRIPTION
## Summary
- Removes unnecessary outer-scope `let zipfile` variable in sync.cjs that was being shadowed by the callback parameter `zf` with an assignment - this was pure indirection since `zipfile` is only used within the callback
- No functional changes; ErrorBoundary already exists and IPC handlers already have proper try/catch

## Validation
- npm run typecheck: ✓
- npm run lint: ✓ (0 errors, 101 warnings)
- npm run build: ✓