### PR TITLE
release: Dome 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to Dome are documented in this file.
 
 ## [Unreleased]
 
+## [2.2.0](https://github.com/maxprain12/dome/releases/tag/v2.2.0) - 2026-05-26
+
+### Added
+
+- **Feeders (artifact data pipelines)**: scripts sandbox (Python/Node/Bash/curl) que alimentan artefactos persistidos (Kind B) con datos externos; vault de secretos cifrado (`safeStorage`), aprobación HITL, historial de ejecuciones, automatizaciones con `target=feeder` y herramientas del agente (`feeder_*`). UI en `FeedersPanel`, `SecretsManager`, `FeederApprovalModal`. Docs: `docs/features/feeders.md`, `prompts/martin/feeders.txt`.
+- **Middleware LangGraph centralizado** (`electron/agent-middleware.cjs`): retry, límites de recursión, HITL, skills, filesystem y trim en una cadena compartida por Many, agent-team, workflows y run engine. Docs: `docs/architecture/middleware.md`.
+- **Embeddings configurables**: Settings → IA → Embeddings (OpenAI, Google Gemini, Ollama vía LangChain); IPC `embeddings:*`; reindexado tras cambio de modelo; descubrimiento dinámico de modelos.
+- **Búsqueda web y fetch configurables**: proveedores Brave, Tavily, SearXNG, DuckDuckGo HTML, Jina Reader y Readability; Settings → IA → Web Search; dispatcher en `electron/services/web/`.
+- **Política MCP por herramienta** (`mcp-tool-policy.cjs`, `app/lib/mcp/tool-policy.ts`): allow/deny por servidor MCP en ajustes.
+- **Chat tools UI**: resumen en árbol (`treeToolSummary`), truncado de resultados, pretty-print JSON (`jsonPrettyPrinter`).
+- **Validadores Studio** (`studio-validators.cjs`) y normalización de quiz (`normalizeQuizContent.ts`).
+- **Tests de scripts**: `test:feeders`, `test:filesystem-tools`, `test:web-search`, `test:studio`.
+- **Docs**: `docs/plans/middleware-audit.md`; guías de automatización ampliadas.
+
+### Changed
+
+- **LangGraph agent / run engine**: refactor para usar middleware compartido; mejor merge de artefactos (`artifact-data-merge.cjs`).
+- **Indexación semántica**: LanceDB + LangChain embeddings (retira worker ONNX local y `@huggingface/transformers`); chunking ampliado.
+- **Web scraping**: retira Playwright del bundle; fetch con cheerio + proveedores HTTP ligeros.
+- **AI Settings**: pestañas modulares Embeddings y Web Search; IndexingSettings simplificado.
+- **Hub Automations / Runs**: filtros y tarjetas editoriales actualizados; iconografía unificada.
+- **i18n**: cadenas en en/es/fr/pt para feeders, embeddings, web search, MCP policy y chat tools.
+- **Inventario IPC**: sincronizado (435 canales); dominios `feeders:*`, `feeder-secrets:*`, `embeddings:*`.
+
+### Removed
+
+- `electron/playwright-scraper.cjs`, `electron/workers/embeddings-worker.cjs`, dependencias Playwright y ONNX del empaquetado.
+
+### Fixed
+
+- **IPC P-002**: validación Zod en handlers `feeders.cjs` y `embeddings.cjs`.
+- **Quiz Studio**: normalización de contenido generado por LLM antes de renderizar.
+
 ## [2.1.9](https://github.com/maxprain12/dome/releases/tag/v2.1.9) - 2026-05-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Desktop**: Electron 41 with strict security (contextIsolation, no nodeIntegration)
 - **Frontend**: Vite 7 + React 18 + React Router 7 (client-side SPA, entry: `app/main.tsx`)
 - **Database**: SQLite via **better-sqlite3** in the main process (standard Node stack — the renderer must use IPC, not direct DB access)
-- **Semantic search**: Local Nomic embeddings in SQLite (`resource_chunks`); PDF/image text via your configured cloud LLM (vision) where applicable
+- **Semantic search**: Configurable LangChain embeddings (OpenAI / Google / Ollama) in LanceDB (`dome-lance`); hybrid search combines FTS + graph + vectors; PDF/image text via your configured cloud LLM (vision) where applicable
 - **AI**: LangChain + LangGraph for agent workflows; multi-provider (OpenAI, Anthropic, Google, Ollama)
 - **State**: Zustand stores + Jotai atoms
 - **Styling**: Tailwind CSS + CSS Variables + Mantine UI components
