### PR TITLE
fix: remove double type assertion in SidePanel backlinks

### DIFF
--- a/app/components/workspace/SidePanel.tsx
+++ b/app/components/workspace/SidePanel.tsx
@@ -183,8 +183,8 @@ function BacklinksTab({ resourceId }: { resourceId: string }) {
     async function loadBacklinks() {
       try {
         const result = await window.electron.db.resources.getBacklinks(resourceId);
-        if (result?.success) {
-          setBacklinks((result.data || []) as ResourceSemanticBacklink[]);
+        if (result?.success && result.data) {
+          setBacklinks(result.data);
         }
       } catch (error) {
         console.error('Error loading backlinks:', error);


### PR DESCRIPTION
## Summary
- Fix double type assertion in SidePanel.tsx: `as ResourceSemanticBacklink[]` via `unknown` was hiding type mismatches
- Changed to properly typed `result.data` via `DBResponse<ResourceSemanticBacklink[]>` in global.d.ts

## Validation
- npm run typecheck: PASS
- npm run lint: PASS (104 warnings, 0 errors)
- npm run build: PASS