### PR TITLE
feat(langgraph): context engineering — memoria AGENTS.md, resumen y límites

### DIFF
--- a/app/lib/skills/append-markdown.ts
+++ b/app/lib/skills/append-markdown.ts
@@ -8,16 +8,32 @@ export interface SkillLike {
   enabled?: boolean;
 }
 
-export function appendSkillsMarkdown(base: string, skillIds: string[] | undefined, skills: SkillLike[]): string {
+const DEFAULT_MAX_BODY_CHARS = 3800;
+
+export interface AppendSkillsMarkdownOptions {
+  /** Per-skill body cap to avoid blowing the LangGraph context window (default 3800). */
+  maxBodyChars?: number;
+}
+
+export function appendSkillsMarkdown(
+  base: string,
+  skillIds: string[] | undefined,
+  skills: SkillLike[],
+  options?: AppendSkillsMarkdownOptions,
+): string {
   const t = base.trimEnd();
   if (!skillIds?.length || !skills.length) return t;
+  const maxBody = typeof options?.maxBodyChars === 'number' && options.maxBodyChars > 500 ? options.maxBodyChars : DEFAULT_MAX_BODY_CHARS;
 
   const chunks: string[] = [];
   for (const id of skillIds) {
     const s = skills.find((x) => x.id === id);
     if (!s || s.enabled === false) continue;
-    const body = (s.prompt || '').trim();
+    let body = (s.prompt || '').trim();
     if (!body) continue;
+    if (body.length > maxBody) {
+      body = `${body.slice(0, maxBody)}…\n[Skill body truncated for context — reduce enabled skills or shorten prompts in Settings → Skills.]`;
+    }
     chunks.push(`### ${s.name || 'Skill'}\n${body}\n`);
   }
   if (chunks.length === 0) return t;

--- a/electron/agent-runtime-context.cjs
+++ b/electron/agent-runtime-context.cjs
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * Typed runtime context for LangGraph tool execution (Many / runs / IPC).
+ * Strips unknown keys and normalizes shapes at the trust boundary.
+ */
+
+const { z } = require('zod');
+
+const DomeRuntimeContextSchema = z
+  .object({
+    activeResourceId: z
+      .string()
+      .min(1)
+      .max(200)
+      .nullable()
+      .optional(),
+    pinnedResourceIds: z.array(z.string().min(1).max(200)).optional().default([]),
+  })
+  .strip();
+
+/**
+ * @param {unknown} raw
+ * @returns {{ activeResourceId: string | null; pinnedResourceIds: string[] } | null}
+ */
+function parseRuntimeContext(raw) {
+  if (raw == null || typeof raw !== 'object') return null;
+  try {
+    const parsed = DomeRuntimeContextSchema.parse(raw);
+    const active = parsed.activeResourceId ?? null;
+    const pins = Array.isArray(parsed.pinnedResourceIds) ? [...new Set(parsed.pinnedResourceIds)] : [];
+    if (!active && pins.length === 0) return null;
+    return { activeResourceId: active, pinnedResourceIds: pins };
+  } catch (e) {
+    console.warn('[AgentRuntimeContext] invalid runtimeContext dropped:', e?.message || e);
+    return null;
+  }
+}
+
+module.exports = { parseRuntimeContext, DomeRuntimeContextSchema };

--- a/electron/langgraph-agent.cjs
+++ b/electron/langgraph-agent.cjs
@@ -11,6 +11,12 @@
  * model gets ls/read_file/write_file/edit_file/glob/grep/execute against an
  * isolated VFS (see electron/langgraph-vfs-thread.cjs for lifecycle).
  *
+ * Context engineering: optional LangChain summarizationMiddleware (disable with
+ * DOME_LANGGRAPH_SUMMARIZATION=0), trim-by-token middleware, tool-result caps
+ * (electron/tool-result-cap.cjs), typed runtimeContext (agent-runtime-context.cjs),
+ * optional workspace AGENTS.md injected via project-memory.cjs, and truncated
+ * file-skill bodies in skill-prompt.cjs.
+ *
  * Human-in-the-Loop (HITL): call_writer_agent and call_data_agent require
  * human approval. Uses a durable SqliteSaver checkpointer so pending
  * interrupts survive app restarts (see ./checkpointer.cjs).
@@ -33,6 +39,10 @@ const database = require('./database.cjs');
 const { getDomeCheckpointer } = require('./checkpointer.cjs');
 const { withLangfuseCallbacks } = require('./observability.cjs');
 const { measurePrompt } = require('./prompt-budget.cjs');
+const { parseRuntimeContext } = require('./agent-runtime-context.cjs');
+const projectMemory = require('./project-memory.cjs');
+const skillRegistry = require('./skills/registry.cjs');
+const { capToolResultString } = require('./tool-result-cap.cjs');
 
 function pickTokenNumber(obj, keys) {
   if (!obj || typeof obj !== 'object') return null;
@@ -666,6 +676,30 @@ async function createTrimmingMiddleware(provider, llm) {
   });
 }
 
+/**
+ * Optional LangChain summarization middleware (context engineering).
+ * Disable with DOME_LANGGRAPH_SUMMARIZATION=0 if it causes issues with a provider.
+ * @param {string} provider
+ * @param {import('@langchain/core').BaseChatModel} llm
+ * @returns {Promise<import('langchain').AgentMiddleware | null>}
+ */
+async function createSummarizationMiddlewareMaybe(provider, llm) {
+  const off = String(process.env.DOME_LANGGRAPH_SUMMARIZATION ?? '').toLowerCase().trim();
+  if (off === '0' || off === 'false' || off === 'off' || off === 'no') return null;
+  try {
+    const { summarizationMiddleware } = await import('langchain');
+    const maxTokens = PROVIDER_TOKEN_BUDGETS[provider] ?? DEFAULT_TOKEN_BUDGET;
+    return summarizationMiddleware({
+      model: llm,
+      trigger: { tokens: Math.floor(maxTokens * 0.7), messages: 8 },
+      keep: { tokens: Math.floor(maxTokens * 0.18), messages: 10 },
+    });
+  } catch (e) {
+    console.warn('[AI LangGraph] summarizationMiddleware not loaded:', e?.message || e);
+    return null;
+  }
+}
+
 const CALENDAR_HITL_TOOLS = {
   calendar_create_event: true,
   calendar_update_event: true,
@@ -719,8 +753,10 @@ async function createConfiguredLangGraphAgent(llm, opts) {
     automationProjectId,
     provider,
     customTools,
-    runtimeContext,
+    runtimeContext: runtimeContextRaw,
   } = opts;
+
+  const runtimeContext = parseRuntimeContext(runtimeContextRaw);
 
   const toolContext = (automationProjectId || runtimeContext)
     ? {
@@ -760,10 +796,11 @@ async function createConfiguredLangGraphAgent(llm, opts) {
         return { error: capError };
       }
       const result = await executeToolInMain(name, args, toolContext);
-      const resultStr = typeof result === 'string' ? result : JSON.stringify(result);
+      const resultStr0 = typeof result === 'string' ? result : JSON.stringify(result);
+      const resultStr = capToolResultString(name, resultStr0);
       if (onChunk) onChunk({ type: 'tool_result', toolCallId: id, result: resultStr });
       rtEmittedResultIds.add(id);
-      return result;
+      return resultStr;
     };
     const directTools = toolDefinitions?.length
       ? await createLangChainToolsFromOpenAIDefinitions(toolDefinitions, executeFn)
@@ -898,7 +935,9 @@ async function createConfiguredLangGraphAgent(llm, opts) {
     const mainAgentTools = await createLangChainToolsFromOpenAIDefinitions(mainAgentDefs, async (name, args) => {
       const capError = callCounter.check(name);
       if (capError) return { error: capError };
-      return executeToolInMain(name, args, toolContext);
+      const result = await executeToolInMain(name, args, toolContext);
+      const resultStr0 = typeof result === 'string' ? result : JSON.stringify(result);
+      return capToolResultString(name, resultStr0);
     });
     tools = [...subagentTools, ...asyncSubagentTools, ...mcpTools, ...mainAgentTools];
   }
@@ -931,10 +970,12 @@ async function createConfiguredLangGraphAgent(llm, opts) {
         },
       },
     ];
