### PR TITLE
chore: release v2.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,34 +4,44 @@ All notable changes to Dome are documented in this file.
 
 ## [Unreleased]
 
-## [2.3.5](https://github.com/maxprain12/dome/releases/tag/v2.3.5) - 2026-06-07
+## [2.3.5](https://github.com/maxprain12/dome/releases/tag/v2.3.5) - 2026-06-08
+
+Release pública para todos los usuarios. Sustituye el runtime LangGraph por el harness nativo Dome, corrige regresiones de Learn/Flashcards del redesign 2.3.0 y mejora la higiene del historial Many.
 
 ### Added
 
-- **Dome-native agent runtime** (`@dome/agent-core` + `AgentHarness`) for Many, agent-chat, workflows, Agent Team, automations, and bench — LangGraph fully removed.
-- **JSONL session persistence** for Many (`threads:*` IPC, `manyThreadBridge`, sidebar hydration from `threads:list?rootOnly=true`).
-- **Context usage UI**: `ContextUsageIndicator`, segmented budget popup, `CompactionNotice`, live token estimates.
-- **HITL resume**, Many `task` subagents, Agent Team `delegate_to_agent`, manual `threads:compact` / `threads:navigate-tree`.
-- **Native web search** for Anthropic / Gemini / OpenAI Responses; HTTP `web_search` / `web_fetch` fallback for other providers.
-- **Multimodal Many attachments** via `ImageContent` (sharp resize in main process).
-- **Tool schema normalization** (`normalizeToolParameters`, `tool-schema.ts`) for strict providers (MiniMax error 2013).
-- **Workflow DAG executor** in `run-engine.cjs` (topological levels, per-node retry); text-only propagation between agent nodes.
+- **Dome-native agent runtime** (`@dome/agent-core` + `AgentHarness`) para Many, agent-chat, workflows, Agent Team, automations y bench — **LangGraph eliminado por completo**.
+- **Persistencia de sesiones JSONL** para Many (`threads:*` IPC, `manyThreadBridge`, hidratación del sidebar desde `threads:list?rootOnly=true`).
+- **UI de uso de contexto**: `ContextUsageIndicator`, popup de presupuesto segmentado, `CompactionNotice`, estimaciones de tokens en vivo.
+- **HITL resume**, subagentes Many `task`, `delegate_to_agent` en Agent Team, `threads:compact` / `threads:navigate-tree` manuales.
+- **Búsqueda web nativa** para Anthropic / Gemini / OpenAI Responses; fallback HTTP `web_search` / `web_fetch` para otros proveedores.
+- **Adjuntos multimodales en Many** vía `ImageContent` (resize con sharp en main process).
+- **Normalización de schemas de tools** (`normalizeToolParameters`, `tool-schema.ts`) para proveedores estrictos (error MiniMax 2013).
+- **Ejecutor DAG de workflows** en `run-engine.cjs` (niveles topológicos, retry por nodo); propagación solo de texto entre nodos agente.
+- **FSRS** (`ts-fsrs`) para flashcards — migración DB 38; backfill desde campos SM-2 legacy; botones de estudio con vista previa de intervalos.
+- **Logos de marca de proveedores** actualizados (DeepSeek, Moonshot, Qwen, GitHub Copilot) + `modelcontextprotocol.svg`; filtro `--dome-logo-filter` en tema oscuro para iconos monocromos.
 
 ### Changed
 