@@ -97,7 +97,7 @@ IPC handlers are organized in `electron/ipc/` (one file per domain). All channel
 3. **Whitelist** (`electron/preload.cjs`): Add channel to ALLOWED_CHANNELS
 4. **Renderer** (`app/`): Call via `window.electron.invoke('channel', args)`
 
-IPC domains in `electron/ipc/`: `ai`, `ai-tools`, `agent-team`, `audio`, `auth`, `calendar`, `chat`, `cloud-llm`, `cloud-storage`, `database`, `dome-auth`, `files`, `flashcards`, `graph`, `images`, `indexing-sync`, `interactions`, `marketplace`, `mcp`, `migration`, `notebook`, `ollama`, `pdf-render`, `personality`, `plugins`, `resources`, `runs`, `semantic`, `storage`, `studio`, `sync`, `system`, `tags`, `updater`, `web`, `window`.
+IPC domains in `electron/ipc/`: `ai`, `ai-tools`, `agent-team`, `audio`, `auth`, `calendar`, `chat`, `cloud-llm`, `cloud-storage`, `database`, `dome-auth`, `embeddings`, `feeders`, `files`, `flashcards`, `graph`, `images`, `indexing-sync`, `interactions`, `marketplace`, `mcp`, `migration`, `notebook`, `ollama`, `pdf-render`, `personality`, `plugins`, `resources`, `runs`, `semantic`, `storage`, `studio`, `sync`, `system`, `tags`, `updater`, `web`, `window`.
 
 ### Database Architecture
 
@@ -143,7 +143,7 @@ dome/
 │   ├── pdf-extractor.cjs       # PDF text/page extraction
 │   ├── github-client.cjs       # GitHub API integration
 │   ├── crop-image.cjs          # Image cropping utilities
-│   ├── services/               # Nomic embeddings, indexing.pipeline, chunking, hybrid search
+│   ├── services/               # LangChain embeddings, indexing.pipeline, chunking, hybrid search, feeders, web providers
 │   └── ppt-slide-extractor.cjs # PPTX slide extraction (hidden BrowserWindow)
 │
 ├── app/                         # Renderer Process (Browser context)

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ Dome is an open-source desktop app for researchers, academics, and knowledge wor
 | **Agent Canvas** | Visual drag-and-drop workflow builder (D3 + SVG edges) |
 | **Agent Teams** | Multi-agent collaboration in a shared chat session |
 | **Studio** | Generate mindmaps, quizzes, flashcards, guides, FAQs, and timelines from your content |
-| **Semantic search** | Local Nomic embeddings in SQLite, hybrid search (vectors + FTS + graph); PDF/image text via your cloud LLM (vision) |
+| **Semantic search** | Configurable LangChain embeddings (OpenAI / Google / Ollama) in LanceDB, hybrid search (vectors + FTS + graph); PDF/image text via your cloud LLM (vision) |
 | **Flashcards** | SM-2 spaced repetition with AI-generated decks |
 | **Calendar** | Google Calendar sync + AI tools to create and manage events from chat |
 | **Google Drive** | Native import with PKCE OAuth 2.0 — tokens stored locally, never on Dome servers |
 | **PDF Viewer** | Highlight, underline, comment, and annotate |
 | **PowerPoint Viewer** | Full `.pptx` rendering and presentation mode, no LibreOffice needed |
 | **Notion-style Editor** | Tiptap-based with slash commands, tables, columns, toggles, callouts |
-| **Web Scraper** | Playwright-based — no Brave API key required |
+| **Artifact Feeders** | Scheduled sandbox scripts that feed persisted mini-apps with external JSON (Redfish, APIs, etc.) |
 | **Academic Library** | APA, MLA, Chicago, Harvard, Vancouver, IEEE citations |
 | **MCP Integration** | Connect `stdio` or `http` MCP servers; tools available to all agents |
 | **Marketplace** | Community agents, plugins, skills, and workflows |