-    const domeLoadDocTools = await createLangChainToolsFromOpenAIDefinitions(domeLoadDocDef, (name, args) => {
+    const domeLoadDocTools = await createLangChainToolsFromOpenAIDefinitions(domeLoadDocDef, async (name, args) => {
       const capError = callCounter.check(name);
       if (capError) return { error: capError };
-      return executeToolInMain(name, args, toolContext);
+      const result = await executeToolInMain(name, args, toolContext);
+      const resultStr0 = typeof result === 'string' ? result : JSON.stringify(result);
+      return capToolResultString(name, resultStr0);
     });
     tools = [...domeLoadDocTools, ...tools];
   }
@@ -969,10 +1010,12 @@ async function createConfiguredLangGraphAgent(llm, opts) {
       });
     }
     if (rtDefs.length > 0) {
-      const rtTools = await createLangChainToolsFromOpenAIDefinitions(rtDefs, (name, args) => {
+      const rtTools = await createLangChainToolsFromOpenAIDefinitions(rtDefs, async (name, args) => {
         const capError = callCounter.check(name);
         if (capError) return { error: capError };
-        return executeToolInMain(name, args, toolContext);
+        const result = await executeToolInMain(name, args, toolContext);
+        const resultStr0 = typeof result === 'string' ? result : JSON.stringify(result);
+        return capToolResultString(name, resultStr0);
       });
       tools = [...tools, ...rtTools];
     }
@@ -984,6 +1027,8 @@ async function createConfiguredLangGraphAgent(llm, opts) {
     descriptionPrefix: 'Acción pendiente de aprobación',
   });
   const trimMiddleware = await createTrimmingMiddleware(provider, llm);
+  const summarizationMw = await createSummarizationMiddlewareMaybe(provider, llm);
+  const contextMiddlewares = summarizationMw ? [summarizationMw, trimMiddleware] : [trimMiddleware];
 
   /** LangChain / deepagents sandbox: isolated VFS + execute (read_file, write_file, …). */
   let fsMiddleware = null;
@@ -995,12 +1040,12 @@ async function createConfiguredLangGraphAgent(llm, opts) {
     }
   }
 
