### PR TITLE
refactor(ux): migrar los 6 modales Mantine a DomeModal — fase 3 (03/T01)

### DIFF
--- a/app/components/editor/EmbedModal.tsx
+++ b/app/components/editor/EmbedModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Modal, Stack, TextInput, Text } from '@mantine/core';
+import { Stack, TextInput, Text } from '@mantine/core';
+import DomeModal from '@/components/ui/DomeModal';
 import DomeButton from '@/components/ui/DomeButton';
 import { useTranslation } from 'react-i18next';
 import type { Editor } from '@tiptap/core';
@@ -39,17 +40,19 @@ export default function EmbedModal({ opened, onClose, editor, kind }: EmbedModal
     onClose();
   };
 
+  const handleClose = () => {
+    setUrl('');
+    setErr(null);
+    onClose();
+  };
+
   return (
-    <Modal
-      opened={opened}
-      onClose={() => {
-        setUrl('');
-        setErr(null);
-        onClose();
-      }}
+    <DomeModal
+      open={opened}
+      onClose={handleClose}
       title={kind === 'youtube' ? t('editor.embed_modal_title_youtube') : t('editor.embed_modal_title_iframe')}
       size="md"
-      centered
+      footer={<DomeButton variant="primary" onClick={submit}>{t('editor.embed_modal_submit')}</DomeButton>}
     >
       <Stack gap="md">
         <Text size="sm" c="dimmed">
@@ -72,8 +75,7 @@ export default function EmbedModal({ opened, onClose, editor, kind }: EmbedModal
             {err}
           </Text>
         )}
-        <DomeButton variant="primary" onClick={submit}>{t('editor.embed_modal_submit')}</DomeButton>
       </Stack>
-    </Modal>
+    </DomeModal>
   );
 }

--- a/app/components/editor/ImagePickerModal.tsx
+++ b/app/components/editor/ImagePickerModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Modal, Text, ScrollArea, UnstyledButton, Stack } from '@mantine/core';
+import { Text, ScrollArea, UnstyledButton, Stack } from '@mantine/core';
+import DomeModal from '@/components/ui/DomeModal';
 import { Image as ImageIcon } from 'lucide-react';
 import type { Resource } from '@/types';
 
@@ -56,7 +57,7 @@ export default function ImagePickerModal({
   };
 
   return (
-    <Modal opened={opened} onClose={onClose} title="Imagen desde Dome" size="md" centered>
+    <DomeModal open={opened} onClose={onClose} title="Imagen desde Dome" size="md">
       <Stack gap="sm">
         <Text size="xs" c="dimmed">
           {loading ? 'Cargando…' : `${items.length} imagen(es) en el proyecto`}
@@ -113,6 +114,6 @@ export default function ImagePickerModal({
           </Stack>
         </ScrollArea>
       </Stack>
-    </Modal>
+    </DomeModal>
   );
 }

--- a/app/components/editor/ResourcePickerModal.tsx
+++ b/app/components/editor/ResourcePickerModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Modal, TextInput, Stack, Text, ScrollArea, UnstyledButton } from '@mantine/core';
+import { TextInput, Stack, Text, ScrollArea, UnstyledButton } from '@mantine/core';
+import DomeModal from '@/components/ui/DomeModal';
 import type { Resource, ResourceType } from '@/types';
 import DomeResourceIcon from '@/components/ui/DomeResourceIcon';
 
@@ -76,7 +77,7 @@ export default function ResourcePickerModal({
   }, [opened, load, query]);
 
   return (
-    <Modal opened={opened} onClose={onClose} title={title} size="md" centered>
+    <DomeModal open={opened} onClose={onClose} title={title} size="md">
       <Stack gap="sm">
         <TextInput
           placeholder="Buscar en la librería…"
@@ -126,6 +127,6 @@ export default function ResourcePickerModal({
           </Stack>
         </ScrollArea>
       </Stack>
-    </Modal>
+    </DomeModal>
   );
 }

--- a/app/components/shell/FolderTabView.tsx
+++ b/app/components/shell/FolderTabView.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useCallback, useState, useRef, useEffect, Fragment } from 'react';
-import { Modal, ScrollArea, Stack, UnstyledButton, Text, Group } from '@mantine/core';
+import { ScrollArea, Stack, UnstyledButton, Text } from '@mantine/core';
+import DomeModal from '@/components/ui/DomeModal';
 import DomeButton from '@/components/ui/DomeButton';
 import {
   FolderOpen, Plus, Home, ChevronRight,
@@ -501,12 +502,16 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
 
       </div>
 
-      <Modal
-        opened={folderPickOpen}
+      <DomeModal
+        open={folderPickOpen}
         onClose={() => setFolderPickOpen(false)}
         title={t('selection.move_to_folder')}
-        centered
         size="sm"
+        footer={
+          <DomeButton variant="secondary" onClick={() => setFolderPickOpen(false)}>
+            {t('common.cancel')}
+          </DomeButton>
+        }
       >
         <Stack gap="xs">
           <Text size="xs" c="dimmed">
@@ -549,13 +554,8 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
               ))}
             </Stack>
           </ScrollArea.Autosize>
