### PR TITLE
fix: safe error.message access in storage.cjs and sync.cjs

### DIFF
--- a/electron/ipc/storage.cjs
+++ b/electron/ipc/storage.cjs
@@ -10,7 +10,7 @@ function register({ ipcMain, windowManager, database, fileStorage }) {
       return { success: true, data: usage };
     } catch (error) {
       console.error('[Storage] Error getting usage:', error);
-      return { success: false, error: error.message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 
@@ -42,7 +42,7 @@ function register({ ipcMain, windowManager, database, fileStorage }) {
       return { success: true, data: result };
     } catch (error) {
       console.error('[Storage] Error during cleanup:', error);
-      return { success: false, error: error.message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 

--- a/electron/ipc/sync.cjs
+++ b/electron/ipc/sync.cjs
@@ -218,7 +218,7 @@ function register({ ipcMain, windowManager, database, fileStorage, validateSende
     } catch (error) {
       console.error('[Sync] Import error:', error);
       database.initDatabase().catch(() => {});
-      return { success: false, error: error.message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 }


### PR DESCRIPTION
## Summary
- storage.cjs: Fixed error.message access to use instanceof Error check
- sync.cjs: Same fix for import error handler

## Validation
- npm run typecheck: passed
- npm run lint: passed (0 errors, 104 warnings pre-existing)
- npm run build: passed