### PR TITLE
ci: project-sync best-effort (no rojo si falta PROJECT_TOKEN)

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -13,6 +13,9 @@ jobs:
       repository-projects: write
     steps:
       - name: Add PR to Code Health project
+        # Best-effort: la sync al proyecto no debe poner la PR en rojo si
+        # PROJECT_TOKEN no está configurado o le falta scope.
+        continue-on-error: true
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/users/maxprain12/projects/1


### PR DESCRIPTION
El job `add-to-project` falla en toda PR con 'audit' en el título porque `PROJECT_TOKEN` no está configurado, dejando las PRs en estado UNSTABLE. `continue-on-error: true` lo convierte en best-effort sin afectar al merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)