### PR TITLE
feat(ux): errores del main process visibles para el usuario (06/T03)

### DIFF
--- a/app/components/shell/AppShell.tsx
+++ b/app/components/shell/AppShell.tsx
@@ -12,6 +12,7 @@ import ResizeHandle from '@/components/workspace/ResizeHandle';
 import WindowControls from '@/components/ui/WindowControls';
 import DomeButton from '@/components/ui/DomeButton';
 import ManyVoiceBridge from '@/components/many/ManyVoiceBridge';
+import SystemErrorNotifier from '@/components/shell/SystemErrorNotifier';
 import TranscriptionPill from '@/components/transcription/TranscriptionPill';
 import { useTranscriptionStore } from '@/lib/transcription/useTranscriptionStore';
 import ApprovalProvider from '@/components/approval/ApprovalProvider';
@@ -402,6 +403,7 @@ export default function AppShell() {
 
       {/* Voice IPC bridge — always mounted, zero UI */}
       <ManyVoiceBridge />
+      <SystemErrorNotifier />
 
       {/* In-app HITL approval modals */}
       <ApprovalProvider />

--- a/app/components/shell/SystemErrorNotifier.tsx
+++ b/app/components/shell/SystemErrorNotifier.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { notifications } from '@mantine/notifications';
+import { useTabStore } from '@/lib/store/useTabStore';
+
+interface SystemErrorPayload {
+  severity: 'error' | 'warning';
+  scope: string;
+  code: string;
+  message: string;
+  detail?: string;
+  runId?: string;
+  title?: string;
+  ts: number;
+}
+
+const KNOWN_SCOPES = new Set(['runs', 'workflows', 'automations', 'ai', 'indexing', 'sync']);
+const KNOWN_CODES = new Set([
+  'invalid_api_key',
+  'rate_limit',
+  'model_not_found',
+  'network',
+  'context_overflow',
+  'unknown',
+]);
+
+/**
+ * Global listener for `system:error-notification` (broadcast by
+ * electron/core/error-notify.cjs). Renders main-process failures as Mantine
+ * toasts with a translated cause+action message; the raw error goes in a
+ * secondary line so the user can report it. Mounted once in AppShell.
+ */
+export default function SystemErrorNotifier() {
+  const { t } = useTranslation();
+  const openSettingsTab = useTabStore((s) => s.openSettingsTab);
+
+  useEffect(() => {
+    const on = window.electron?.on;
+    if (!on) return undefined;
+
+    const cleanup = on('system:error-notification', (payload: SystemErrorPayload) => {
+      if (!payload || typeof payload !== 'object') return;
+      const scope = KNOWN_SCOPES.has(payload.scope) ? payload.scope : 'app';
+      const code = KNOWN_CODES.has(payload.code) ? payload.code : 'unknown';
+      const scopeTitle = t(`errors.system.scope.${scope}`);
+      const codeMessage = t(`errors.system.code.${code}`);
+
+      const title = payload.title ? `${scopeTitle} — ${payload.title}` : scopeTitle;
+      // For unknown codes, the raw (truncated) message is the most useful
+      // detail; for classified codes it goes on a secondary line.
+      const message =
+        code === 'unknown' && payload.message
+          ? `${codeMessage}\n${payload.message.slice(0, 200)}`
+          : codeMessage;
+
+      notifications.show({
+        id: `system-error-${scope}`,
+        color: payload.severity === 'warning' ? 'yellow' : 'red',
+        title,
+        message,
+        autoClose: 10000,
+        withCloseButton: true,
+        onClick: code === 'invalid_api_key' || code === 'model_not_found'
+          ? () => openSettingsTab()
+          : undefined,
+        style: { cursor: code === 'invalid_api_key' || code === 'model_not_found' ? 'pointer' : undefined },
+      });
+    });
+
+    return cleanup;
+  }, [t, openSettingsTab]);
+
+  return null;
+}

--- a/docs/auditoria/06-calidad-observabilidad/T03-errores-visibles-usuario.md
+++ b/docs/auditoria/06-calidad-observabilidad/T03-errores-visibles-usuario.md
@@ -1,6 +1,7 @@
 # T03 — Errores de tools/runs visibles para el usuario
 
 **Prioridad**: P2 · **Severidad**: Media · **Esfuerzo**: M · **Área**: Observabilidad / UX
+**Estado**: ✅ Implementado (2026-06-10, rama `feat/ux-errores-visibles`) — `electron/core/error-notify.cjs` es el embudo único: loguea con el logger estructurado (T02) y emite `system:error-notification` (broadcast, throttle 1/min por scope). Clasificador de errores comunes (`invalid_api_key`, `rate_limit`, `model_not_found`, `network`, `context_overflow`) → mensajes i18n con causa+acción en 4 idiomas (`errors.system.*`). Conectado a: fallo de agent-run y de workflow en `run-engine.cjs` (scope `runs`/`workflows`) y fallo de automation en `automation-service.cjs` (scope `automations`). Renderer: `SystemErrorNotifier.tsx` montado en AppShell muestra toasts Mantine (click en errores de clave/modelo abre Settings). `RunLogView` ya mostraba `run.error` en un callout (sin cambios). Tests: `error-notify.test.mjs` (4: classify, payload, throttle, sin windowManager).
 
 ## Problema
 

--- a/electron/__tests__/error-notify.test.mjs
+++ b/electron/__tests__/error-notify.test.mjs
@@ -1,0 +1,57 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { init, notifyError, classifyError, _resetThrottle } = require('../core/error-notify.cjs');
+
+function makeFakeWindowManager() {
+  const broadcasts = [];
+  return {
+    broadcasts,
+    broadcast: (channel, payload) => broadcasts.push({ channel, payload }),
+  };
+}
+
+describe('error-notify', () => {
+  beforeEach(() => _resetThrottle());
+
+  it('classifies common provider errors', () => {
+    assert.equal(classifyError('401 Unauthorized: invalid api key'), 'invalid_api_key');
+    assert.equal(classifyError('Rate limit exceeded (429)'), 'rate_limit');
+    assert.equal(classifyError('The model `gpt-99` does not exist'), 'model_not_found');
+    assert.equal(classifyError('fetch failed: ECONNREFUSED 127.0.0.1'), 'network');
+    assert.equal(classifyError('maximum context length is 8192 tokens'), 'context_overflow');
+    assert.equal(classifyError('something exploded'), 'unknown');
+  });
+
+  it('broadcasts a compact payload on system:error-notification', () => {
+    const wm = makeFakeWindowManager();
+    init(wm);
+    notifyError({ scope: 'runs', message: 'invalid api key', runId: 'r1', title: 'My run' });
+    assert.equal(wm.broadcasts.length, 1);
+    const { channel, payload } = wm.broadcasts[0];
+    assert.equal(channel, 'system:error-notification');
+    assert.equal(payload.scope, 'runs');
+    assert.equal(payload.code, 'invalid_api_key');
+    assert.equal(payload.runId, 'r1');
+    assert.equal(payload.title, 'My run');
+  });
+
+  it('throttles repeated errors per scope (1/min)', () => {
+    const wm = makeFakeWindowManager();
+    init(wm);
+    notifyError({ scope: 'automations', message: 'boom 1' });
+    notifyError({ scope: 'automations', message: 'boom 2' });
+    notifyError({ scope: 'automations', message: 'boom 3' });
+    assert.equal(wm.broadcasts.length, 1);
+    // A different scope is not throttled by the first one
+    notifyError({ scope: 'runs', message: 'other failure' });
+    assert.equal(wm.broadcasts.length, 2);
+  });
+
+  it('does not crash when windowManager is missing', () => {
+    init(null);
+    assert.doesNotThrow(() => notifyError({ scope: 'runs', message: 'x' }));
+  });
+});

--- a/electron/agents/automation-service.cjs
+++ b/electron/agents/automation-service.cjs
@@ -2,6 +2,7 @@
 
 const runEngine = require('./run-engine.cjs');
 const database = require('../core/database.cjs');
+const { notifyError } = require('../core/error-notify.cjs');
 
 const TICK_INTERVAL_MS = 60 * 1000;
 
@@ -78,6 +79,11 @@ async function tick() {
       await runEngine.startAutomationNow(automation.id);
     } catch (error) {
       console.error(`[Automation] Failed to run ${automation.id}:`, error?.message || error);
+      notifyError({
+        scope: 'automations',
+        message: error?.message || String(error),
+        title: automation.title || automation.id,
+      });
     }
   }
 }

