### PR TITLE
fix: CI release — materialize idempotente (v2.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Dome are documented in this file.
 
 ## [Unreleased]
 
+## [2.3.7](https://github.com/maxprain12/dome/releases/tag/v2.3.7) - 2026-06-09
+
+### Fixed
+
+- **CI release build**: `materialize:workspace-deps` fallaba en la segunda ejecución (`electron:pack` tras el paso de build) porque borraba `node_modules/@dome/*` antes de copiar — ahora siempre copia desde `packages/`.
+
 ## [2.3.6](https://github.com/maxprain12/dome/releases/tag/v2.3.6) - 2026-06-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {

--- a/scripts/materialize-workspace-deps.cjs
+++ b/scripts/materialize-workspace-deps.cjs
@@ -47,27 +47,32 @@ if (!fs.existsSync(scopeDir)) {
 
 for (const name of WORKSPACE_PKGS) {
   const linkPath = path.join(scopeDir, name);
+  const sourcePkgDir = path.join(root, 'packages', name);
+
   if (!fs.existsSync(linkPath)) {
     fail(`Missing @dome/${name} in node_modules`);
   }
+  if (!fs.existsSync(sourcePkgDir)) {
+    fail(`Missing packages/${name} — workspace package not checked out`);
+  }
 
-  const stat = fs.lstatSync(linkPath);
-  const realPkgDir = stat.isSymbolicLink() ? fs.realpathSync(linkPath) : linkPath;
-  const indexJs = path.join(realPkgDir, 'dist', 'index.js');
+  const indexJs = path.join(sourcePkgDir, 'dist', 'index.js');
   if (!fs.existsSync(indexJs)) {
     fail(`@dome/${name} dist/index.js not built — run pnpm run build:packages`);
   }
 
+  const stat = fs.lstatSync(linkPath);
   if (stat.isSymbolicLink()) {
     const tmpDir = path.join(scopeDir, `.${name}.materialize.tmp`);
-    copyPackage(realPkgDir, tmpDir);
+    copyPackage(sourcePkgDir, tmpDir);
     fs.rmSync(linkPath);
     fs.renameSync(tmpDir, linkPath);
-    console.log(`[materialize-workspace-deps] Materialized @dome/${name} from ${realPkgDir}`);
+    console.log(`[materialize-workspace-deps] Materialized @dome/${name} from ${sourcePkgDir}`);
   } else {
-    // Refresh dist in an already-materialized directory (idempotent rebuilds).
-    copyPackage(realPkgDir, linkPath);
-    console.log(`[materialize-workspace-deps] Refreshed @dome/${name}`);
+    // Idempotent: CI runs materialize twice (build step + electron:pack). Always copy
+    // from packages/, never from node_modules/@dome/* (copyPackage rmSync would delete source).
+    copyPackage(sourcePkgDir, linkPath);
+    console.log(`[materialize-workspace-deps] Refreshed @dome/${name} from ${sourcePkgDir}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Corrige fallo del workflow Build Electron App v2.3.6: segunda ejecución de `materialize:workspace-deps` borraba el destino y fallaba con `package.json missing`.
- Siempre usa `packages/<name>` como fuente de copia.

## Test plan
- [ ] `pnpm run materialize:workspace-deps` dos veces seguidas sin error
- [ ] Build release v2.3.7 genera artefactos macOS/Windows