-  // Order: trim → optional sandbox FS/execute (LangChain) → HITL when enabled.
+  // Order: optional summarization → trim → optional sandbox FS/execute → HITL when enabled.
   const middleware = (() => {
     if (skipHitl) {
-      return fsMiddleware ? [trimMiddleware, fsMiddleware] : [trimMiddleware];
+      return fsMiddleware ? [...contextMiddlewares, fsMiddleware] : [...contextMiddlewares];
     }
-    return fsMiddleware ? [trimMiddleware, fsMiddleware, hitlMiddleware] : [trimMiddleware, hitlMiddleware];
+    return fsMiddleware ? [...contextMiddlewares, fsMiddleware, hitlMiddleware] : [...contextMiddlewares, hitlMiddleware];
   })();
 
   const agent = createAgent({
@@ -1041,6 +1086,16 @@ async function invokeLangGraphAgent(opts) {
   const mcpServerIds = opts.mcpServerIds;
   const subagentIds = Array.isArray(opts.subagentIds) ? opts.subagentIds : undefined;
 
+  let domeMessages = Array.isArray(messages) ? [...messages] : [];
+  try {
+    const agentsMd = projectMemory.loadProjectAgentsMarkdown(skillRegistry.getProjectRoot());
+    if (agentsMd) {
+      domeMessages = projectMemory.injectProjectMemoryIntoMessages(domeMessages, agentsMd);
+    }
+  } catch (e) {
+    console.warn('[AI LangGraph] project memory (AGENTS.md) skipped:', e?.message || e);
+  }
+
   try {
     const { agent, rtEmittedCallIds, rtEmittedResultIds } = await createConfiguredLangGraphAgent(llm, {
       useDirectTools,
@@ -1058,12 +1113,12 @@ async function invokeLangGraphAgent(opts) {
 
     // Trimming is handled inside the graph by `DomeTrimMessages` middleware so
     // that intermediate tool turns also stay within the provider budget.
-    const lcMessages = await toLangChainMessages(messages);
+    const lcMessages = await toLangChainMessages(domeMessages);
 
     // Emit token budget breakdown for telemetry (first message of the run only).
     if (onChunk) {
-      const sysMsg = Array.isArray(messages) ? messages.find((m) => m.role === 'system') : null;
-      const histMsgs = Array.isArray(messages) ? messages.filter((m) => m.role !== 'system') : [];
+      const sysMsg = Array.isArray(domeMessages) ? domeMessages.find((m) => m.role === 'system') : null;
+      const histMsgs = Array.isArray(domeMessages) ? domeMessages.filter((m) => m.role !== 'system') : [];
       const budgetBreakdown = measurePrompt({
         system: sysMsg?.content || '',
         tools: opts.toolDefinitions || [],

--- a/electron/project-memory.cjs
+++ b/electron/project-memory.cjs
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * Optional project-level "memory" (AGENTS.md at workspace root).
+ * Same idea as LangChain Deep Agents / agents.md — keep small; skills carry detail.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_MAX_CHARS = 14_000;
+
+/**
+ * @param {string | null | undefined} projectRoot - absolute workspace path
+ * @param {{ maxChars?: number }} [opts]
+ * @returns {string} Markdown block to append to system prompt, or empty string
+ */
+function loadProjectAgentsMarkdown(projectRoot, opts = {}) {
+  const maxChars = typeof opts.maxChars === 'number' && opts.maxChars > 500 ? opts.maxChars : DEFAULT_MAX_CHARS;
+  if (!projectRoot || typeof projectRoot !== 'string') return '';
+  const trimmed = projectRoot.trim();
+  if (!trimmed) return '';
+  const absRoot = path.resolve(trimmed);
+  const agentsPath = path.join(absRoot, 'AGENTS.md');
+  try {
+    if (!fs.existsSync(agentsPath) || !fs.statSync(agentsPath).isFile()) return '';
+    const raw = fs.readFileSync(agentsPath, 'utf8');
+    if (!raw || !String(raw).trim()) return '';
+    const text = String(raw).trim();
+    const body = text.length > maxChars ? `${text.slice(0, maxChars)}\n\n[AGENTS.md truncated at ${maxChars} chars for context budget]` : text;
+    return `## Project memory (AGENTS.md)\n\n${body}\n`;
+  } catch (e) {
+    console.warn('[ProjectMemory] read AGENTS.md failed:', agentsPath, e?.message || e);
+    return '';
+  }
+}
+
+/**
+ * @param {Array<{ role: string; content?: string }>} messages - Dome chat shape
+ * @param {string} block - markdown from loadProjectAgentsMarkdown
+ * @returns {Array<{ role: string; content: string }>}
+ */
+function injectProjectMemoryIntoMessages(messages, block) {
+  if (!block || !Array.isArray(messages) || messages.length === 0) return messages;
+  const first = messages[0];
+  if (first && first.role === 'system' && typeof first.content === 'string') {
+    const next = [...messages];
+    next[0] = { ...first, content: `${first.content.trimEnd()}\n\n${block}` };
+    return next;
+  }
+  return [{ role: 'system', content: block }, ...messages];
+}
+
+module.exports = { loadProjectAgentsMarkdown, injectProjectMemoryIntoMessages };

--- a/electron/run-engine.cjs
+++ b/electron/run-engine.cjs
@@ -7,6 +7,7 @@ const { getToolDefinitionsByIds } = require('./tool-dispatcher.cjs');
 const streamingTts = require('./streaming-tts.cjs');
 const { getOpenAIKey } = require('./openai-key.cjs');
 const { appendSkillsToPrompt, filterToolsBySkill } = require('./skill-prompt.cjs');
+const { parseRuntimeContext } = require('./agent-runtime-context.cjs');
 
 const RUN_EVENT_CHANNEL = 'runs:updated';
 const RUN_STEP_CHANNEL = 'runs:step';
@@ -1028,13 +1029,12 @@ async function executeLangGraphRun(runId, params) {
     subagentIds: params.ownerType === 'many' ? [] : params.subagentIds,
     skipHitl: !!params.skipHitl,
     automationProjectId,
+    runtimeContext,
   };
-  const runtimeContext = (params.contextId || (Array.isArray(params.pinnedResourceIds) && params.pinnedResourceIds.length > 0))
-    ? {
-        activeResourceId: params.contextId || null,
-        pinnedResourceIds: Array.isArray(params.pinnedResourceIds) ? params.pinnedResourceIds : [],
-      }
-    : null;
+  const runtimeContext = parseRuntimeContext({
+    activeResourceId: params.contextId || null,
+    pinnedResourceIds: Array.isArray(params.pinnedResourceIds) ? params.pinnedResourceIds : [],
+  });
 
   try {
     const result = await langgraphAgent.invokeLangGraphAgent({
@@ -1244,6 +1244,7 @@ async function resumeRun(runId, decisions) {
       mcpServerIds: undefined,
       subagentIds: undefined,
       skipHitl: false,
+      runtimeContext: null,
     };
     await langgraphAgent.resumeLangGraphAgent({
       provider: providerConfig.provider,
@@ -1260,6 +1261,7 @@ async function resumeRun(runId, decisions) {
       mcpServerIds: lgOpts.mcpServerIds,
       subagentIds: lgOpts.subagentIds,
       skipHitl: lgOpts.skipHitl,
+      runtimeContext: lgOpts.runtimeContext,
       automationProjectId:
         run.automationId ? (run.projectId ?? 'default') : lgOpts.automationProjectId,
     });

--- a/electron/skill-prompt.cjs
+++ b/electron/skill-prompt.cjs
@@ -4,6 +4,10 @@
  */
 const registry = require('./skills/registry.cjs');
 const { renderSkillBody } = require('./skills/renderer.cjs');
+const { capToolResultString } = require('./tool-result-cap.cjs');
+
+/** Max rendered SKILL.md body chars before asking model to call load_skill (context engineering). */
+const SKILL_BODY_PREVIEW_CHARS = 3600;
 
 function getDisableShellFromQueries(queries) {
   if (!queries?.getSetting) return false;
@@ -24,7 +28,7 @@ function appendSkillsToPrompt(basePrompt, skillIds, queries) {
     if (typeof id !== 'string') continue;
     const rec = registry.getById(id) || registry.resolve(id);
     if (!rec) continue;
-    const body = renderSkillBody(rec.body, {
+    const bodyRaw = renderSkillBody(rec.body, {
       argumentsLine: '',
       namedArgs: rec.arguments,
       sessionId: '',
@@ -32,7 +36,12 @@ function appendSkillsToPrompt(basePrompt, skillIds, queries) {
       shell: rec.shell,
       disableSkillShellExecution: disableShell,
     });
-    if (!String(body).trim()) continue;
+    if (!String(bodyRaw).trim()) continue;
+    const slug = String(rec.slashName || rec.dirName || id || '').trim();
+    let body = String(bodyRaw).trim();
+    if (body.length > SKILL_BODY_PREVIEW_CHARS) {
+      body = `${body.slice(0, SKILL_BODY_PREVIEW_CHARS)}…\n\n[Truncated — call load_skill('${slug}') for the full skill body.]`;
+    }
     const title = rec.name || 'Skill';
     chunks.push(`### ${title}\n${body}\n`);
   }

--- a/electron/skills/registry.cjs
+++ b/electron/skills/registry.cjs
@@ -153,6 +153,11 @@ function getAllIds() {
   return Array.from(skillsById.keys());
 }
 
+/** Absolute workspace root when set (Skills settings / project folder). */
+function getProjectRoot() {
+  return _projectRoot;
+}
+
 module.exports = {
   setContext,
   setProjectRoot,
@@ -161,6 +166,7 @@ module.exports = {
   resolve,
   list,
   getAllIds,
+  getProjectRoot,
   collectWatchRoots,
   getPersonalSkillsRoot,
   getBundledSkillsRoot,

--- a/electron/subagents.cjs
+++ b/electron/subagents.cjs
@@ -15,6 +15,7 @@ const toolDispatcher = require('./tool-dispatcher.cjs');
 const vfsThread = require('./langgraph-vfs-thread.cjs');
 const { executeToolInMain, getToolDefsBySubagent } = toolDispatcher;
 const { readPrompt } = require('./prompts-loader.cjs');
+const { capToolResultString } = require('./tool-result-cap.cjs');
 
 /** Canonical subagent names. Order matters: it's the default tool order
  *  the supervisor sees, and the supervisor's choice can be order-biased. */
@@ -96,9 +97,10 @@ async function buildSubagentRunner(agentName, llm, executeFn, createLangChainToo
           },
         });
         const result = await executeFn(name, args);
-        const resultStr = typeof result === 'string' ? result : JSON.stringify(result);
+        const resultStr0 = typeof result === 'string' ? result : JSON.stringify(result);
+        const resultStr = capToolResultString(name, resultStr0);
         onChunk({ type: 'tool_result', toolCallId: id, result: resultStr });
-        return result;
+        return resultStr;
       }
     : executeFn;
 
@@ -166,7 +168,7 @@ async function createSubagentAsTool(agentName, llm, executeFn, createLangChainTo
   const description = SUBAGENT_DESCRIPTIONS[agentName] || `Delegate to the ${agentName} subagent.`;
 
   return tool(
-    async ({ query }) => runner.run(query),
+    async ({ query }) => capToolResultString(name, await runner.run(query)),
     {
       name,
       description,

--- a/electron/tool-result-cap.cjs
+++ b/electron/tool-result-cap.cjs
@@ -1,0 +1,24 @@
+'use strict';
+
+/** ~12k tokens at chars/4 — keeps tool-heavy turns inside rough budgets before trim. */
+const DEFAULT_MAX_CHARS = 48_000;
+
+/**
+ * @param {string} toolName
+ * @param {string} text
+ * @param {{ maxChars?: number }} [opts]
+ * @returns {string}
+ */
+function capToolResultString(toolName, text, opts = {}) {
+  const maxChars = typeof opts.maxChars === 'number' && opts.maxChars > 2000 ? opts.maxChars : DEFAULT_MAX_CHARS;
+  const s = typeof text === 'string' ? text : String(text ?? '');
+  if (s.length <= maxChars) return s;
+  const head = Math.floor(maxChars * 0.5);
+  return (
+    `${s.slice(0, head)}\n\n` +
+    `[Dome: tool result truncated — ${s.length} chars → ~${head} shown. Tool: ${toolName}. ` +
+    `Use smaller pages/batches, filters, or follow-up calls to retrieve the rest.]`
+  );
+}
+
+module.exports = { capToolResultString, DEFAULT_MAX_CHARS };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Se valida `runtimeContext` con Zod al arrancar runs LangGraph y se reenvía en la reanudación HITL.
- Si existe `AGENTS.md` en la raíz del workspace (Skills / carpeta de proyecto), se inyecta en el system prompt de cada invocación LangGraph con techo de caracteres.
- Se encadena `summarizationMiddleware` de LangChain antes del recorte por tokens (desactivable con `DOME_LANGGRAPH_SUMMARIZATION=0`).
- Se limitan resultados muy grandes de herramientas y salidas de subagentes; los skills en archivo se truncan con indicación de usar `load_skill`.
- `appendSkillsMarkdown` admite límite por skill (por defecto ~3800 caracteres) para el chat de agentes en SQLite.

## Type

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs / config

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (solo warnings preexistentes)
- [x] `npm run build` passes
- [x] i18n keys added in all 4 languages (en, es, fr, pt) if new user-visible strings — N/A
- [x] No hardcoded colors (CSS variables only) — N/A

## Notas

- **AGENTS.md**: requiere la misma raíz de proyecto que usa el registro de skills (`skills:setProjectRoot` / Ajustes).
- **Resumen**: puede aumentar llamadas al modelo cuando el historial se acerca al umbral; desactivar con `DOME_LANGGRAPH_SUMMARIZATION=0` si hiciera falta.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22e1957f-731d-49d0-99d3-165345cd18e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22e1957f-731d-49d0-99d3-165345cd18e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