--- a/electron/agents/run-engine.cjs
+++ b/electron/agents/run-engine.cjs
@@ -14,6 +14,7 @@ const { parseRuntimeContext } = require('./agent-runtime-context.cjs');
 const { buildDomeSystemPrompt } = require('../prompts/system-prompt.cjs');
 const { readPrompt } = require('../prompts/prompts-loader.cjs');
 const logger = require('../core/logger.cjs');
+const { notifyError } = require('../core/error-notify.cjs');
 
 function manySubagentIds() {
   const { manySubagentIds: ids } = require('./subagents-native.cjs');
@@ -1293,6 +1294,14 @@ async function executeAgentRun(runId, params) {
       content: error?.message || String(error),
       ...(context.llmUsage ? { metadata: { usage: context.llmUsage } } : {}),
     });
+    if (!aborted) {
+      notifyError({
+        scope: 'runs',
+        message: error?.message || String(error),
+        runId,
+        title: getRun(runId)?.title || undefined,
+      });
+    }
     const currentMeta = getRun(runId)?.metadata ?? {};
     const patched = await patchRun(runId, {
       status: aborted ? 'cancelled' : 'failed',
@@ -1942,6 +1951,14 @@ async function executeWorkflowRun(runId, params, workflow) {
           ...(workflowLlmUsage ? { usage: workflowLlmUsage } : {}),
         },
       });
