### PR TITLE
fix(ci): GH_TOKEN para electron-builder en release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,16 @@ on:
   release:
     types: [published]
 
+# Permite subir activos al release (electron-publish / action-gh-release) con GITHUB_TOKEN.
+permissions:
+  contents: write
+
 env:
   NODE_VERSION: '24'
+  # electron-publish (dependencia de electron-builder) exige GH_TOKEN; Actions solo define GITHUB_TOKEN.
+  # Si el builder intenta publicar a GitHub (p. ej. por build.publish en package.json), sin esto falla:
+  # "GitHub Personal Access Token is not set ... env GH_TOKEN".
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Evita avisos de deprecación de Node 20 en actions/checkout, setup-node, etc. (hasta junio 2026)
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # pnpm sin TTY (evita abortos tipo confirmModulesPurge / purga de node_modules)
@@ -130,8 +138,6 @@ jobs:
   attach-artifacts:
     needs: [build-macos, build-windows]
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

El release en GitHub disparaba `electron-publish` (cadena de `electron-builder`), que **solo** reconoce la variable de entorno `GH_TOKEN`. En GitHub Actions el token del job llega como `GITHUB_TOKEN`, no como `GH_TOKEN`, lo que produce el error:

`GitHub Personal Access Token is not set ... env "GH_TOKEN"`

Con `build.publish.provider: "github"` en `package.json`, cualquier intento de publicación automática durante el empaquetado necesita ese alias.

## Cambio

- Definir `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` en el `env` global del workflow de release (`.github/workflows/build.yml`).
- Añadir `permissions: contents: write` a nivel de workflow para que el token pueda adjuntar activos al release cuando haga falta (coherente con el job `attach-artifacts` que ya usaba `contents: write`).

Tras fusionar, volver a publicar o re-ejecutar el workflow del release debería completar el empaquetado sin ese fallo (si aparece otro error de permisos en repos con políticas restrictivas, habría que revisar los permisos del `GITHUB_TOKEN` en ajustes del repo/organización).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d085d3ef-d68d-42bc-bc46-00967a43a79b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d085d3ef-d68d-42bc-bc46-00967a43a79b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

