### PR TITLE
fix: semantic reindex stability (ONNX reset, memory caps)

### DIFF
--- a/electron/database.cjs
+++ b/electron/database.cjs
@@ -3481,6 +3481,25 @@ function getQueries() {
       WHERE resource_id = ? AND model_version = ?
       ORDER BY chunk_index ASC
     `),
+    /** Barato: dimensionar muestreo de embeddings sin cargar blobs. */
+    countChunksByResourceForModel: db.prepare(`
+      SELECT COUNT(*) AS c FROM resource_chunks
+      WHERE resource_id = ? AND model_version = ?
+    `),
+    /**
+     * Solo filas cuyo ROW_NUMBER (orden chunk_index) está en la lista JSON (enteros 1-based).
+     * Evita `getChunkEmbeddingsByResourceForModel` + miles de blobs en RAM por recurso vecino.
+     */
+    getChunkEmbeddingsByRankSampleForModel: db.prepare(`
+      WITH ranked AS (
+        SELECT embedding, ROW_NUMBER() OVER (ORDER BY chunk_index) AS rn
+        FROM resource_chunks
+        WHERE resource_id = ? AND model_version = ?
+      )
+      SELECT embedding FROM ranked
+      WHERE rn IN (SELECT CAST(value AS INTEGER) FROM json_each(?))
+      ORDER BY rn
+    `),
     getChunkRowsForSemanticSearch: db.prepare(`
       SELECT c.id, c.resource_id, c.chunk_index, c.char_start, c.char_end, c.page_number, c.text, c.embedding,
              r.title AS res_title, r.type AS res_type

--- a/electron/services/embeddings.service.cjs
+++ b/electron/services/embeddings.service.cjs
@@ -33,11 +33,10 @@ function runEmbedExclusive(fn) {
 }
 
 /**
- * The ONNX session can SIGTRAP after many sequential inferences without a session reset
- * (same issue as consecutive reindexAll calls). Reset every N inferences to keep the
- * session fresh and prevent the crash.
+ * Reinicia la sesión ONNX cada N **lotes** dentro de `embedDocuments` (no por invocación
+ * al handler). Un solo documento con miles de chunks dispara cientos de `pipe()` seguidos;
+ * sin esto el runtime nativo puede SIGTRAP / crashear (reindexación masiva).
  */
-let _embedInvocationCount = 0;
 const PIPELINE_RESET_INTERVAL = 25;
 
 /**
@@ -73,7 +72,6 @@ async function getPipeline() {
  */
 function resetPipeline() {
   _pipelinePromise = null;
-  _embedInvocationCount = 0;
 }
 
 /**
@@ -113,16 +111,18 @@ function tensorToRowVectors(tensor) {
  */
 async function embedDocuments(texts) {
   return runEmbedExclusive(async () => {
-    // Periodically reset the ONNX session to avoid the session-corruption SIGTRAP that
-    // occurs after many sequential inferences (same bug as consecutive reindexAll calls).
-    _embedInvocationCount += 1;
-    if (_embedInvocationCount % PIPELINE_RESET_INTERVAL === 0) {
-      resetPipeline();
-    }
-    const pipe = await getPipeline();
     const inputs = (texts || []).map((t) => `search_document: ${String(t ?? '')}`);
+    if (inputs.length === 0) {
+      return [];
+    }
     const out = [];
+    let pipe = await getPipeline();
+    let batchIdx = 0;
     for (let i = 0; i < inputs.length; i += EMBED_BATCH) {
+      if (batchIdx > 0 && batchIdx % PIPELINE_RESET_INTERVAL === 0) {
+        resetPipeline();
+        pipe = await getPipeline();
+      }
       const slice = inputs.slice(i, i + EMBED_BATCH);
       let tensor;
       try {
@@ -132,6 +132,11 @@ async function embedDocuments(texts) {
         throw e;
       }
       out.push(...tensorToRowVectors(tensor));
+      batchIdx += 1;
+      // Deja respirar al bucle de Node / Electron entre lotes muy largos (OOM / UI freeze).
+      if (batchIdx % 32 === 0) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
     }
     return out;
   });

--- a/electron/services/embeddings.service.cjs
+++ b/electron/services/embeddings.service.cjs
@@ -37,7 +37,7 @@ function runEmbedExclusive(fn) {
  * al handler). Un solo documento con miles de chunks dispara cientos de `pipe()` seguidos;
  * sin esto el runtime nativo puede SIGTRAP / crashear (reindexación masiva).
  */
-const PIPELINE_RESET_INTERVAL = 25;
+const PIPELINE_RESET_INTERVAL = 10;
 
 /**
  * @param {{ modelsDir: string }} opts
@@ -111,19 +111,23 @@ function tensorToRowVectors(tensor) {
  */
 async function embedDocuments(texts) {
   return runEmbedExclusive(async () => {
-    const inputs = (texts || []).map((t) => `search_document: ${String(t ?? '')}`);
-    if (inputs.length === 0) {
+    const arr = texts || [];
+    const len = arr.length;
+    if (len === 0) {
       return [];
     }
     const out = [];
     let pipe = await getPipeline();
     let batchIdx = 0;
-    for (let i = 0; i < inputs.length; i += EMBED_BATCH) {
+    for (let i = 0; i < len; i += EMBED_BATCH) {
       if (batchIdx > 0 && batchIdx % PIPELINE_RESET_INTERVAL === 0) {
         resetPipeline();
         pipe = await getPipeline();
       }
-      const slice = inputs.slice(i, i + EMBED_BATCH);
+      const slice = [];
+      for (let j = i; j < Math.min(i + EMBED_BATCH, len); j++) {
+        slice.push(`search_document: ${String(arr[j] ?? '')}`);
+      }
       let tensor;
       try {
         tensor = await pipe(slice, { pooling: 'mean', normalize: true });
@@ -134,7 +138,7 @@ async function embedDocuments(texts) {
       out.push(...tensorToRowVectors(tensor));
       batchIdx += 1;
       // Deja respirar al bucle de Node / Electron entre lotes muy largos (OOM / UI freeze).
-      if (batchIdx % 32 === 0) {
+      if (batchIdx % 16 === 0) {
         await new Promise((resolve) => setImmediate(resolve));
       }
     }

--- a/electron/services/indexing.pipeline.cjs
+++ b/electron/services/indexing.pipeline.cjs
@@ -23,6 +23,29 @@ const TOP_K = 8;
 const MAX_CHUNKS_PER_RESOURCE = 5000;
 /** Máx. embeddings por recurso al calcular centroides (reindex de docs enormes + biblioteca grande). */
 const MAX_EMBEDDINGS_FOR_CENTROID = 384;
+/** Evita cargar notas/PDF enormes en un solo string antes del chunking (OOM del proceso). */
+const MAX_INDEXABLE_TEXT_CHARS = 6_000_000;
+
+/**
+ * Rangos 1-based de ROW_NUMBER() para muestrear filas sin leer todos los blobs en RAM.
+ * @param {number} cnt
+ * @param {number} k
+ * @returns {number[]}
+ */
+function pickEvenlySpacedRanks1Based(cnt, k) {
+  const n = Math.max(0, Math.floor(Number(cnt)) || 0);
+  if (n === 0) return [];
+  const kk = Math.max(1, Math.floor(Number(k)) || 1);
+  if (n <= kk) {
+    return Array.from({ length: n }, (_, i) => i + 1);
+  }
+  const out = [];
+  for (let j = 0; j < kk; j++) {
+    const rn = 1 + Math.min(n - 1, Math.floor((j * (n - 1)) / Math.max(1, kk - 1)));
+    out.push(rn);
+  }
+  return [...new Set(out)].sort((a, b) => a - b);
+}
 
 /**
  * @template T
@@ -190,6 +213,12 @@ function createIndexer(opts) {
       return { ok: true, skipped: true, reason: 'empty_text' };
     }
 
+    if (text.length > MAX_INDEXABLE_TEXT_CHARS) {
+      text =
+        text.slice(0, MAX_INDEXABLE_TEXT_CHARS) +
+        '\n\n[Dome: texto truncado para indexación por límite de tamaño]';
+    }
+
     let chunks;
     try {
       chunks = chunkText(text);
@@ -255,11 +284,23 @@ function createIndexer(opts) {
     /** @type {{ targetId: string, sim: number }[]} */
     const relations = [];
     const otherIds = queries.getDistinctChunkResourceIdsExcluding.all(MODEL_VERSION, resourceId);
+    let relScan = 0;
     for (const row of otherIds) {
+      relScan += 1;
+      if (relScan % 48 === 0) {
+        await new Promise((r) => setImmediate(r));
+      }
       const otherId = row.resource_id;
-      const embRowsRaw = queries.getChunkEmbeddingsByResourceForModel.all(otherId, MODEL_VERSION);
-      if (!embRowsRaw.length) continue;
-      const embRows = sampleEvenlyForCentroid(embRowsRaw);
+      const cntRow = queries.countChunksByResourceForModel.get(otherId, MODEL_VERSION);
+      const cnt = Number(cntRow?.c ?? 0) || 0;
+      if (!cnt) continue;
+      const ranks = pickEvenlySpacedRanks1Based(cnt, MAX_EMBEDDINGS_FOR_CENTROID);
+      const embRows = queries.getChunkEmbeddingsByRankSampleForModel.all(
+        otherId,
+        MODEL_VERSION,
+        JSON.stringify(ranks),
+      );
+      if (!embRows.length) continue;
       /** @type {Float32Array[]} */
       const ovecs = [];
       for (const er of embRows) {

--- a/electron/services/indexing.pipeline.cjs
+++ b/electron/services/indexing.pipeline.cjs
@@ -21,6 +21,25 @@ const DEFAULT_THRESHOLD = 0.45;
 const TOP_K = 8;
 /** Límite de fragmentos por recurso para evitar OOM en embeddings / SQLite. */
 const MAX_CHUNKS_PER_RESOURCE = 5000;
+/** Máx. embeddings por recurso al calcular centroides (reindex de docs enormes + biblioteca grande). */
+const MAX_EMBEDDINGS_FOR_CENTROID = 384;
+
+/**
+ * @template T
+ * @param {T[]} items
+ * @returns {T[]}
+ */
+function sampleEvenlyForCentroid(items) {
+  if (!Array.isArray(items) || items.length <= MAX_EMBEDDINGS_FOR_CENTROID) return items;
+  const n = items.length;
+  const k = MAX_EMBEDDINGS_FOR_CENTROID;
+  const out = [];
+  for (let j = 0; j < k; j++) {
+    const idx = n <= 1 ? 0 : Math.min(n - 1, Math.floor((j * (n - 1)) / Math.max(1, k - 1)));
+    out.push(items[idx]);
+  }
+  return out;
+}
 
 /**
  * @param {Float32Array | null} a
@@ -227,7 +246,7 @@ function createIndexer(opts) {
 
     queries.deleteSemanticAutoFromSource.run(resourceId);
 
-    const myCentroid = centroidL2Normalized(vectors);
+    const myCentroid = centroidL2Normalized(sampleEvenlyForCentroid(vectors));
     if (!myCentroid) {
       finalizeArtifactSearchSurface(queries, resource);
       return { ok: true, count: 0, chunks: chunks.length, textSource: source };
@@ -238,8 +257,9 @@ function createIndexer(opts) {
     const otherIds = queries.getDistinctChunkResourceIdsExcluding.all(MODEL_VERSION, resourceId);
     for (const row of otherIds) {
       const otherId = row.resource_id;
-      const embRows = queries.getChunkEmbeddingsByResourceForModel.all(otherId, MODEL_VERSION);
-      if (!embRows.length) continue;
+      const embRowsRaw = queries.getChunkEmbeddingsByResourceForModel.all(otherId, MODEL_VERSION);
+      if (!embRowsRaw.length) continue;
+      const embRows = sampleEvenlyForCentroid(embRowsRaw);
       /** @type {Float32Array[]} */
       const ovecs = [];
       for (const er of embRows) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Qué pasaba
La reindexación de documentos muy grandes podía tumbar el proceso por:
- **ONNX / `@huggingface/transformers`**: muchas llamadas seguidas a `pipe()` sin refrescar la sesión.
- **RAM**: al recalcular relaciones semánticas se hacía `SELECT embedding ...` de **todos** los chunks de cada recurso vecino y solo después se muestreaba en JS — con miles de blobs por recurso el pico de memoria seguía siendo enorme.
- **Texto indexable**: notas/PDF con `content` gigante se cargaban enteros antes del chunking.

## Cambios (último commit)
- **SQLite**: `countChunksByResourceForModel` + `getChunkEmbeddingsByRankSampleForModel` (CTE + `ROW_NUMBER` + `json_each`) para leer solo ~384 embeddings por vecino.
- **Pipeline**: tope de **6M caracteres** de texto antes de `chunkText`; `setImmediate` cada 48 vecinos en el bucle de relaciones.
- **embeddings.service**: lotes sin duplicar todo el corpus en un array prefijado; reset del pipeline cada **10** lotes; ceder el bucle cada **16** lotes.

Tras fusionar, vuelve a probar reindexar el documento problemático. Si sigue crasheando, conviene copiar la salida del terminal (últimas líneas antes del cierre) o el mensaje de macOS «Problem Report» para ver si es SIGTRAP del runtime nativo u otro motivo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22e1957f-731d-49d0-99d3-165345cd18e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22e1957f-731d-49d0-99d3-165345cd18e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

