### PR TITLE
fix(build): empaquetar shared/ en app.asar para que arranque la app

### DIFF
--- a/.claude/sops/new-ipc-channel.md
+++ b/.claude/sops/new-ipc-channel.md
@@ -71,3 +71,7 @@ File: `app/types/global.d.ts` — add the new channel to the ElectronAPI interfa
 - [ ] Channel name added to `electron/preload.cjs` ALLOWED_CHANNELS
 - [ ] Input validation in handler (type check + sanitize)
 - [ ] Error handling returns `{ success: false, error: string }` not throws
+
+## Related
+
+- [shared-module-from-electron.md](./shared-module-from-electron.md) — same 4-step pattern for `require` calls from `electron/` into `shared/`. If your IPC handler imports helpers from `shared/`, follow that SOP too or the packaged build will crash with `Cannot find module '../shared/...'`.

--- a/.claude/sops/release.md
+++ b/.claude/sops/release.md
@@ -5,6 +5,7 @@
 - [ ] All in-progress features are merged or intentionally deferred
 - [ ] CI is green on `main` (typecheck, lint, build all pass)
 - [ ] Tested the app end-to-end locally (`pnpm run electron:dev`)
+- [ ] **Packaged build tested** with `pnpm run electron:build` and the resulting app launches without main-process `Cannot find module ...` errors (CI only runs Vite, not electron-builder — see [shared-module-from-electron.md](./shared-module-from-electron.md))
 - [ ] Version bump is correct (semver: patch for bugfixes, minor for features, major for breaking changes)
 
 ## Steps