-          <Group justify="flex-end">
-            <DomeButton variant="secondary" onClick={() => setFolderPickOpen(false)}>
-              {t('common.cancel')}
-            </DomeButton>
-          </Group>
         </Stack>
-      </Modal>
+      </DomeModal>
 
       <MoveToProjectModal
         opened={moveProjectIds.length > 0}

--- a/app/components/workspace/MoveToProjectModal.tsx
+++ b/app/components/workspace/MoveToProjectModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Modal, Text, ScrollArea, UnstyledButton, Group, Stack } from '@mantine/core';
+import { Text, ScrollArea, UnstyledButton, Stack } from '@mantine/core';
+import DomeModal from '@/components/ui/DomeModal';
 import DomeButton from '@/components/ui/DomeButton';
 import { useTranslation } from 'react-i18next';
 import type { Project } from '@/types';
@@ -144,12 +145,26 @@ export default function MoveToProjectModal({
   }, [pickedId, roots, onClose, onCompleted, t]);
 
   return (
-    <Modal
-      opened={opened}
+    <DomeModal
+      open={opened}
       onClose={onClose}
       title={t('moveProject.title')}
-      centered
       size="md"
+      footer={
+        <>
+          <DomeButton variant="secondary" onClick={onClose} disabled={submitting}>
+            {t('common.cancel')}
+          </DomeButton>
+          <DomeButton
+            variant="primary"
+            onClick={() => void handleMove()}
+            loading={submitting}
+            disabled={!pickedId || roots.length === 0 || eligibleProjects.length === 0}
+          >
+            {t('moveProject.confirm')}
+          </DomeButton>
+        </>
+      }
     >
       <Stack gap="md">
         <Text size="sm" c="dimmed">
@@ -204,20 +219,7 @@ export default function MoveToProjectModal({
           </Text>
         ) : null}
 
-        <Group justify="flex-end" mt="md">
-          <DomeButton variant="secondary" onClick={onClose} disabled={submitting}>
-            {t('common.cancel')}
-          </DomeButton>
-          <DomeButton
-            variant="primary"
-            onClick={() => void handleMove()}
-            loading={submitting}
-            disabled={!pickedId || roots.length === 0 || eligibleProjects.length === 0}
-          >
-            {t('moveProject.confirm')}
-          </DomeButton>
-        </Group>
       </Stack>
-    </Modal>
+    </DomeModal>
   );
 }

--- a/app/components/workspace/file-manager/FileManagerTree.tsx
+++ b/app/components/workspace/file-manager/FileManagerTree.tsx
@@ -16,7 +16,8 @@ import type { Resource } from '@/lib/hooks/useResources';
 import MoveToProjectModal, { filterMoveProjectRoots } from '@/components/workspace/MoveToProjectModal';
 import { useTranslation } from 'react-i18next';
 import SelectionActionBar from '@/components/home/SelectionActionBar';
-import { Modal, ScrollArea, Stack, UnstyledButton, Text, Group } from '@mantine/core';
+import { ScrollArea, Stack, UnstyledButton, Text } from '@mantine/core';
+import DomeModal from '@/components/ui/DomeModal';
 import DomeButton from '@/components/ui/DomeButton';
 import DomeResourceIcon from '@/components/ui/DomeResourceIcon';
 
