### PR TITLE
fix(ux): contrato responsive 800×600 y colapso del shell en ventanas estrechas (03/T06)

### DIFF
--- a/.claude/rules/ui-style-guidelines.md
+++ b/.claude/rules/ui-style-guidelines.md
@@ -420,16 +420,25 @@ Los valores hex por tema viven en `app/globals.css` (`:root` y `[data-theme="dar
 
 ---
 
-## Responsive Breakpoints
+## Responsive Breakpoints (desktop app — 03/T06)
 
-```css
-/* Mobile first approach */
---breakpoint-sm: 640px;   /* Large phones */
---breakpoint-md: 768px;   /* Tablets */
---breakpoint-lg: 1024px;  /* Small laptops */
---breakpoint-xl: 1280px;  /* Desktops */
---breakpoint-2xl: 1536px; /* Large screens */
-```
+Dome es una app Electron: el objetivo es robustez entre la ventana mínima y
+pantallas grandes, **no** mobile-first. Contrato vigente:
+
+| Umbral | Qué pasa |
+|--------|----------|
+| **800×600** | Tamaño mínimo de ventana, forzado en `electron/main.cjs` (`minWidth`/`minHeight`). Toda vista principal debe ser usable aquí. |
+| **≤ 980px** | El panel derecho (Many) pasa a overlay (`position: absolute`, `width: min(380px, 86vw)`) y el sidebar izquierdo cede ancho (`min(260px, 28vw)`, mínimo 200px). Definido en `app/globals.css` (`@media (max-width: 980px)`). |
+| **> 980px** | Layout de tres paneles completo (sidebar 260px + contenido + Many 280–600px redimensionable). |
+
+Reglas al añadir UI nueva:
+- Anchos fijos solo si caben a 800px de ventana; si no, `min()`/`clamp()`.
+- El contenido principal siempre con `min-width: 0` dentro de filas flex.
+- Probar a 800×600 y ~1000×700 antes de mergear cambios de layout.
+
+Tailwind sigue ofreciendo sus breakpoints estándar (`sm`/`md`/`lg`…) para
+utilidades puntuales, pero los umbrales de comportamiento del shell son los
+de la tabla.
 
 ---
 

--- a/app/components/workspace/UnifiedSidebar.tsx
+++ b/app/components/workspace/UnifiedSidebar.tsx
@@ -1765,7 +1765,7 @@ export default function UnifiedSidebar({ collapsed, onCollapse: _onCollapse }: U
 
   return (
     <aside
-      className="flex flex-col h-full relative shrink-0 overflow-hidden"
+      className="dome-left-sidebar flex flex-col h-full relative shrink-0 overflow-hidden"
       style={{ width: 260, minWidth: 260, background: 'var(--dome-sidebar-bg)', borderRight: '1px solid var(--dome-border)' }}
     >
       {/* Proyecto activo + selector (antes marca fija) */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -88,6 +88,12 @@
       min-width: 0;
     }
 
+    /* 03/T06: ventanas estrechas — el sidebar cede ancho al contenido */
+    .dome-left-sidebar {
+      width: min(260px, 28vw) !important;
+      min-width: 200px !important;
+    }
+
     .dome-right-panel {
       position: absolute;
       top: 0;

--- a/docs/auditoria/03-ux-componentes/T06-responsive.md
+++ b/docs/auditoria/03-ux-componentes/T06-responsive.md
@@ -1,6 +1,7 @@
 # T06 — Responsive y ventanas pequeñas
 
 **Prioridad**: P3 · **Severidad**: Baja · **Esfuerzo**: M · **Área**: UX Componentes
+**Estado**: ✅ Implementado (2026-06-11, rama `fix/ux-responsive`) — contrato fijado en **800×600** (`minWidth`/`minHeight` de la ventana principal en `main.cjs`, antes 1024×768 que impedía media ventana en un 13"). El shell ya colapsaba el panel Many a overlay en ≤980px (`min(380px, 86vw)`); se añade que el sidebar izquierdo ceda ancho (`min(260px, 28vw)`, mínimo 200px) bajo ese mismo umbral (clase `dome-left-sidebar` nueva). Breakpoints del proyecto documentados en `.claude/rules/ui-style-guidelines.md` con semántica de app de escritorio (reemplaza la tabla mobile-first genérica). Pendiente manual: pase de prueba a 800×600 y ~1000×700 por home, chat/Many, viewer PDF, settings, learn, canvas y runs.
 
 ## Problema
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -382,8 +382,10 @@ async function createWindow() {
     {
       width: 1400,
       height: 900,
-      minWidth: 1024,
-      minHeight: 768,
+      // Contrato responsive (03/T06): la app debe ser usable hasta 800×600
+      // (media ventana en un portátil de 13"); el CSS colapsa paneles antes.
+      minWidth: 800,
+      minHeight: 600,
       icon: fs.existsSync(getAssetPath('icon.png'))
         ? getAssetPath('icon.png')
         : undefined,


### PR DESCRIPTION
Reapertura de #358 contra `main` tras el merge de #351 (la PR original se cerró al borrarse la rama base). Mismo contenido, rebasado sobre main — ver #358 para la descripción completa y el checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)