### PR TITLE
fix(errors): remove dead code in sync.cjs, audit findings

### DIFF
--- a/electron/ipc/sync.cjs
+++ b/electron/ipc/sync.cjs
@@ -117,10 +117,8 @@ function register({ ipcMain, windowManager, database, fileStorage, validateSende
         yauzl.open(zipPath, { lazyEntries: true }, (err, zf) => {
           if (err) return reject(err);
 
-          let zipError;
           zf.on('end', () => resolve());
           zf.on('error', (e) => {
-            zipError = e;
             reject(e);
           });
 


### PR DESCRIPTION
## Summary
- Removed dead `zipError` variable in sync.cjs (assigned but never read)

## Findings addressed
The unresolved audit findings from the previous audit were reviewed:

| Issue | Status |
|-------|--------|
| sync.cjs:120 - zipError dead code | Fixed by removing unused variable |
| sync.cjs:126 - zipError assignment dead | Confirmed - rejection already uses `e` directly |
| sync.cjs:129 - Comment on '..' path | Comment is present at lines 133-135 |
| sync.cjs:165 - Race condition | Handlers registered before readEntry() call within callback |
| agent-team.cjs:192,202,205,206,268,270 | Code has proper try/catch and validation |

## Validation
- npm run typecheck ✓
- npm run lint ✓ (102 warnings, 0 errors - pre-existing)
- npm run build ✓
- npm run check:ipc-inventory ✓