@@ -71,11 +71,11 @@ Dome is an open-source desktop app for researchers, academics, and knowledge wor
 | AI Agent | [LangGraph](https://langchain-ai.github.io/langgraphjs/) + [LangChain](https://js.langchain.com/) |
 | MCP | [@langchain/mcp-adapters](https://js.langchain.com/docs/integrations/tools/mcp) |
 | Database | SQLite via [better-sqlite3](https://github.com/WiseLibs/better-sqlite3) |
-| Semantic index | Nomic embeddings (`resource_chunks`) + hybrid search; see `docs/features/indexing.md` |
+| Semantic index | LangChain embeddings + LanceDB + hybrid search; see `docs/features/indexing.md` |
 | State | [Zustand](https://github.com/pmndrs/zustand) |
 | Editor | [Tiptap](https://tiptap.dev/) + Dome Editor (MIT) |
 | Graphs | [D3.js](https://d3js.org/) |
-| Web automation | [Playwright](https://playwright.dev/) |
+| Web search / fetch | Configurable providers (Brave, Tavily, SearXNG, DDG, Jina, Readability) |
 | PDF | [PDF.js](https://mozilla.github.io/pdf.js/) |
 | PowerPoint | [pptx-preview](https://github.com/mesmerize-dev/pptx-preview) |
 | i18n | [react-i18next](https://react.i18next.com/) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Dome – índice de documentación
 
-Documentación del proyecto Dome (v2.1.7). Además de este índice:
+Documentación del proyecto Dome (v2.2.0). Además de este índice:
 
 - **[Principios de ingeniería](principles.md)** — P-001…P-010, citados por linters y auditorías.
 - **[Arquitectura](architecture/README.md)** — capas, dominios, IPC, ADRs, worktree.
@@ -38,11 +38,12 @@ Documentación del proyecto Dome (v2.1.7). Además de este índice:
 | Feature | Archivo | Contenido |
 | ------- | ------- | ---------- |
 | **KB LLM** | [kb-llm-wiki-model.md](features/kb-llm-wiki-model.md) | Recurso `dome_kb`, roles |
-| **Indexación** | [indexing.md](features/indexing.md) | Nomic, chunks, `db:semantic:*` |
+| **Indexación** | [indexing.md](features/indexing.md) | LangChain embeddings, LanceDB, `embeddings:*`, `db:semantic:*` |
 | **KB UX** | [kb-ux-unification.md](features/kb-ux-unification.md) | Learn, Studio, Runs |
 | **Agent Canvas** | [agent-canvas.md](features/agent-canvas.md) | Workflows D3 |
 | **Agent Teams** | [agent-teams.md](features/agent-teams.md) | Equipos multi-agente |
 | **Studio** | [studio.md](features/studio.md) | Mindmaps, quizzes, flashcards |
+| **Feeders** | [feeders.md](features/feeders.md) | Scripts sandbox, vault de secretos, artefactos |
 
 ### Productividad
 
@@ -50,7 +51,7 @@ Documentación del proyecto Dome (v2.1.7). Además de este índice:
 | ------- | ------- | ---------- |
 | **Calendar** | [calendar.md](features/calendar.md) | Calendario, Google sync |
 | **Flashcards** | [flashcards.md](features/flashcards.md) | SM-2, sesiones |
-| **Automatizaciones** | [automations.md](features/automations.md) | Run Engine |
+| **Automatizaciones** | [automations.md](features/automations.md) | Run Engine, feeders |
 | **Runs** | [runs.md](features/runs.md) | Estados, logs |
 
 ### Extensiones e integración

--- a/docs/manual-tecnico.md
+++ b/docs/manual-tecnico.md
@@ -1,6 +1,6 @@
 # Manual Técnico — Dome Desktop
 
-> Referencia técnica consolidada para desarrolladores de Dome (v2.1.7).
+> Referencia técnica consolidada para desarrolladores de Dome (v2.2.0).
 > Asume conocimiento de TypeScript, React y Electron.
 
 ---
@@ -12,7 +12,7 @@
 3. [Estructura de directorios](#3-estructura-de-directorios)
 4. [IPC — Comunicación entre procesos](#4-ipc--comunicación-entre-procesos)
 5. [Base de datos SQLite](#5-base-de-datos-sqlite)
-6. [Indexación semántica (IA en la nube + Nomic)](#6-indexación-semántica-ia-en-la-nube--nomic) (incl. [KB LLM](#kb-llm-wiki-compilada-por-agentes))
+6. [Indexación semántica (LangChain + LanceDB)](#6-indexación-semántica-langchain--lancedb) (incl. [KB LLM](#kb-llm-wiki-compilada-por-agentes))
 7. [AI Integration](#7-ai-integration)
 8. [Run Engine y Automatizaciones](#8-run-engine-y-automatizaciones)
 9. [State Management (Zustand)](#9-state-management-zustand)
@@ -80,7 +80,7 @@ const data = await window.electron.invoke('db:resources:getAll', projectId);
 | UI components | Mantine | latest |
 | Styling | Tailwind CSS + CSS Variables | — |
 | Database | better-sqlite3 | latest |
-| Vector search | Nomic embeddings en SQLite (`resource_chunks`) | — |
+| Vector search | LangChain embeddings + LanceDB (`dome-lance`) | — |
 | AI orchestration | LangChain + LangGraph | latest |
 | AI providers | OpenAI, Anthropic, Google, Ollama, Dome | — |
 | Editor | Tiptap (ProseMirror) | — |
@@ -305,9 +305,9 @@ const resource = await dbClient.getResourceById(id);
 
 ---
 
-## 6. Indexación semántica (IA en la nube + Nomic)
+## 6. Indexación semántica (LangChain + LanceDB)
 
-La búsqueda híbrida usa **chunks vectoriales locales** (Nomic en `resource_chunks`) más FTS5 y el grafo. Los PDFs y las imágenes se transcriben o describen con el **LLM en la nube** del usuario (Ajustes → IA, visión / multimodal). No hay runtime Python embebido en el proceso principal; el índice semántico vive en SQLite. La transcripción on-device vía **Gemma** se retiró en versiones recientes.
+La búsqueda híbrida usa **vectores en LanceDB** (embeddings LangChain configurables: OpenAI, Google Gemini u Ollama) más FTS y el grafo. Los PDFs y las imágenes se transcriben o describen con el **LLM en la nube** del usuario (Ajustes → IA, visión / multimodal). Configuración en **Ajustes → IA → Embeddings**; IPC `embeddings:*` y `db:semantic:*`.
 
 Documentación detallada: **[indexing.md](./features/indexing.md)**.
 
@@ -316,14 +316,14 @@ Documentación detallada: **[indexing.md](./features/indexing.md)**.
 ```
 Recursos → semantic-index-scheduler → indexing.pipeline.cjs
     → (texto) resource-text / cloud PDF / cloud imagen
-    → chunking.cjs → embeddings Nomic → resource_chunks
+    → chunking.cjs → embeddings.service.cjs (LangChain) → lancedb-semantic.cjs
 ```
 
 ### IPC principal
 
 | Área | Canales / módulo |
 |------|------------------|
-| Embeddings / índice | `db:semantic:*`, `semantic:progress` |
+| Embeddings / índice | `embeddings:*`, `db:semantic:*`, `semantic:progress` |
 | Cloud LLM (visión) | `cloud:llm:pdf-region-stream`, streaming `cloud:llm:stream-*` |
 | Reindex biblioteca | `indexing:full-sync` |
 | Vista página PDF (chat) | `pdf:render-page`, `ai:tools:pdfRenderPage` |
@@ -393,7 +393,7 @@ Definidas en `electron/ai-chat-with-tools.cjs` y `app/lib/ai/tools/`:
 | `web_fetch` | Descarga y procesa URLs |
 | `deep_research` | Investigación multi-paso |
 | `resource_search` | FTS en biblioteca Dome |
-| `resource_semantic_search` | Búsqueda semántica (embeddings Nomic, chunks + `page_number`) |
+| `resource_semantic_search` | Búsqueda semántica (embeddings LangChain + LanceDB, chunks + `page_number`) |
 | `resource_get` | Lee contenido de recurso |
 | `resource_create` | Crea nota nueva |
 | `resource_update` | Edita nota existente |
@@ -783,4 +783,4 @@ Checklist:
 
 ---
 
-*Manual Técnico — Dome v2.1.7*
+*Manual Técnico — Dome v2.2.0*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.1.9",
+  "version": "2.2.0",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump `package.json` to **2.2.0**
- CHANGELOG con feeders, middleware LangGraph, embeddings configurables, web search/fetch, MCP tool policy y retirada Playwright/ONNX
- README, `docs/README.md`, `docs/manual-tecnico.md` y `CLAUDE.md` alineados con la arquitectura actual

## Test plan

- [x] Cambios de documentación y versión únicamente (features ya validadas en #339)
- [ ] Tras merge: crear tag `v2.2.0` y GitHub Release para disparar `build.yml`