### PR TITLE
chore: ignore bun.lock (npm canonical)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # dependencies (bun install)
 node_modules
+bun.lock
 
 # output
 out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Añade `bun.lock` a `.gitignore` para que no aparezca como archivo sin seguimiento cuando se use Bun localmente; el proyecto sigue usando **npm** (`package-lock.json`), tal como indican AGENTS.md y CLAUDE.md.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66b22fb5-912d-48cd-9a62-ff831e83c3f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66b22fb5-912d-48cd-9a62-ff831e83c3f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