-- Renamed `useLangGraphRunStream` → `useAgentRunStream`; renderer/runtime terminology aligned with Dome agent harness (no upstream product names in code).
-- MiniMax: disabled Anthropic server web tools; client HTTP search/fetch retained; empty tool names filtered in Anthropic provider.
-- Provider config unified (`resolve-provider-config.cjs`); cloud providers wired end-to-end in settings.
+- `useLangGraphRunStream` → `useAgentRunStream`; terminología renderer/runtime alineada con el harness Dome (sin nombres de productos upstream en código).
+- MiniMax: desactivadas web tools nativas Anthropic; búsqueda/fetch HTTP cliente conservados; nombres de tool vacíos filtrados en el proveedor Anthropic.
+- Config de proveedores unificada (`resolve-provider-config.cjs`); proveedores cloud cableados end-to-end en ajustes.
+- Empaquetado: `shared/` incluido en `app.asar` para que la app arranque en producción (#342).
 
 ### Fixed
 
-- MiniMax API **2013** (`function name or parameters is empty`) from invalid native web tools and empty tool schemas.
-- Many session list drift (JSONL as source of truth; localStorage UI meta only).
-- Workflow LLM usage double-counting on multi-agent runs.
+- MiniMax API **2013** (`function name or parameters is empty`) por web tools nativas inválidas y schemas vacíos.
+- Deriva de la lista de sesiones Many (JSONL como fuente de verdad; localStorage solo meta UI).
+- Doble conteo de usage LLM en workflows multi-agente.
+- **Flashcards (Learn 2.3.0)**: volteo 3D restaurado; tarjetas nuevas contaban como due; sesiones vacías; re-estudio bloqueado; `deck_id` incorrecto desde Studio (#344).
+- KPIs Learn: tarjetas con `next_review_at IS NULL` incluidas en el conteo due.
+- **Historial Many**: sesiones JSONL de Studio (`studio-*`), agent-canvas (`canvas-*`) y nodos de workflow (`{runId}_{nodeId}`) excluidas del sidebar de chats.
+- Aviso **DEP0040** de `punycode` incorporado en Electron — redirect a paquete userland en `main.cjs`.
 
 ### Docs
 
-- `docs/architecture/agent-runtime.md` — runtime, sessions, workflow propagation, provider notes; upstream [pi](https://github.com/earendil-works/pi) cited as design reference only.
+- `docs/architecture/agent-runtime.md` — runtime, sesiones, propagación en workflows, notas de proveedores; referencia upstream [pi](https://github.com/earendil-works/pi) solo como diseño.
+- Manuales, README y feature docs actualizados a v2.3.5 (runtime nativo, FSRS, logos).
 
 ## [2.3.0](https://github.com/maxprain12/dome/releases/tag/v2.3.0) - 2026-06-02
 

--- a/MASTER.md
+++ b/MASTER.md
@@ -24,7 +24,7 @@
 │  y investigación académica. Combina editor, IA, agentes,    │
 │  organización de recursos y herramientas de estudio.        │
 │                                                              │
-│  v2.1.6  ·  pnpm  ·  Electron 41  ·  TypeScript             │
+│  v2.3.5  ·  pnpm  ·  Electron 41  ·  TypeScript             │
 └──────────────────────────────┬──────────────────────────────┘
                                │ OAuth PKCE + AI Proxy
                                │ dome://dome-auth/oauth/callback
@@ -98,7 +98,7 @@
 | Feature | Doc | Estado |
 |---------|-----|--------|
 | Calendar + Google Calendar | [calendar.md](./docs/features/calendar.md) | ✅ v2.0.0 |
-| Flashcards SM-2 | [flashcards.md](./docs/features/flashcards.md) | ✅ Implementado |
+| Flashcards FSRS | [flashcards.md](./docs/features/flashcards.md) | ✅ v2.3.5 |
 | Automatizaciones | [automations.md](./docs/features/automations.md) | ✅ v2.0.8 |
 | Run Engine | [runs.md](./docs/features/runs.md) | ✅ v2.0.8 |
 
@@ -246,4 +246,4 @@ Ver: [CLAUDE.md](./CLAUDE.md) · [.claude/rules/architecture-rules.md](./.claude
 
 ---
 
-*Última actualización: v2.1.6 (2026-04-27) — Dome Desktop + Dome Provider Fase 1*
+*Última actualización: v2.3.5 (2026-06-08) — Dome Desktop + Dome Provider Fase 1*

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Vite](https://img.shields.io/badge/Vite-646CFF?style=flat&logo=vite&logoColor=white)](https://vitejs.dev/)
 [![React](https://img.shields.io/badge/React-61DAFB?style=flat&logo=react&logoColor=black)](https://reactjs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![LangGraph](https://img.shields.io/badge/LangGraph-1.1-00C853?style=flat)](https://langchain-ai.github.io/langgraphjs/)
+[![Agent Runtime](https://img.shields.io/badge/Agent%20Runtime-Dome%20native-6366f1?style=flat)](#tech-stack)
 [![License](https://img.shields.io/badge/License-Custom%20Open%20Source-blue.svg)](LICENSE)
 
 ![GitHub Stars](https://img.shields.io/github/stars/maxprain12/dome?style=for-the-badge&labelColor=grey&color=6366f1)
@@ -40,13 +40,13 @@ Dome is an open-source desktop app for researchers, academics, and knowledge wor
 
 | | |
 |---|---|
-| **Many AI Assistant** | LangGraph-powered chat with web search, resource search, memory, and MCP tools |
+| **Many AI Assistant** | Dome-native agent runtime with web search, resource search, JSONL sessions, and MCP tools |
 | **Many Agents** | Custom agents with their own instructions, tools, MCP servers, and sessions |
 | **Agent Canvas** | Visual drag-and-drop workflow builder (D3 + SVG edges) |
 | **Agent Teams** | Multi-agent collaboration in a shared chat session |
 | **Studio** | Generate mindmaps, quizzes, flashcards, guides, FAQs, and timelines from your content |
 | **Semantic search** | Configurable LangChain embeddings (OpenAI / Google / Ollama) in LanceDB, hybrid search (vectors + FTS + graph); PDF/image text via your cloud LLM (vision) |
-| **Flashcards** | SM-2 spaced repetition with AI-generated decks |
+| **Flashcards** | FSRS spaced repetition with AI-generated decks and 3D flip study UI |
 | **Calendar** | Google Calendar sync + AI tools to create and manage events from chat |
 | **Google Drive** | Native import with PKCE OAuth 2.0 — tokens stored locally, never on Dome servers |
 | **PDF Viewer** | Highlight, underline, comment, and annotate |
@@ -68,7 +68,7 @@ Dome is an open-source desktop app for researchers, academics, and knowledge wor
 | Desktop | [Electron 41](https://www.electronjs.org/) |
 | Frontend | [Vite 7](https://vitejs.dev/) + [React 18](https://reactjs.org/) |
 | Styling | [Tailwind CSS](https://tailwindcss.com/) + [Mantine UI](https://mantine.dev/) |
-| AI Agent | [LangGraph](https://langchain-ai.github.io/langgraphjs/) + [LangChain](https://js.langchain.com/) |
+| AI Agent | `@dome/agent-core` (Dome-native harness) + [LangChain](https://js.langchain.com/) (LLM/embeddings) |
 | MCP | [@langchain/mcp-adapters](https://js.langchain.com/docs/integrations/tools/mcp) |
 | Database | SQLite via [better-sqlite3](https://github.com/WiseLibs/better-sqlite3) |
 | Semantic index | LangChain embeddings + LanceDB + hybrid search; see `docs/features/indexing.md` |

--- a/app/lib/chat/manyThreadBridge.ts
+++ b/app/lib/chat/manyThreadBridge.ts
@@ -122,8 +122,15 @@ export interface ThreadSessionSummary {
 /** Nested harness sessions (subagents, team delegates, forks) — not shown in Many sidebar. */
 export const NESTED_MANY_THREAD_ID_RE = /_(sub|member|fork)_/;
 
+/** Non-Many surfaces (Learn/Studio generation, agent-canvas nodes) — not Many chats. */
+const NON_MANY_THREAD_PREFIXES = ['studio-', 'canvas-'];
+
 export function isNestedManyThreadId(threadId: string): boolean {
-  return NESTED_MANY_THREAD_ID_RE.test(threadId) || threadId.startsWith('many_');
+  return (
+    NESTED_MANY_THREAD_ID_RE.test(threadId) ||
+    threadId.startsWith('many_') ||
+    NON_MANY_THREAD_PREFIXES.some((p) => threadId.startsWith(p))
+  );
 }
 
 /**

--- a/app/lib/hooks/useStudioGenerate.ts
+++ b/app/lib/hooks/useStudioGenerate.ts
@@ -405,7 +405,14 @@ export function useStudioGenerate(options?: {
         progress?.('writing', 'Writing draft…');
 
         if (useTools && tools && tools.length > 0) {
-          const result = await chatWithTools(messages, tools, { maxIterations: 5, skipHitl: true });
+          // Mark the harness session as a Learn/Studio run so it is excluded from
+          // the Many chat history (it is one-shot generation, not a conversation).
+          const studioThreadId = `studio-${type}-${Date.now()}`;
+          const result = await chatWithTools(messages, tools, {
+            maxIterations: 5,
+            skipHitl: true,
+            threadId: studioThreadId,
+          });
           response = result.response;
         } else {
           for await (const chunk of chatStream(messages)) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Dome – índice de documentación
 
-Documentación del proyecto Dome (v2.2.0). Además de este índice:
+Documentación del proyecto Dome (v2.3.5). Además de este índice:
 
 - **[Principios de ingeniería](principles.md)** — P-001…P-010, citados por linters y auditorías.
 - **[Arquitectura](architecture/README.md)** — capas, dominios, IPC, ADRs, worktree.
@@ -27,7 +27,8 @@ Documentación del proyecto Dome (v2.2.0). Además de este índice:
 
 | Feature | Archivo | Contenido |
 | ------- | ------- | ---------- |
-| **AI / Chat (Martin/Many)** | [ai-chat.md](features/ai-chat.md) | Cliente, streaming, Many, Agent Teams, IPC `ai:`* |
+| **AI / Chat (Martin/Many)** | [ai-chat.md](features/ai-chat.md) | Cliente, streaming, Many, Agent Teams, IPC `ai:*` |
+| **Agent runtime** | [agent-runtime.md](architecture/agent-runtime.md) | Harness `@dome/agent-core`, JSONL, threads IPC |
 | **Recursos** | [resources.md](features/resources.md) | Resource/Project, DB client, almacenamiento |
 | **Editor** | [editor.md](features/editor.md) | Tiptap, bloques, slash commands |
 | **Workspace** | [workspace.md](features/workspace.md) | Layout, pestañas, rutas |
@@ -50,7 +51,7 @@ Documentación del proyecto Dome (v2.2.0). Además de este índice:
 | Feature | Archivo | Contenido |
 | ------- | ------- | ---------- |
 | **Calendar** | [calendar.md](features/calendar.md) | Calendario, Google sync |
-| **Flashcards** | [flashcards.md](features/flashcards.md) | SM-2, sesiones |
+| **Flashcards** | [flashcards.md](features/flashcards.md) | FSRS, sesiones, volteo 3D |
 | **Automatizaciones** | [automations.md](features/automations.md) | Run Engine, feeders |
 | **Runs** | [runs.md](features/runs.md) | Estados, logs |
 

--- a/docs/architecture/ipc-channels.md
+++ b/docs/architecture/ipc-channels.md
@@ -1,7 +1,7 @@
 # Canales IPC (autogenerado)
 
 > **No edites a mano.** Regenera con `pnpm run generate:ipc-inventory`.
-> Última generación: 2026-06-08T11:29:04.641Z
+> Última generación: 2026-06-08T23:11:38.972Z
 
 Canales detectados vía `ipcMain.handle` / `ipcMain.on` en `electron/ipc/**/*.cjs`.
 
@@ -417,13 +417,13 @@ Canales detectados vía `ipcMain.handle` / `ipcMain.on` en `electron/ipc/**/*.cj
 | `system:get-login-item` | `electron/ipc/core/system.cjs:177` |
 | `system:quit` | `electron/ipc/core/system.cjs:210` |
 | `system:set-login-item` | `electron/ipc/core/system.cjs:188` |
-| `threads:compact` | `electron/ipc/agents/threads.cjs:226` |
-| `threads:delete` | `electron/ipc/agents/threads.cjs:173` |
-| `threads:get-history` | `electron/ipc/agents/threads.cjs:145` |
-| `threads:get-state` | `electron/ipc/agents/threads.cjs:110` |
-| `threads:list` | `electron/ipc/agents/threads.cjs:78` |
-| `threads:navigate-tree` | `electron/ipc/agents/threads.cjs:254` |
-| `threads:update-state` | `electron/ipc/agents/threads.cjs:193` |
+| `threads:compact` | `electron/ipc/agents/threads.cjs:248` |
+| `threads:delete` | `electron/ipc/agents/threads.cjs:195` |
+| `threads:get-history` | `electron/ipc/agents/threads.cjs:167` |
+| `threads:get-state` | `electron/ipc/agents/threads.cjs:132` |
+| `threads:list` | `electron/ipc/agents/threads.cjs:89` |
+| `threads:navigate-tree` | `electron/ipc/agents/threads.cjs:276` |
+| `threads:update-state` | `electron/ipc/agents/threads.cjs:215` |
 | `transcription:get-active` | `electron/ipc/media/transcription.cjs:401` |
 | `transcription:get-permissions` | `electron/ipc/media/transcription.cjs:242` |
 | `transcription:get-settings` | `electron/ipc/media/transcription.cjs:143` |

--- a/docs/features/ai-chat.md
+++ b/docs/features/ai-chat.md
@@ -7,7 +7,7 @@ Documentation for Dome's AI chat: unified client, streaming, tools, and UI.
 **Agent Teams** (v2.0.8): Multi-agent supervisor + specialized sub-agents. `electron/ipc/agent-team.cjs`. See [agent-teams.md](./agent-teams.md).
 **Agent Canvas** (v2.0.8): Visual workflow builder. `app/components/agent-canvas/`. See [agent-canvas.md](./agent-canvas.md).
 
-State: `app/lib/store/useManyStore.ts` (Many chat), `app/lib/store/useAgentChatStore.ts` (agent sessions). Main process AI: `electron/ai-chat-with-tools.cjs`, `electron/langgraph-agent.cjs`, `electron/ipc/ai.cjs`.
+State: `app/lib/store/useManyStore.ts` (Many chat), `app/lib/store/useAgentChatStore.ts` (agent sessions). Main process AI: `electron/agents/agent-runtime.cjs`, `electron/agents/dome-harness-bridge.cjs`, `electron/ipc/ai.cjs`, `electron/ipc/agents/threads.cjs`. Ver [agent-runtime.md](../architecture/agent-runtime.md).
 
 ---
 

--- a/docs/features/flashcards.md
+++ b/docs/features/flashcards.md
@@ -1,16 +1,16 @@
 # Flashcards
 
-Documentación del sistema de tarjetas de memoria de Dome con algoritmo SM-2 (Spaced Repetition).
+Documentación del sistema de tarjetas de memoria de Dome con algoritmo **FSRS** (Free Spaced Repetition Scheduler). Las tarjetas legacy con campos SM-2 se migran automáticamente (migración DB 38).
 
 ---
 
 ## Concepto
 
-Las **Flashcards** de Dome implementan el algoritmo **SM-2** (SuperMemo 2) para optimizar el aprendizaje por repetición espaciada. El sistema calcula automáticamente cuándo volver a mostrarte cada tarjeta según tu rendimiento, maximizando la retención a largo plazo.
+Las **Flashcards** de Dome implementan **FSRS** para optimizar el aprendizaje por repetición espaciada. El sistema calcula automáticamente cuándo volver a mostrarte cada tarjeta según tu rendimiento, maximizando la retención a largo plazo. La UI de estudio (`FlashPlayer`) incluye volteo 3D de la tarjeta.
 
-### ¿Qué es SM-2?
+### ¿Qué es FSRS?
 
-SM-2 es un algoritmo de repetición espaciada que:
+FSRS es un algoritmo moderno de repetición espaciada que:
 
 - Muestra las tarjetas que estás a punto de olvidar (antes de que lo hagas)
 - Si recuerdas bien una tarjeta, el intervalo hasta verla de nuevo se alarga (1d → 3d → 7d → 15d...)

--- a/docs/manual-tecnico.md
+++ b/docs/manual-tecnico.md
@@ -1,6 +1,6 @@
 # Manual Técnico — Dome Desktop
 
-> Referencia técnica consolidada para desarrolladores de Dome (v2.2.0).
+> Referencia técnica consolidada para desarrolladores de Dome (v2.3.5).
 > Asume conocimiento de TypeScript, React y Electron.
 
 ---
@@ -36,7 +36,7 @@ Dome usa el modelo multi-proceso de Electron (similar a Chrome):
 │  ✅ better-sqlite3                   │
 │  ✅ fs, child_process                │
 │  ✅ Electron APIs                    │
-│  ✅ LangGraph, LangChain             │
+│  ✅ @dome/agent-core, LangChain      │
 │  ✅ AI providers (directo)           │
 └──────────────┬───────────────────────┘
                │
@@ -224,7 +224,7 @@ const result = await window.electron.invoke('myfeature:doAction', params);
 | Semantic | `db:semantic:*`, `semantic:progress` | Embeddings, indexación, búsqueda |
 | Cloud LLM | `cloud:llm:*` | Visión / transcripción PDF e imagen (proveedor del usuario) |
 | Calendar | `calendar:*` | Events CRUD, Google Calendar sync |
-| Flashcards | `flashcards:*` | Decks, cards, SM-2 scheduling |
+| Flashcards | `flashcards:*` | Decks, cards, FSRS scheduling |
 | Studio | `studio:*` | Content generation |
 | Cloud | `cloud:*` | Google Drive, OneDrive |
 | Dome Auth | `dome-auth:*` | OAuth session con Provider |
@@ -368,19 +368,21 @@ for await (const chunk of client.streamChat(messages, options)) {
 | `dome` | dome/auto (proxy al Provider) | ✅ | ✅ | Según plan |
 | `openrouter` | Todos los modelos vía OR | ✅ | ✅ | Según modelo |
 
-### LangGraph (main process)
+### Agent runtime (main process)
 
-Las conversaciones complejas y agents usan LangGraph:
+Las conversaciones con herramientas y todos los agentes usan el harness nativo Dome (`@dome/agent-core`). Ver [architecture/agent-runtime.md](architecture/agent-runtime.md).
 
 ```javascript
-// electron/langgraph-agent.cjs
-const graph = buildAgentGraph({
-  agentConfig,
-  tools: getToolDefinitionsByIds(toolIds),
-  aiConfig: { provider, model, apiKey },
-});
+// electron/agents/agent-runtime.cjs
+const { runAgent } = require('./agent-runtime.cjs');
 
-const runId = await runEngine.startLangGraphRun({ graph, prompt, sessionId });
+await runAgent('many', {
+  threadId,
+  messages,
+  provider,
+  model,
+  tools,
+});
 ```
 
 ### Herramientas de IA disponibles
@@ -436,7 +438,7 @@ queued → running → completed
 |-------|-------------|
 | `runs:get` | Obtener run por ID |
 | `runs:list` | Listar runs con filtros |
-| `runs:startLangGraph` | Iniciar run de agente |
+| `runs:start` | Iniciar run de agente |
 | `runs:startWorkflow` | Iniciar run de workflow |
 | `runs:cancel` | Cancelar run activo |
 | `runs:resume` | Reanudar run con decisiones |
@@ -783,4 +785,4 @@ Checklist:
 
 ---
 
-*Manual Técnico — Dome v2.2.0*
+*Manual Técnico — Dome v2.3.5*

--- a/docs/manual-usuario.md
+++ b/docs/manual-usuario.md
@@ -1,6 +1,6 @@
 # Manual de Usuario — Dome
 
-> Guía completa para usuarios finales de Dome Desktop (v2.1.7).
+> Guía completa para usuarios finales de Dome Desktop (v2.3.5).
 > Este manual no requiere conocimientos técnicos.
 
 ---
@@ -36,7 +36,7 @@ Dome es una aplicación de escritorio para **gestión del conocimiento e investi
 - Generar automáticamente resúmenes, quizzes, flashcards y más
 - Crear workflows de IA complejos con una interfaz visual
 - Sincronizar con Google Calendar, Google Drive y OneDrive
-- Estudiar con repetición espaciada (SM-2)
+- Estudiar con repetición espaciada (FSRS)
 
 Dome funciona **completamente offline** con proveedores IA locales (Ollama), o conectado a la nube con OpenAI, Anthropic, Google u otros proveedores.
 
@@ -356,7 +356,7 @@ El **Studio** genera automáticamente materiales de estudio y contenido estructu
 
 ## 12. Flashcards — estudio inteligente
 
-Las **Flashcards** de Dome usan el algoritmo **SM-2** (Spaced Repetition) para optimizar cuándo repasar cada tarjeta según tu rendimiento.
+Las **Flashcards** de Dome usan el algoritmo **FSRS** (Free Spaced Repetition Scheduler) para optimizar cuándo repasar cada tarjeta según tu rendimiento. Las tarjetas se voltean con animación 3D al pulsar o con la barra espaciadora.
 
 ### Crear un deck
 

--- a/electron/agents/dome-harness-bridge.cjs
+++ b/electron/agents/dome-harness-bridge.cjs
@@ -13,17 +13,26 @@ const SESSION_CWD = 'dome';
 /** Nested harness sessions (subagents, team delegates, forks) — hidden from Many chat list. */
 const NESTED_THREAD_ID_RE = /_(sub|member|fork)_/;
 
+/**
+ * Non-Many surfaces that run through the agent runtime but must NOT appear in the
+ * Many chat history (Learn/Studio generation, agent-canvas nodes). They mark their
+ * sessions with one of these threadId prefixes.
+ */
+const NON_MANY_THREAD_PREFIXES = ['studio-', 'canvas-'];
+
 function isNestedThreadId(threadId) {
   return typeof threadId === 'string' && NESTED_THREAD_ID_RE.test(threadId);
 }
 
-/** Root Many/user sessions only — child sessions stay off the sidebar list. */
+/** Root Many/user sessions only — child / non-Many surfaces stay off the sidebar list. */
 function isRootSessionMeta(meta) {
   if (!meta || typeof meta.id !== 'string') return false;
   if (meta.parentSessionPath) return false;
   if (isNestedThreadId(meta.id)) return false;
   // Legacy per-run Many ids (pre stable threadId = sessionId).
   if (meta.id.startsWith('many_')) return false;
+  // Learn/Studio + agent-canvas runs are not Many chats.
+  if (NON_MANY_THREAD_PREFIXES.some((p) => meta.id.startsWith(p))) return false;
   return true;
 }
 

--- a/electron/core/database.cjs
+++ b/electron/core/database.cjs
@@ -3876,6 +3876,9 @@ function getQueries() {
       WHERE id = ?
     `),
     getAutomationRunById: db.prepare('SELECT * FROM automation_runs WHERE id = ?'),
+    // Workflow run ids — used to hide per-node JSONL sessions (`${runId}_${nodeId}`)
+    // from the Many chat history list (they belong to Workflows, not Many chats).
+    getWorkflowRunIds: db.prepare("SELECT id FROM automation_runs WHERE owner_type = 'workflow'"),
     getAutomationRunsByOwner: db.prepare(`
       SELECT * FROM automation_runs
       WHERE owner_type = ? AND owner_id = ?

--- a/electron/ipc/agents/threads.cjs
+++ b/electron/ipc/agents/threads.cjs
@@ -65,6 +65,17 @@ async function openThreadSession(threadId) {
   return { meta, session, repo };
 }
 
+function getWorkflowRunIdSet() {
+  try {
+    const queries = database.getQueries();
+    const rows = queries?.getWorkflowRunIds?.all() ?? [];
+    return new Set(rows.map((row) => row.id));
+  } catch (err) {
+    console.error('[threads:list] getWorkflowRunIds', err?.message);
+    return new Set();
+  }
+}
+
 async function resolveThreadProviderConfig(provider, model) {
   const queries = database.getQueries();
   const providerResult = queries.getSetting.get('ai_provider');
@@ -87,6 +98,17 @@ function register({ ipcMain, windowManager, validateSender }) {
       const rootOnly = parsedOpts.data.rootOnly !== false;
       if (rootOnly) {
         sessions = sessions.filter(bridge.isRootSessionMeta);
+        // Hide workflow per-node sessions (`${workflowRunId}_${nodeId}`): they are
+        // root JSONL sessions but belong to Workflows, not the Many chat history.
+        // Workflow run ids are UUIDs (no underscores), so the segment before the
+        // first underscore is the run id — match it against known workflow runs.
+        const workflowRunIds = getWorkflowRunIdSet();
+        if (workflowRunIds.size > 0) {
+          sessions = sessions.filter((meta) => {
+            const sep = typeof meta.id === 'string' ? meta.id.indexOf('_') : -1;
+            return sep <= 0 || !workflowRunIds.has(meta.id.slice(0, sep));
+          });
+        }
       }
       const limit = Math.min(Number(parsedOpts.data.limit ?? 100), 500);
       const threads = sessions.slice(0, limit).map((meta) => ({

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -3,19 +3,22 @@
 // fetch/stream AbortSignal usage (MCP servers, AI streams, etc.)
 require('events').EventEmitter.defaultMaxListeners = 30;
 
-// Transitive deps (p. ej. whatwg-url/tr46 vía node-fetch) aún resuelven el punycode
-// incorporado de Node; DEP0040 no lo podemos arreglar aquí sin overrides profundos.
-// Con un listener, Node deja de imprimir warnings a stderr; reenviamos el resto.
-process.on('warning', (warning) => {
-  if (
-    warning.name === 'DeprecationWarning' &&
-    warning.code === 'DEP0040' &&
-    String(warning.message).includes('punycode')
-  ) {
-    return;
-  }
-  console.warn(warning.stack || `${warning.name}: ${warning.message}`);
-});
+// DEP0040: deps transitivas (whatwg-url/tr46 vía node-fetch) hacen `require('punycode')`,
+// que carga el módulo *incorporado* y deprecado de Node. En Electron ese warning sí se
+// imprime a stderr. En vez de silenciarlo (un listener de 'warning' NO evita el print),
+// redirigimos `require('punycode')` al paquete userland equivalente: así el built-in
+// deprecado nunca se carga y DEP0040 desaparece de raíz. Debe ir antes de cargar deps.
+(() => {
+  const Module = require('module');
+  const userlandPunycode = require('punycode/');
+  const originalLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (request === 'punycode' || request === 'node:punycode') {
+      return userlandPunycode;
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+})();
 
 // Load .env in development
 const fs_env = require('fs');

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "pptx-preview": "^1.0.7",
     "pptxgenjs": "^3.12.0",
     "protobufjs": "^7.5.6",
+    "punycode": "^2.3.1",
     "pyodide": "^0.29.0",
     "react": "^18.3.0",
     "react-colorful": "^5.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       protobufjs:
         specifier: ^7.5.6
         version: 7.5.8
+      punycode:
+        specifier: ^2.3.1
+        version: 2.3.1
       pyodide:
         specifier: ^0.29.0
         version: 0.29.4


### PR DESCRIPTION
## Summary
- Publica fixes pendientes: historial Many sin sesiones Studio/canvas/workflow, redirect punycode userland.
- CHANGELOG detallado para v2.3.5 (runtime nativo, FSRS, flashcards, logos, build).
- Documentación actualizada (README, manuales, flashcards, ai-chat, MASTER).

## Test plan
- [ ] `pnpm run typecheck && pnpm run lint`
- [ ] Many sidebar no muestra runs de Studio ni nodos de workflow
- [ ] Electron arranca sin warning DEP0040 punycode en stderr