### PR TITLE
docs: update v2.1.6 → v2.1.7 in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Dome – índice de documentación
 
-Documentación del proyecto Dome (v2.1.6). Además de este índice:
+Documentación del proyecto Dome (v2.1.7). Además de este índice:
 
 - **[Principios de ingeniería](principles.md)** — P-001…P-010, citados por linters y auditorías.
 - **[Arquitectura](architecture/README.md)** — capas, dominios, IPC, ADRs, worktree.

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -102,7 +102,7 @@ interface AppPreferences {
 
 ---
 
-## Settings keys reference (v2.1.6)
+## Settings keys reference (v2.1.7)
 
 | Key | Type | Description |
 |-----|------|-------------|

--- a/docs/manual-tecnico.md
+++ b/docs/manual-tecnico.md
@@ -1,6 +1,6 @@
 # Manual Técnico — Dome Desktop
 
-> Referencia técnica consolidada para desarrolladores de Dome (v2.1.6).
+> Referencia técnica consolidada para desarrolladores de Dome (v2.1.7).
 > Asume conocimiento de TypeScript, React y Electron.
 
 ---
@@ -786,4 +786,4 @@ Checklist:
 
 ---
 
-*Manual Técnico — Dome v2.1.6*
+*Manual Técnico — Dome v2.1.7*

--- a/docs/manual-usuario.md
+++ b/docs/manual-usuario.md
@@ -1,6 +1,6 @@
 # Manual de Usuario — Dome
 
-> Guía completa para usuarios finales de Dome Desktop (v2.1.6).
+> Guía completa para usuarios finales de Dome Desktop (v2.1.7).
 > Este manual no requiere conocimientos técnicos.
 
 ---
@@ -581,4 +581,4 @@ Sí. Dome soporta múltiples pestañas (tabs) dentro del workspace, una por recu
 
 ---
 
-*Manual de Usuario — Dome v2.1.6*
+*Manual de Usuario — Dome v2.1.7*


### PR DESCRIPTION
## Summary
- Update version references in docs from v2.1.6 to v2.1.7 to match package.json

## Findings
- **IPC inventory**: OK (397 channels, no drift)
- **Broken links**: No broken links found
- **ADR-0002 status**: `proposed` since 2026-04-27 (~38 days) — per audit rule, proposed >30 days should be flagged. ADR explicitly states it awaits validation from real migrations, not a critical issue.
- **Version drift**: Fixed 4 files (README.md, manual-tecnico.md, manual-usuario.md, settings.md) + footers

## Validation
- npm run typecheck: PASS
- npm run lint: PASS (0 errors, 92 warnings pre-existing)
- npm run build: PASS