### PR TITLE
chore: release v2.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to Dome are documented in this file.
 
 ## [Unreleased]
 
+## [2.1.7] - 2026-05-03
+
+### Added
+
+- **Many**: herramientas shell, archivo y UI; servidor **MCP** embebido de Dome (`DomeMcpServerSettings`); overlay de cursor para interacciones asistidas.
+- **Electron**: nuevos IPC y bridge (`shell`, `dome-mcp`, ejecutor ampliado en `ai-tools-handler`).
+
+### Changed
+
+- **Many / agent canvas**: mejoras en el panel Many y Agent Canvas.
+- **Auditorías**: ciclo habitual de audits (tipos, errores, seguridad, docs, i18n).
+
+### Fixed
+
+- Acceso seguro a `error.message` y condiciones de carrera en varios IPC (incl. `sync`); rutas relacionadas en almacenamiento y sincronización.
+- **`SidePanel`**: eliminación de doble type assertion en backlinks.
+- **`UnifiedSidebar`**: limpieza de `setTimeout` en `TreeNode`.
+- **`PptCapturePage`**: fondo con `var(--bg-secondary)` en lugar de `#fff` hardcoded.
+- **i18n**: claves faltantes en studio y strings en `GenerateSourceModal`.
+
+### Documentation
+
+- Referencia IPC actualizada en `docs/architecture/ipc-channels.md`.
+
+[2.1.7]: https://github.com/maxprain12/dome/releases/tag/v2.1.7
+
 ## [2.1.6] - 2026-04-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dome",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dome",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {


### PR DESCRIPTION
## Resumen
Bump de versión a **2.1.7** y entrada en `CHANGELOG.md` con los cambios desde v2.1.6.

## Tras el merge
- Crear y publicar el tag `v2.1.7` en `main`.
- Publicar la release en GitHub para disparar el workflow de build (artefactos DMG/ZIP/NSIS).

## Checklist
- [x] `package.json` / `package-lock.json`
- [x] `CHANGELOG.md`