### PR TITLE
refactor(ui): unificar botones — Mantine Button → DomeButton + regla de lint (03/T05)

### DIFF
--- a/app/components/editor/EmbedModal.tsx
+++ b/app/components/editor/EmbedModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Modal, Stack, TextInput, Button, Text } from '@mantine/core';
+import { Modal, Stack, TextInput, Text } from '@mantine/core';
+import DomeButton from '@/components/ui/DomeButton';
 import { useTranslation } from 'react-i18next';
 import type { Editor } from '@tiptap/core';
 import type { NoteEmbedKind } from '@/lib/tiptap/extensions/note-editor-bridge';
@@ -71,7 +72,7 @@ export default function EmbedModal({ opened, onClose, editor, kind }: EmbedModal
             {err}
           </Text>
         )}
-        <Button onClick={submit}>{t('editor.embed_modal_submit')}</Button>
+        <DomeButton variant="primary" onClick={submit}>{t('editor.embed_modal_submit')}</DomeButton>
       </Stack>
     </Modal>
   );

--- a/app/components/shell/FolderTabView.tsx
+++ b/app/components/shell/FolderTabView.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useCallback, useState, useRef, useEffect, Fragment } from 'react';
-import { Modal, ScrollArea, Stack, UnstyledButton, Text, Group, Button } from '@mantine/core';
+import { Modal, ScrollArea, Stack, UnstyledButton, Text, Group } from '@mantine/core';
+import DomeButton from '@/components/ui/DomeButton';
 import { formatDistanceToNow } from 'date-fns';
 import {
   FolderOpen, Folder, FileText, Plus, Home, ChevronRight,
@@ -1171,9 +1172,9 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
             </Stack>
           </ScrollArea.Autosize>
           <Group justify="flex-end">
-            <Button variant="default" onClick={() => setFolderPickOpen(false)}>
+            <DomeButton variant="secondary" onClick={() => setFolderPickOpen(false)}>
               {t('common.cancel')}
-            </Button>
+            </DomeButton>
           </Group>
         </Stack>
       </Modal>

--- a/app/components/ui/emoji-picker.tsx
+++ b/app/components/ui/emoji-picker.tsx
@@ -2,9 +2,9 @@ import React, { useState, type ReactNode } from "react";
 import {
   ActionIcon,
   Popover,
-  Button,
   useMantineColorScheme,
 } from "@mantine/core";
+import DomeButton from "@/components/ui/DomeButton";
 import { useClickOutside, useDisclosure, useWindowEvent } from "@mantine/hooks";
 import { Suspense } from "react";
 const Picker = React.lazy(() => import("@emoji-mart/react"));
@@ -88,9 +88,8 @@ function EmojiPicker({
             skinTonePosition="search"
             theme={colorScheme}
           />
-          <Button
-            variant="default"
-            c="gray"
+          <DomeButton
+            variant="secondary"
             size="xs"
             style={{
               position: "absolute",
@@ -101,7 +100,7 @@ function EmojiPicker({
             onClick={handleRemoveEmoji}
           >
             {t("Remove")}
-          </Button>
+          </DomeButton>
         </Popover.Dropdown>
       </Suspense>
     </Popover>

--- a/app/components/workspace/MoveToProjectModal.tsx
+++ b/app/components/workspace/MoveToProjectModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Modal, Text, ScrollArea, UnstyledButton, Button, Group, Stack } from '@mantine/core';
+import { Modal, Text, ScrollArea, UnstyledButton, Group, Stack } from '@mantine/core';
+import DomeButton from '@/components/ui/DomeButton';
 import { useTranslation } from 'react-i18next';
 import type { Project } from '@/types';
 import type { Resource } from '@/lib/hooks/useResources';
@@ -204,16 +205,17 @@ export default function MoveToProjectModal({
         ) : null}
 
         <Group justify="flex-end" mt="md">
-          <Button variant="default" onClick={onClose} disabled={submitting}>
+          <DomeButton variant="secondary" onClick={onClose} disabled={submitting}>
             {t('common.cancel')}
-          </Button>
-          <Button
+          </DomeButton>
+          <DomeButton
+            variant="primary"
             onClick={() => void handleMove()}
             loading={submitting}
             disabled={!pickedId || roots.length === 0 || eligibleProjects.length === 0}
           >
             {t('moveProject.confirm')}
-          </Button>
+          </DomeButton>
         </Group>
       </Stack>
     </Modal>

--- a/app/components/workspace/file-manager/FileManagerTree.tsx
+++ b/app/components/workspace/file-manager/FileManagerTree.tsx
@@ -16,7 +16,8 @@ import type { Resource } from '@/lib/hooks/useResources';
 import MoveToProjectModal, { filterMoveProjectRoots } from '@/components/workspace/MoveToProjectModal';
 import { useTranslation } from 'react-i18next';
 import SelectionActionBar from '@/components/home/SelectionActionBar';
-import { Modal, ScrollArea, Stack, UnstyledButton, Text, Group, Button } from '@mantine/core';
+import { Modal, ScrollArea, Stack, UnstyledButton, Text, Group } from '@mantine/core';
+import DomeButton from '@/components/ui/DomeButton';
 import DomeResourceIcon from '@/components/ui/DomeResourceIcon';
 
 type TreeNodeData = {
@@ -631,9 +632,9 @@ export function FileManagerTree({ compact = false, onRefresh }: FileManagerTreeP
             </Stack>
           </ScrollArea.Autosize>
           <Group justify="flex-end">
-            <Button variant="default" onClick={() => setFolderPickOpen(false)}>
+            <DomeButton variant="secondary" onClick={() => setFolderPickOpen(false)}>
               {t('common.cancel')}
-            </Button>
+            </DomeButton>
           </Group>
         </Stack>
       </Modal>

--- a/docs/auditoria/03-ux-componentes/T05-unificar-botones.md
+++ b/docs/auditoria/03-ux-componentes/T05-unificar-botones.md
@@ -1,6 +1,7 @@
 # T05 — Unificar botones: Mantine Button → DomeButton
 
 **Prioridad**: P2 · **Severidad**: Baja · **Esfuerzo**: M · **Área**: UX Componentes
+**Estado**: ✅ Implementado (2026-06-11, rama `refactor/ux-unificar-botones`) — los 6 usos de `Button` de Mantine migrados a `DomeButton` (EmbedModal, MoveToProjectModal con loading, FileManagerTree, FolderTabView, emoji-picker); regla ESLint `no-restricted-imports` en **error** prohíbe reintroducirlo. Los `<button className="btn …">` crudos (54) usan las clases del design system — mismo CSS que emite `DomeButton` (`.btn .btn-primary/...`), así que están unificados por construcción y son el escape válido del punto 4; migrarlos a componente queda como mejora oportunista al tocar cada archivo (T02).
 
 ## Problema
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,20 @@ export default tseslint.config(
 
       // P-001 — renderer must not import Node/DB/Electron (see docs/principles.md)
       'dome/no-renderer-node-imports': 'error',
+
+      // 03/T05 — buttons go through DomeButton (design system), not Mantine
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@mantine/core',
+              importNames: ['Button'],
+              message: 'Usa DomeButton (@/components/ui/DomeButton) en lugar de Button de Mantine.',
+            },
+          ],
+        },
+      ],
     },
   },
 );


### PR DESCRIPTION
Reapertura de #356 contra `main` tras el merge de #351 (la PR original se cerró al borrarse la rama base). Mismo contenido, rebasado sobre main — ver #356 para la descripción completa y el checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)