### PR TITLE
fix(arch): remove unused Ollama manager channels from preload

### DIFF
--- a/docs/architecture/ipc-channels.md
+++ b/docs/architecture/ipc-channels.md
@@ -1,7 +1,7 @@
 # Canales IPC (autogenerado)
 
 > **No edites a mano.** Regenera con `npm run generate:ipc-inventory`.
-> Última generación: 2026-05-09T22:00:17.643Z
+> Última generación: 2026-05-10T18:36:32.737Z
 
 Canales detectados vía `ipcMain.handle` / `ipcMain.on` en `electron/ipc/*.cjs`.
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -289,12 +289,6 @@ const ALLOWED_CHANNELS = {
     'ollama:generate-embedding',
     'ollama:generate-summary',
     'ollama:chat',
-    // Ollama Manager (Native Integration)
-    'ollama:manager:start',
-    'ollama:manager:stop',
-    'ollama:manager:status',
-    'ollama:manager:download',
-    'ollama:manager:versions',
     // Legacy vector DB / LanceDB IPC removed — semantic index is SQLite + Nomic (see `db:semantic:*`)
     // WhatsApp
     'whatsapp:status',
@@ -558,10 +552,6 @@ const ALLOWED_CHANNELS = {
     'tts:error',
     // Auto-updater events
     'updater:status',
-    // Ollama Manager events
-    'ollama:download-progress',
-    'ollama:server-log',
-    'ollama:status-changed',
     // Studio events
     'studio:outputCreated',
     // Deep link: open studio output from dome://studio/ID
@@ -1543,42 +1533,6 @@ const electronHandler = {
 
     // Chat
     chat: (messages, model) => ipcRenderer.invoke('ollama:chat', { messages, model }),
-
-    // Native Ollama Manager (binary management and lifecycle)
-    manager: {
-      // Start Ollama server (downloads if needed)
-      start: (version) => ipcRenderer.invoke('ollama:manager:start', version),
-
-      // Stop Ollama server
-      stop: () => ipcRenderer.invoke('ollama:manager:stop'),
-
-      // Get status
-      status: () => ipcRenderer.invoke('ollama:manager:status'),
-
-      // Download version without starting
-      download: (version) => ipcRenderer.invoke('ollama:manager:download', version),
-
-      // Get list of downloaded versions
-      versions: () => ipcRenderer.invoke('ollama:manager:versions'),
-
-      // Listen to download progress
-      onDownloadProgress: (callback) => {
-        ipcRenderer.on('ollama:download-progress', (event, data) => callback(data));
-        return () => ipcRenderer.removeAllListeners('ollama:download-progress');
-      },
-
-      // Listen to server logs
-      onServerLog: (callback) => {
-        ipcRenderer.on('ollama:server-log', (event, message) => callback(message));
-        return () => ipcRenderer.removeAllListeners('ollama:server-log');
-      },
-
-      // Listen to status changes
-      onStatusChanged: (callback) => {
-        ipcRenderer.on('ollama:status-changed', (event, status) => callback(status));
-        return () => ipcRenderer.removeAllListeners('ollama:status-changed');
-      },
-    },
   },
 
   // ============================================


### PR DESCRIPTION
## Summary
- Removed 5 Ollama manager IPC channels (`ollama:manager:start/stop/status/download/versions`) and 3 event channels from `ALLOWED_CHANNELS` in `electron/preload.cjs`
- Confirmed no callers in `app/` invoke these channels (grep verified)
- Also removed the dead `window.electron.ollama.manager` preload API object

## Verification
- `npm run typecheck` ✅
- `npm run lint` ✅ (0 errors, 95 warnings pre-existing)
- `npm run build` ✅
- `npm run depcruise` ✅ (no violations)
- `npm run check:ipc-inventory` ✅ (406 channels)

## Context
Per the architecture audit, Ollama manager channels were never called from the renderer — only registered in `ALLOWED_CHANNELS`. Handler code in `electron/ipc/ollama.cjs` remains untouched for main-to-main usage via `getOllamaManager()`.