### PR TITLE
fix: PDF annotation CSS color fallback issues

### DIFF
--- a/app/components/viewers/pdf/AnnotationLayer.tsx
+++ b/app/components/viewers/pdf/AnnotationLayer.tsx
@@ -101,7 +101,7 @@ export default function AnnotationLayer({
             width: coordinates.width,
             height: coordinates.height,
           });
-          ctx.strokeStyle = resolveCssColor('var(--accent)', '#596037');
+          ctx.strokeStyle = resolveCssColor('var(--accent)') || '#596037';
           ctx.lineWidth = 2;
           ctx.setLineDash([5, 5]);
           ctx.strokeRect(

--- a/app/components/viewers/pdf/PDFHighlightsList.tsx
+++ b/app/components/viewers/pdf/PDFHighlightsList.tsx
@@ -11,6 +11,8 @@ const HEX_TO_VAR_MAP: Record<string, string> = {
   '#596037': 'var(--accent)',
   '#A4AD7A': 'var(--accent)',
   '#E88585': 'var(--error)',
+  '#ef4444': 'var(--error)',
+  '#0ea5e9': 'var(--accent)',
 };
 
 function normalizeColor(color: string | undefined): string {

--- a/app/lib/pdf/annotation-utils.ts
+++ b/app/lib/pdf/annotation-utils.ts
@@ -223,7 +223,7 @@ function renderHighlight(
 ): void {
   if (viewportRect.width > 0 && viewportRect.height > 0) {
     ctx.globalAlpha = style.opacity ?? 0.3;
-    ctx.fillStyle = resolveCssColor(style.color);
+    ctx.fillStyle = resolveCssColor(style.color) || '#596037';
     ctx.fillRect(viewportRect.x, viewportRect.y, viewportRect.width, viewportRect.height);
   }
 }
@@ -238,12 +238,12 @@ function renderNote(
 
   // Draw note background
   ctx.globalAlpha = 0.95;
-  ctx.fillStyle = resolveCssColor(style.color || 'var(--accent)');
+  ctx.fillStyle = resolveCssColor(style.color) || '#596037';
   ctx.fillRect(coordinates.x, coordinates.y, noteWidth, noteHeight);
 
   // Draw note border
   ctx.globalAlpha = 1;
-  ctx.strokeStyle = resolveCssColor('var(--warning)');
+  ctx.strokeStyle = resolveCssColor('var(--warning)') || 'var(--warning)';
   ctx.lineWidth = 2;
   ctx.strokeRect(coordinates.x, coordinates.y, noteWidth, noteHeight);
 


### PR DESCRIPTION
## Summary
- Fix resolveCssColor null return in AnnotationLayer.tsx:104
- Fix fillStyle/strokeStyle CSS variable fallbacks in annotation-utils.ts
- Extend HEX_TO_VAR_MAP in PDFHighlightsList.tsx for color normalization

## Validation
- npm run typecheck ✓
- npm run lint ✓ (95 warnings, pre-existing)
- npm run build ✓