### PR TITLE
fix: resolve CSS variable null returns in PDF annotation rendering

### DIFF
--- a/app/lib/pdf/annotation-utils.ts
+++ b/app/lib/pdf/annotation-utils.ts
@@ -223,7 +223,8 @@ function renderHighlight(
 ): void {
   if (viewportRect.width > 0 && viewportRect.height > 0) {
     ctx.globalAlpha = style.opacity ?? 0.3;
-    ctx.fillStyle = resolveCssColor(style.color) ?? '#0ea5e9';
+    const resolved = resolveCssColor(style.color, '#0ea5e9');
+    ctx.fillStyle = resolved || '#0ea5e9';
     ctx.fillRect(viewportRect.x, viewportRect.y, viewportRect.width, viewportRect.height);
   }
 }
@@ -236,19 +237,19 @@ function renderNote(
   const noteWidth = 200;
   const noteHeight = 150;
 
-  // Draw note background
   ctx.globalAlpha = 0.95;
-    ctx.fillStyle = resolveCssColor(style.color) ?? '#f59e0b';
-    ctx.fillRect(coordinates.x, coordinates.y, noteWidth, noteHeight);
+  const resolvedColor = resolveCssColor(style.color, '#f59e0b');
+  ctx.fillStyle = resolvedColor || '#f59e0b';
+  ctx.fillRect(coordinates.x, coordinates.y, noteWidth, noteHeight);
 
-    ctx.globalAlpha = 1;
-    ctx.strokeStyle = resolveCssColor(style.color) ?? '#f59e0b';
-    ctx.lineWidth = 2;
-    ctx.strokeRect(coordinates.x, coordinates.y, noteWidth, noteHeight);
+  ctx.globalAlpha = 1;
+  ctx.strokeStyle = resolvedColor || '#f59e0b';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(coordinates.x, coordinates.y, noteWidth, noteHeight);
 
-  // Draw text if available
   if (content) {
-    ctx.fillStyle = resolveCssColor('var(--primary-text)') ?? '#111827';
+    const resolvedTextColor = resolveCssColor('var(--primary-text)', '#111827');
+    ctx.fillStyle = resolvedTextColor || '#111827';
     ctx.font = '12px sans-serif';
     const lines = content.split('\n');
     const lineHeight = 16;


### PR DESCRIPTION
## Summary
- Fixed `renderHighlight` and `renderNote` in `annotation-utils.ts` to properly handle `resolveCssColor` returning null/undefined
- Pass fallback values explicitly and use `resolved || fallback` pattern instead of `??` to handle empty strings
- Fixed indentation issues in `renderNote`

## Validation
- npm run typecheck ✓
- npm run lint ✓ (only pre-existing warnings)
- npm run build ✓