### PR TITLE
fix: prevent OOM crash when indexing large PDFs (>59 pages)

### DIFF
--- a/electron/pdf-extractor.cjs
+++ b/electron/pdf-extractor.cjs
@@ -440,6 +440,100 @@ async function getPdfFilePathFromResource(resourceId, database) {
   }
 }
 
+/**
+ * Load a PDF document once from disk. Returns { doc, numPages } for reuse across pages.
+ * Caller must call destroyPdfDocument(doc) when finished to free pdfjs internal resources.
+ * @param {string} filePath
+ * @returns {Promise<{ doc: any, numPages: number } | null>}
+ */
+async function openPdfDocument(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return null;
+  const pdfjs = await loadPdfJs();
+  if (!pdfjs?.getDocument) return null;
+  try {
+    const data = new Uint8Array(fs.readFileSync(filePath));
+    const loadingTask = pdfjs.getDocument({ data, disableFontFace: true, useSystemFonts: true });
+    const doc = await loadingTask.promise;
+    return { doc, numPages: doc.numPages };
+  } catch (error) {
+    console.error('[PDF Extractor] openPdfDocument:', error.message);
+    return null;
+  }
+}
+
+/**
+ * Explicitly destroy a pdfjs document to free internal worker buffers.
+ * @param {any} pdfDoc
+ */
+async function destroyPdfDocument(pdfDoc) {
+  if (!pdfDoc) return;
+  try {
+    await pdfDoc.destroy();
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Render one PDF page to a PNG data URL from an already-loaded pdfDoc.
+ * Use openPdfDocument() once and pass the returned doc here for each page.
+ * @param {any} pdfDoc
+ * @param {number} pageNum
+ * @param {number} [scale]
+ * @returns {Promise<{ success: boolean, dataUrl?: string, error?: string }>}
+ */
+async function renderPdfPageFromDoc(pdfDoc, pageNum = 1, scale = 1.5) {
+  if (!pdfDoc) return { success: false, error: 'No pdfDoc provided' };
+
+  let createCanvas;
+  try {
+    createCanvas = require('@napi-rs/canvas').createCanvas;
+  } catch (e) {
+    return { success: false, error: 'Canvas not available: ' + (e?.message || e) };
+  }
+
+  try {
+    const p = Math.min(Math.max(1, pageNum), pdfDoc.numPages);
+    const page = await pdfDoc.getPage(p);
+    const viewport = page.getViewport({ scale });
+    const w = Math.max(1, Math.floor(viewport.width));
+    const h = Math.max(1, Math.floor(viewport.height));
+    const canvas = createCanvas(w, h);
+    const ctx = canvas.getContext('2d');
+    const renderTask = page.render({ canvasContext: ctx, viewport, canvas });
+    await renderTask.promise;
+    const buf = canvas.toBuffer('image/png');
+    const dataUrl = `data:image/png;base64,${buf.toString('base64')}`;
+    page.cleanup();
+    return { success: true, dataUrl };
+  } catch (error) {
+    console.error('[PDF Extractor] renderPdfPageFromDoc:', error.message);
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Extract text from a single page of an already-loaded pdfDoc.
+ * @param {any} pdfDoc
+ * @param {number} pageNum
+ * @param {number} [maxChars]
+ * @returns {Promise<string>}
+ */
+async function extractTextFromDocPage(pdfDoc, pageNum = 1, maxChars = 100000) {
+  if (!pdfDoc) return '';
+  try {
+    const p = Math.min(Math.max(1, pageNum), pdfDoc.numPages);
+    const page = await pdfDoc.getPage(p);
+    const textContent = await page.getTextContent();
+    const raw = textContent.items.map((item) => item.str || '').join(' ');
+    page.cleanup();
+    return raw.length > maxChars ? raw.slice(0, maxChars) : raw;
+  } catch (error) {
+    console.error('[PDF Extractor] extractTextFromDocPage page', pageNum, error.message);
+    return '';
+  }
+}
+
 module.exports = {
   extractPdfText,
   getPdfMetadata,
@@ -448,4 +542,8 @@ module.exports = {
   extractPdfTables,
   getPdfFilePathFromResource,
   renderPdfPagePngDataUrl,
+  openPdfDocument,
+  destroyPdfDocument,
+  renderPdfPageFromDoc,
+  extractTextFromDocPage,
 };

--- a/electron/services/lancedb-semantic.cjs
+++ b/electron/services/lancedb-semantic.cjs
@@ -15,6 +15,8 @@ const INDEXED_TABLE = 'indexed_resources';
 const MODEL_VERSION = 'nomic-embed-text-v1.5';
 const EMBED_DIM = 768;
 const MAX_LEX_CHARS = 500_000;
+/** Max rows per LanceDB add() call to avoid large Arrow batch allocations for big PDFs. */
+const LANCE_WRITE_BATCH = 250;
 
 /** @type {string | null} */
 let _root = null;
@@ -182,7 +184,10 @@ async function replaceResourceChunks(resourceId, rows) {
     res_type: String(r.res_type ?? ''),
     project_id: String(r.project_id ?? ''),
   }));
-  await _chunks.add(batch);
+  for (let i = 0; i < batch.length; i += LANCE_WRITE_BATCH) {
+    await _chunks.add(batch.slice(i, i + LANCE_WRITE_BATCH));
+    if (i + LANCE_WRITE_BATCH < batch.length) await new Promise((r) => setImmediate(r));
+  }
   await markIndexed(resourceId);
 }
 

--- a/electron/services/pdf-transcription.cjs
+++ b/electron/services/pdf-transcription.cjs
@@ -22,11 +22,22 @@ function getModelVersionLabel() {
  * @param {number} numPages
  */
 async function buildPdfjsMarkedText(fullPath, numPages) {
+  const session = await pdfExtractor.openPdfDocument(fullPath);
+  if (!session) {
+    // Fallback: load once via extractPdfText (full document, all pages).
+    const r = await pdfExtractor.extractPdfText(fullPath, { maxChars: numPages * 100000 });
+    return r.success && r.text ? r.text : '';
+  }
   const parts = [];
-  for (let p = 1; p <= numPages; p++) {
-    const r = await pdfExtractor.extractPdfText(fullPath, { maxChars: 100000, pages: String(p) });
-    const t = (r.success && r.text ? String(r.text) : '').trim();
-    parts.push(`<!-- page:${p} -->\n\n${t}`);
+  try {
+    for (let p = 1; p <= numPages; p++) {
+      const t = await pdfExtractor.extractTextFromDocPage(session.doc, p, 100000);
+      parts.push(`<!-- page:${p} -->\n\n${t.trim()}`);
+      // Yield to event loop every 10 pages so V8 GC can collect intermediate objects.
+      if (p % 10 === 0) await new Promise((r) => setImmediate(r));
+    }
+  } finally {
+    await pdfExtractor.destroyPdfDocument(session.doc);
   }
   return parts.join('\n\n');
 }
@@ -97,37 +108,52 @@ async function extractPdfTextWithCloud(resource, queries, opts = {}) {
 
   const parts = [];
 
-  for (let p = 1; p <= numPages; p++) {
-    const rend = await pdfExtractor.renderPdfPagePngDataUrl(fullPath, p, SCALE);
-    if (!rend.success || !rend.dataUrl) {
-      console.warn('[pdf-transcription] render failed page', p, rend.error);
-      parts.push(`<!-- page:${p} -->\n\n`);
+  // Load the PDF document ONCE and reuse it across all pages to avoid re-reading
+  // the entire file from disk and re-parsing it for every single page (OOM on large PDFs).
+  const docSession = await pdfExtractor.openPdfDocument(fullPath);
+
+  try {
+    for (let p = 1; p <= numPages; p++) {
+      let rend;
+      if (docSession) {
+        rend = await pdfExtractor.renderPdfPageFromDoc(docSession.doc, p, SCALE);
+      } else {
+        rend = await pdfExtractor.renderPdfPagePngDataUrl(fullPath, p, SCALE);
+      }
+      if (!rend.success || !rend.dataUrl) {
+        console.warn('[pdf-transcription] render failed page', p, rend.error);
+        parts.push(`<!-- page:${p} -->\n\n`);
+        onProgress?.({ done: p, total: numPages, page: p });
+        continue;
+      }
+      let md = '';
+      try {
+        md = await cloudLlmTasks.transcribePdfPage(gen, rend.dataUrl, p);
+      } catch (e) {
+        console.warn('[pdf-transcription] transcribe page', p, e?.message || e);
+      }
+      md = String(md || '').trim();
+      parts.push(`<!-- page:${p} -->\n\n${md}`);
+
+      try {
+        queries.upsertResourceTranscript.run(
+          resourceId,
+          p,
+          md,
+          modelUsed,
+          fileHash || null,
+          now,
+        );
+      } catch (e) {
+        console.warn('[pdf-transcription] upsert transcript', p, e?.message || e);
+      }
+
       onProgress?.({ done: p, total: numPages, page: p });
-      continue;
+      // Yield every page so V8 GC can reclaim the PNG buffer and canvas objects.
+      await new Promise((r) => setImmediate(r));
     }
-    let md = '';
-    try {
-      md = await cloudLlmTasks.transcribePdfPage(gen, rend.dataUrl, p);
-    } catch (e) {
-      console.warn('[pdf-transcription] transcribe page', p, e?.message || e);
-    }
-    md = String(md || '').trim();
-    parts.push(`<!-- page:${p} -->\n\n${md}`);
-
-    try {
-      queries.upsertResourceTranscript.run(
-        resourceId,
-        p,
-        md,
-        modelUsed,
-        fileHash || null,
-        now,
-      );
-    } catch (e) {
-      console.warn('[pdf-transcription] upsert transcript', p, e?.message || e);
-    }
-
-    onProgress?.({ done: p, total: numPages, page: p });
+  } finally {
+    if (docSession) await pdfExtractor.destroyPdfDocument(docSession.doc);
   }
 
   const text = parts.join('\n\n');


### PR DESCRIPTION
Root causes:
- pdf-extractor: renderPdfPagePngDataUrl read the entire PDF file from disk
  and parsed a full pdfjs document for EVERY page, never calling destroy().
  For a 60-page PDF that meant 60× file reads + 60 accumulated pdfDoc instances.
- pdf-transcription: buildPdfjsMarkedText had the same problem calling
  extractPdfText page-by-page, each loading the full file.
- lancedb-semantic: replaceResourceChunks wrote all chunks in one Arrow batch,
  causing large memory spikes for long documents (thousands of chunks).

Fixes:
- Add openPdfDocument/destroyPdfDocument/renderPdfPageFromDoc/extractTextFromDocPage
  to pdf-extractor.cjs — loads the PDF once and reuses the doc across all pages.
- Update pdf-transcription.cjs (both pdfjs fallback and cloud paths) to open the
  doc once, iterate pages, then explicitly destroy it; yields setImmediate every
  page/10 pages so V8 GC can reclaim PNG buffers and canvas objects between pages.
- Split replaceResourceChunks writes into sub-batches of 250 rows to cap Arrow
  batch allocation when indexing documents with thousands of chunks.

https://claude.ai/code/session_01MJeVK7AGfYFWGqeWHhtG4H