### PR TITLE
fix(build): esquema NSIS compatible con electron-builder 26

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,8 +303,7 @@
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
-      "artifactName": "${productName}-Setup-${version}.${ext}",
-      "compression": "maximum"
+      "artifactName": "${productName}-Setup-${version}.${ext}"
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

En [run 24983329691](https://github.com/maxprain12/dome/actions/runs/24983329691) fallaron **build-macos** y **build-windows** con el mismo error al validar la config **antes** de empaquetar:

`configuration.nsis has an unknown property 'compression'`

`electron-builder` 26.9.0 carga y valida el esquema completo (incl. `nsis`) aunque el target sea `--mac`, por eso ambos jobs fallan.

## Solución

Se elimina `nsis.compression` de `package.json` (no figura en el esquema aceptado en v26; la compresión del instalador queda con el comportamiento por defecto de NSIS).

## Tras el merge

Vuelve a ejecutar el workflow de build (p. ej. re-ejecutar jobs fallidos si GitHub lo permite tras actualizar `main`) o publica un **patch release** si hace falta nueva build de artefactos para la misma versión.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66b22fb5-912d-48cd-9a62-ff831e83c3f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66b22fb5-912d-48cd-9a62-ff831e83c3f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