@@ -586,12 +587,16 @@ export function FileManagerTree({ compact = false, onRefresh }: FileManagerTreeP
         onAction={handleContextMenuAction}
       />
 
-      <Modal
-        opened={folderPickOpen}
+      <DomeModal
+        open={folderPickOpen}
         onClose={() => setFolderPickOpen(false)}
         title={t('selection.move_to_folder')}
-        centered
         size="sm"
+        footer={
+          <DomeButton variant="secondary" onClick={() => setFolderPickOpen(false)}>
+            {t('common.cancel')}
+          </DomeButton>
+        }
       >
         <Stack gap="xs">
           <Text size="xs" c="dimmed">
@@ -634,13 +639,8 @@ export function FileManagerTree({ compact = false, onRefresh }: FileManagerTreeP
               ))}
             </Stack>
           </ScrollArea.Autosize>
-          <Group justify="flex-end">
-            <DomeButton variant="secondary" onClick={() => setFolderPickOpen(false)}>
-              {t('common.cancel')}
-            </DomeButton>
-          </Group>
         </Stack>
-      </Modal>
+      </DomeModal>
 
       <MoveToProjectModal
         opened={moveProjectIds.length > 0}

--- a/docs/auditoria/03-ux-componentes/T01-consolidar-modales.md
+++ b/docs/auditoria/03-ux-componentes/T01-consolidar-modales.md
@@ -1,7 +1,7 @@
 # T01 — Consolidar modales en DomeModal
 
 **Prioridad**: P1 · **Severidad**: Alta · **Esfuerzo**: L · **Área**: UX Componentes
-**Estado**: 🔶 Fase 2 implementada (2026-06-11, rama `refactor/ux-modales-fase2`) — sobre la fase 1 (#369): `DomeModal` gana `size="full"` (85vh, superficie de trabajo), `subtitle` y `headerActions`; migrados los dos modales ad-hoc restantes con overlay propio: **PluginRuntimeModal** (runtime de plugins con iframe + botón de recarga en cabecera) y **EventModal** (formulario de calendario con submit por `form=` y borrar/cancelar/guardar en el footer). `FeederApprovalModal` y `NoteQuickTagModal` ya estaban sobre DomeModal. **Pendiente (fase 3):** los 6 que usan `Modal` de Mantine (EmbedModal, ImagePickerModal, ResourcePickerModal, MoveToProjectModal, y los de FolderTabView/FileManagerTree) — comportamiento consistente entre sí; decidir si se migran o se toleran como casos Mantine-internos (nota de la propia tarea).
+**Estado**: ✅ Implementado (fase 3, 2026-06-13) — migrados a `DomeModal` los 6 modales que quedaban sobre `Modal` de Mantine: EmbedModal, ImagePickerModal, ResourcePickerModal, MoveToProjectModal (editor/workspace) y los dos folder-pick (FolderTabView, FileManagerTree). Ya **no queda ningún `Modal` de `@mantine/core`** en `app/` (grep: 0). Todos los modales de la app (genéricos + feature) comparten ahora la misma base: portal, Escape, focus trap, devolución de foco y scroll lock. Las primitivas de layout de Mantine (Stack/Text/ScrollArea/UnstyledButton) se conservan dentro del cuerpo (no son `Button`). Criterios de aceptación cumplidos.
 
 ## Problema
 


### PR DESCRIPTION
## Summary
- Cierra 03/T01: migra a `DomeModal` los **6 modales que aún usaban `Modal` de `@mantine/core`** — EmbedModal, ImagePickerModal, ResourcePickerModal, MoveToProjectModal y los dos modales folder-pick de FolderTabView y FileManagerTree.
- **`grep` de `Modal` desde `@mantine/core` en `app/`: 0.** Todos los modales de la app (genéricos + de feature) comparten ahora la misma base: portal, Escape, focus trap, devolución de foco al trigger y scroll lock.
- Las primitivas de layout de Mantine (`Stack`/`Text`/`ScrollArea`/`UnstyledButton`) se conservan dentro del cuerpo — solo se reemplaza el wrapper `Modal`; los botones de acción van al `footer` con `DomeButton`.

## Type
- [x] Refactor

## Checklist
- [x] `pnpm run typecheck` / `lint` (0 nuevos) / `build` passes
- [x] `test:security` 61/61
- [ ] Smoke manual: insertar embed (YouTube/iframe), picker de imagen y de recurso en el editor, mover a proyecto, y mover a carpeta (selección múltiple) en sidebar y file-manager

> Con esto 03/T01 queda completa (fase 1 #369 base + fase 2 #373 ad-hoc + fase 3 Mantine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)