+      if (!aborted) {
+        notifyError({
+          scope: 'workflows',
+          message: error?.message || String(error),
+          runId,
+          title: workflow?.title || workflow?.name || undefined,
+        });
+      }
       patchRun(runId, {
         status: aborted ? 'cancelled' : 'failed',
         error: aborted ? null : (error?.message || String(error)),

--- a/electron/core/error-notify.cjs
+++ b/electron/core/error-notify.cjs
@@ -1,0 +1,89 @@
+/* eslint-disable no-console */
+/**
+ * User-visible error notifications (docs/auditoria/06-calidad-observabilidad/T03).
+ *
+ * Single funnel for main-process failures the user should know about: logs the
+ * full detail via the structured logger AND broadcasts a compact, renderer-safe
+ * payload on `system:error-notification` (shown as a toast by
+ * app/components/shell/SystemErrorNotifier.tsx).
+ *
+ * Throttled per scope so a broken automation firing every minute produces one
+ * toast per window, not fifty.
+ */
+
+const logger = require('./logger.cjs');
+
+const THROTTLE_MS = 60 * 1000;
+
+/** scope → last broadcast timestamp */
+const lastNotifiedByScope = new Map();
+
+let _windowManager = null;
+
+function init(windowManager) {
+  _windowManager = windowManager;
+}
+
+/**
+ * Map raw error text to a stable code the renderer can translate with
+ * cause + action. Keep coarse — detail goes to the log, not the toast.
+ */
+function classifyError(message) {
+  const text = String(message || '').toLowerCase();
+  if (/(invalid[ _]?api[ _-]?key|incorrect api key|unauthorized|401|authentication)/.test(text)) {
+    return 'invalid_api_key';
+  }
+  if (/(rate.?limit|429|quota|insufficient_quota)/.test(text)) return 'rate_limit';
+  if (/(model.*(not found|does not exist)|404.*model)/.test(text)) return 'model_not_found';
+  if (/(econnrefused|enotfound|etimedout|fetch failed|network|socket hang up)/.test(text)) {
+    return 'network';
+  }
+  if (/(context.*(length|window)|too many tokens|maximum.*tokens)/.test(text)) {
+    return 'context_overflow';
+  }
+  return 'unknown';
+}
+
+/**
+ * @param {object} opts
+ * @param {'error'|'warning'} [opts.severity]
+ * @param {string} opts.scope    — 'runs' | 'automations' | 'ai' | 'indexing' | 'sync' | …
+ * @param {string} opts.message  — short, raw error message (renderer maps code → i18n)
+ * @param {string} [opts.detail] — technical detail (logged, shown in expandible)
+ * @param {string} [opts.runId]
+ * @param {string} [opts.title]  — context label (run/automation title)
+ */
+function notifyError({ severity = 'error', scope, message, detail, runId, title }) {
+  const code = classifyError(message);
+  const log = severity === 'warning' ? logger.warn : logger.error;
+  log(scope || 'app', message || 'Unknown error', { detail, runId, title, code });
+
+  if (!_windowManager) return;
+
+  const now = Date.now();
+  const last = lastNotifiedByScope.get(scope) ?? 0;
+  if (now - last < THROTTLE_MS) return;
+  lastNotifiedByScope.set(scope, now);
+
+  try {
+    _windowManager.broadcast('system:error-notification', {
+      severity,
+      scope,
+      code,
+      message: String(message || '').slice(0, 500),
+      detail: detail ? String(detail).slice(0, 1000) : undefined,
+      runId,
+      title,
+      ts: now,
+    });
+  } catch (err) {
+    console.error('[error-notify] broadcast failed:', err?.message);
+  }
+}
+
+/** Test hook. */
+function _resetThrottle() {
+  lastNotifiedByScope.clear();
+}
+
+module.exports = { init, notifyError, classifyError, _resetThrottle };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -238,6 +238,7 @@ const calendarNotificationService = require('./calendar/calendar-notification-se
 const calendarSyncScheduler = require('./calendar/calendar-sync-scheduler.cjs');
 const automationService = require('./agents/automation-service.cjs');
 const runRetention = require('./agents/run-retention.cjs');
+const errorNotify = require('./core/error-notify.cjs');
 const runEngine = require('./agents/run-engine.cjs');
 const { validateSender, sanitizePath, validateUrl } = require('./core/security.cjs');
 const { setupContentSecurityPolicy } = require('./core/csp.cjs');
@@ -1045,6 +1046,7 @@ app
     runEngine.init(windowManager, database, ttsService);
     automationService.init(windowManager, database);
     runRetention.init();
+    errorNotify.init(windowManager);
 
     // Initialize the app in background (SQLite settings, filesystem)
     initModule.initializeApp().catch(err => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -557,6 +557,8 @@ const ALLOWED_CHANNELS = {
   // Canales para on/once (main → renderer)
   on: [
     'theme-changed',
+    // System error notifications (main → toast in renderer)
+    'system:error-notification',
     // Resource events
     'resource:created',
     'resource:updated',

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:filesystem-tools": "node --test scripts/test-filesystem-tools.mjs",
     "test:feeders": "node --test scripts/test-feeders.mjs",
     "test:web-search": "node --test scripts/test-web-search.mjs",
-    "test:security": "node --test electron/__tests__/shell-policy.test.mjs electron/__tests__/url-guard.test.mjs electron/__tests__/migration-backup.test.mjs electron/__tests__/settings-secrets.test.mjs electron/__tests__/security-path.test.mjs electron/__tests__/logger.test.mjs electron/__tests__/tool-call-policy.test.mjs electron/__tests__/run-retention.test.mjs",
+    "test:security": "node --test electron/__tests__/shell-policy.test.mjs electron/__tests__/url-guard.test.mjs electron/__tests__/migration-backup.test.mjs electron/__tests__/settings-secrets.test.mjs electron/__tests__/security-path.test.mjs electron/__tests__/logger.test.mjs electron/__tests__/tool-call-policy.test.mjs electron/__tests__/run-retention.test.mjs electron/__tests__/error-notify.test.mjs",
     "test": "pnpm run test:security && pnpm --filter @dome/agent-core run test",
     "test:studio": "node scripts/test-studio-validators.mjs",
     "test:studio:tools": "node scripts/test-studio-tools.mjs",

--- a/packages/i18n/locales/en/errors.json
+++ b/packages/i18n/locales/en/errors.json
@@ -1,3 +1,24 @@
 {
-  "database_unavailable": "Database not available"
+  "database_unavailable": "Database not available",
+  "system": {
+    "scope": {
+      "runs": "Agent run failed",
+      "workflows": "Workflow failed",
+      "automations": "Automation failed",
+      "ai": "AI provider error",
+      "indexing": "Indexing problem",
+      "sync": "Sync problem",
+      "app": "Application error"
+    },
+    "code": {
+      "invalid_api_key": "The API key was rejected by the provider. Check your key in Settings → AI.",
+      "rate_limit": "The provider rate limit was reached. Wait a moment and try again, or check your plan.",
+      "model_not_found": "The selected model is not available. Pick another model in Settings → AI.",
+      "network": "Could not reach the service. Check your internet connection and try again.",
+      "context_overflow": "The conversation is too long for the model. Start a new chat or compact the thread.",
+      "unknown": "Something went wrong. The technical detail is in the log."
+    },
+    "viewDetails": "View details",
+    "openAiSettings": "Open AI settings"
+  }
 }

--- a/packages/i18n/locales/es/errors.json
+++ b/packages/i18n/locales/es/errors.json
@@ -1,3 +1,24 @@
 {
-  "database_unavailable": "Base de datos no disponible"
+  "database_unavailable": "Base de datos no disponible",
+  "system": {
+    "scope": {
+      "runs": "Run de agente fallido",
+      "workflows": "Workflow fallido",
+      "automations": "Automatización fallida",
+      "ai": "Error del proveedor de IA",
+      "indexing": "Problema de indexación",
+      "sync": "Problema de sincronización",
+      "app": "Error de la aplicación"
+    },
+    "code": {
+      "invalid_api_key": "El proveedor rechazó la API key. Revisa tu clave en Ajustes → IA.",
+      "rate_limit": "Se alcanzó el límite de peticiones del proveedor. Espera un momento y reintenta, o revisa tu plan.",
+      "model_not_found": "El modelo seleccionado no está disponible. Elige otro modelo en Ajustes → IA.",
+      "network": "No se pudo conectar con el servicio. Comprueba tu conexión a internet y reintenta.",
+      "context_overflow": "La conversación es demasiado larga para el modelo. Empieza un chat nuevo o compacta el hilo.",
+      "unknown": "Algo salió mal. El detalle técnico está en el log."
+    },
+    "viewDetails": "Ver detalles",
+    "openAiSettings": "Abrir ajustes de IA"
+  }
 }

--- a/packages/i18n/locales/fr/errors.json
+++ b/packages/i18n/locales/fr/errors.json
@@ -1,3 +1,24 @@
 {
-  "database_unavailable": "Base de données indisponible"
+  "database_unavailable": "Base de données indisponible",
+  "system": {
+    "scope": {
+      "runs": "Échec du run d'agent",
+      "workflows": "Échec du workflow",
+      "automations": "Échec de l'automatisation",
+      "ai": "Erreur du fournisseur d'IA",
+      "indexing": "Problème d'indexation",
+      "sync": "Problème de synchronisation",
+      "app": "Erreur de l'application"
+    },
+    "code": {
+      "invalid_api_key": "Le fournisseur a rejeté la clé API. Vérifiez votre clé dans Paramètres → IA.",
+      "rate_limit": "La limite de requêtes du fournisseur est atteinte. Patientez un instant et réessayez, ou vérifiez votre forfait.",
+      "model_not_found": "Le modèle sélectionné n'est pas disponible. Choisissez un autre modèle dans Paramètres → IA.",
+      "network": "Impossible de joindre le service. Vérifiez votre connexion internet et réessayez.",
+      "context_overflow": "La conversation est trop longue pour le modèle. Démarrez une nouvelle discussion ou compactez le fil.",
+      "unknown": "Une erreur s'est produite. Le détail technique est dans le journal."
+    },
+    "viewDetails": "Voir les détails",
+    "openAiSettings": "Ouvrir les paramètres IA"
+  }
 }

--- a/packages/i18n/locales/pt/errors.json
+++ b/packages/i18n/locales/pt/errors.json
@@ -1,3 +1,24 @@
 {
-  "database_unavailable": "Banco de dados indisponível"
+  "database_unavailable": "Banco de dados indisponível",
+  "system": {
+    "scope": {
+      "runs": "Falha no run do agente",
+      "workflows": "Falha no workflow",
+      "automations": "Falha na automação",
+      "ai": "Erro do provedor de IA",
+      "indexing": "Problema de indexação",
+      "sync": "Problema de sincronização",
+      "app": "Erro do aplicativo"
+    },
+    "code": {
+      "invalid_api_key": "O provedor rejeitou a API key. Verifique sua chave em Configurações → IA.",
+      "rate_limit": "O limite de requisições do provedor foi atingido. Aguarde um momento e tente novamente, ou verifique seu plano.",
+      "model_not_found": "O modelo selecionado não está disponível. Escolha outro modelo em Configurações → IA.",
+      "network": "Não foi possível conectar ao serviço. Verifique sua conexão com a internet e tente novamente.",
+      "context_overflow": "A conversa é longa demais para o modelo. Inicie um novo chat ou compacte a thread.",
+      "unknown": "Algo deu errado. O detalhe técnico está no log."
+    },
+    "viewDetails": "Ver detalhes",
+    "openAiSettings": "Abrir configurações de IA"
+  }
 }


### PR DESCRIPTION
Reapertura de #353 contra `main` tras el merge de #351 (la PR original se cerró al borrarse la rama base). Mismo contenido, rebasado sobre main — ver #353 para la descripción completa y el checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)