### PR TITLE
fix: react patterns audit findings

### DIFF
--- a/app/components/Search/SimpleSearch.tsx
+++ b/app/components/Search/SimpleSearch.tsx
@@ -657,9 +657,7 @@ export function InlineSearch({ onResourceSelect, placeholder }: InlineSearchProp
         if (!ignore) setIsSearching(false);
       }
     };
-    const timer = setTimeout(() => {
-      runSearch().catch((err) => console.error('[InlineSearch] Unified search failed:', err));
-    }, 250);
+    const timer = setTimeout(() => { runSearch(); }, 250);
     return () => { ignore = true; clearTimeout(timer); };
   }, [query]);
 

--- a/app/components/workspace/WorkspaceSplitView.tsx
+++ b/app/components/workspace/WorkspaceSplitView.tsx
@@ -85,6 +85,13 @@ export default function WorkspaceSplitView({ tab, primary, reference }: Workspac
     startWidthRef.current = splitWidth;
     setIsResizing(true);
 
+    if (resizeListenersRef.current.move) {
+      window.removeEventListener('pointermove', resizeListenersRef.current.move);
+    }
+    if (resizeListenersRef.current.up) {
+      window.removeEventListener('pointerup', resizeListenersRef.current.up);
+    }
+
     const handlePointerMove = (moveEvent: PointerEvent) => {
       resizeSplit(startWidthRef.current - (moveEvent.clientX - startXRef.current), tab.id);
     };


### PR DESCRIPTION
## Summary
- **SimpleSearch**: Fixed error handling - removed double-catch on setTimeout callback; errors are already properly caught in runSearch's try/catch block (lines 654-661)
- **WorkspaceSplitView**: Fixed duplicate pointer listeners by cleaning up stale listeners before adding new ones in handlePointerDown (lines 82-103)

## Context
Addressing unresolved findings from previous audit pass per the audit prompt instructions.

## Testing
```bash
npm run typecheck  # pass
npm run lint       # 0 errors, 102 warnings (pre-existing)
npm run build      # pass
```