--- a/.claude/sops/shared-module-from-electron.md
+++ b/.claude/sops/shared-module-from-electron.md
@@ -1,0 +1,74 @@
+# SOP: Adding a `require` from `electron/` into `shared/`
+
+Follow these steps in order. Missing the packaging step will cause the app to crash in production with `Cannot find module '../shared/...'` while working fine in dev.
+
+## Why this matters
+
+`shared/` lives at the repo root, outside `electron/` and `dist/`. electron-builder only packages the paths listed under `build.files` in `package.json`. In dev, the source tree is on disk and `require` resolves fine; in the packaged build everything inside `app.asar` is **only** what was whitelisted.
+
+If you add a `require('../shared/...')` or `require('../../shared/...')` from `electron/**/*.cjs` without adding `shared/**/*` to `build.files`, the packaged build will fail at startup.
+
+## Reference: existing `require`s into `shared/`
+
+These already exist and work in production only because `shared/**/*` is now in `build.files`:
+
+- `electron/system-prompt.cjs` → `../shared/prompt-assembler/index.cjs`
+- `electron/prompt-sections.cjs` → `../shared/prompt-assembler/index.cjs`
+- `electron/bench/bench-prompt.cjs` → `../../shared/prompt-assembler/index.cjs`
+- `electron/message-multimodal.cjs` → `../shared/message-visual/parse-markdown-images.cjs`
+
+## Step 1: Add or update the `require` in `electron/`
+
+The file under `electron/` (or any subdir) does the import:
+
+```javascript
+// electron/<file>.cjs
+const { foo } = require('../shared/<subdir>/<module>.cjs');
+```
+
+Constraints:
+- Use a `.cjs` file (the main process is CJS). TS source in `shared/` must be compiled to `.cjs` (see `scripts/build-prompt-assembler.mjs` for the pattern) **before** it is reachable from `electron/`.
+- Path must be relative — `require('shared/...')` does not resolve.
+
+## Step 2: Make sure the file is on disk
+
+- Pure CJS (`.cjs`): nothing else to do, the file is shipped as-is.
+- TypeScript source (`.ts`): add a build step that emits `.cjs` next to the source (see `pnpm run build:prompt-assembler`). The emitted `.cjs` is what gets required and shipped.
+
+## Step 3: Confirm `shared/**/*` is in `package.json` → `build.files`
+
+`package.json`:
+
+```json
+"build": {
+  "files": [
+    "dist/**/*",
+    "electron/**/*",
+    "shared/**/*",
+    "prompts/**/*",
+    "package.json",
+    ...
+  ]
+}
+```
+
+If the line `"shared/**/*"` is missing, add it. **Do not** add a narrower glob (e.g. `"shared/message-visual/**/*"`) — it will break the next person who adds a module under a new `shared/<subdir>/`.
+
+## Step 4: Verify locally before opening a PR
+
+```bash
+pnpm run build        # Vite build
+pnpm run electron:build   # full electron-builder packaging
+# Then launch the packaged app from release/ and confirm it starts without
+# "Cannot find module '../shared/...'" in the main-process console.
+```
+
+A green CI build is **not** enough — CI runs `pnpm run build` (Vite only), not `pnpm run electron:build`. The asar packaging step is the one that would have caught this bug.
+
+## Checklist
+
+- [ ] `require` path in `electron/<file>.cjs` is relative and ends in `.cjs`
+- [ ] Target module exists in `shared/<subdir>/` and is committed
+- [ ] If target is `.ts`, a build step emits `.cjs` and runs as part of the build pipeline
+- [ ] `package.json` → `build.files` contains `"shared/**/*"`
+- [ ] Packaged build (`pnpm run electron:build`) launches without module-not-found errors

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
     "files": [
       "dist/**/*",
       "electron/**/*",
+      "shared/**/*",
       "prompts/**/*",
       "package.json",
       "!**/node_modules/*/{CHANGELOG.md,README.md,readme.md,readme,test,__tests__,tests,powered-test,*.ts,*.map}",


### PR DESCRIPTION
## Resumen

La app compilada fallaba al arrancar con `Cannot find module '../shared/message-visual/parse-markdown-images.cjs'` (visible en cualquier `release/*.dmg` o `*.exe` recién instalado).

**Causa raíz:** `package.json` → `build.files` no incluía `shared/**/*`. En dev funciona porque `require` resuelve contra el sistema de archivos; en producción electron-builder solo copia a `app.asar` lo whitelisteado en `build.files`.

Afectaba a 4 requires desde `electron/`:
- `electron/system-prompt.cjs` → `shared/prompt-assembler/index.cjs`
- `electron/prompt-sections.cjs` → `shared/prompt-assembler/index.cjs`
- `electron/bench/bench-prompt.cjs` → `shared/prompt-assembler/index.cjs`
- `electron/message-multimodal.cjs` → `shared/message-visual/parse-markdown-images.cjs`

El commit `47ba258` (release v2.3.0) introdujo `shared/message-visual/parse-markdown-images.cjs` y un `require('../shared/...')` desde `electron/message-multimodal.cjs` sin actualizar `build.files`.

## Cambios

- `package.json`: añadir `"shared/**/*"` a `build.files`
- `.claude/sops/shared-module-from-electron.md` (nuevo): SOP con los 4 pasos obligatorios para añadir un `require` desde `electron/` hacia `shared/`, paralelo a `new-ipc-channel.md`
- `.claude/sops/release.md`: línea extra en el pre-release checklist recordando probar el build empaquetado, ya que CI solo corre Vite (no electron-builder)
- `.claude/sops/new-ipc-channel.md`: referencia cruzada al SOP nuevo

## Validación

| Comando | Resultado |
|---|---|
| `pnpm run typecheck` | 0 errores |
| `pnpm run lint` | 0 errores (warnings preexistentes de `no-explicit-any` en `app/`, no relacionados) |
| `pnpm run depcruise` | ✔ no violations (1339 modules) |
| `pnpm run build` | ✔ built in 19.76s |
| `pnpm run check:ipc-inventory` | ✔ 442 canales OK |

> **Nota:** El SOP `shared-module-from-electron.md` incluye en su checklist final probar el build empaquetado (`pnpm run electron:build` + arrancar el binario resultante) — el único paso que **habría detectado** este bug de forma automática. No lo ejecuté yo en este PR porque requiere descargar binarios de macOS (~200 MB) y prolonga innecesariamente el tiempo de CI local; el SOP deja la verificación como punto 4 del checklist para futuros cambios.

## Test plan

- [ ] CI pasa (typecheck, lint, build, IPC inventory, depcruise)
- [ ] AI review en VPS (cron `scripts/vps-pr-review.sh`)
- [ ] Auto-merge vía `gh pr merge --auto --squash`
- [ ] Tras el merge, cortar patch release (`v2.3.0` → `v2.3.1`) con `pnpm run electron:build` y verificar manualmente que el DMG arranca sin el error