### PR TITLE
fix(skills): resolver carga de skills en Windows (rutas absolutas en ignore)

### DIFF
--- a/packages/agent-core/src/harness/skills.ts
+++ b/packages/agent-core/src/harness/skills.ts
@@ -349,25 +349,36 @@ async function resolveKind(
 	return target.value.kind === "file" || target.value.kind === "directory" ? target.value.kind : undefined;
 }
 
+// Skill paths come from the host filesystem and may use native separators
+// (Windows `listDir`/`fileInfo` return `C:\Users\...\skills\foo`). These
+// helpers — and the `ignore` matcher, which requires a relative POSIX path —
+// operate on forward slashes, so normalize first. Without this, relativeEnvPath
+// fails the startsWith check on Windows and leaks an absolute path into
+// ignoreMatcher.ignores(), which throws "path should be a path.relative()'d
+// string, but got C:\Users\...".
+function toPosixPath(p: string): string {
+	return p.replace(/\\/g, "/");
+}
+
 function joinEnvPath(base: string, child: string): string {
-	return `${base.replace(/\/+$/, "")}/${child.replace(/^\/+/, "")}`;
+	return `${toPosixPath(base).replace(/\/+$/, "")}/${toPosixPath(child).replace(/^\/+/, "")}`;
 }
 
 function dirnameEnvPath(path: string): string {
-	const normalized = path.replace(/\/+$/, "");
+	const normalized = toPosixPath(path).replace(/\/+$/, "");
 	const slashIndex = normalized.lastIndexOf("/");
 	return slashIndex <= 0 ? "/" : normalized.slice(0, slashIndex);
 }
 
 function basenameEnvPath(path: string): string {
-	const normalized = path.replace(/\/+$/, "");
+	const normalized = toPosixPath(path).replace(/\/+$/, "");
 	const slashIndex = normalized.lastIndexOf("/");
 	return slashIndex === -1 ? normalized : normalized.slice(slashIndex + 1);
 }
 
 function relativeEnvPath(root: string, path: string): string {
-	const normalizedRoot = root.replace(/\/+$/, "");
-	const normalizedPath = path.replace(/\/+$/, "");
+	const normalizedRoot = toPosixPath(root).replace(/\/+$/, "");
+	const normalizedPath = toPosixPath(path).replace(/\/+$/, "");
 	if (normalizedPath === normalizedRoot) return "";
 	return normalizedPath.startsWith(`${normalizedRoot}/`)
 		? normalizedPath.slice(normalizedRoot.length + 1)

--- a/packages/agent-core/test/skills.test.ts
+++ b/packages/agent-core/test/skills.test.ts
@@ -74,3 +74,57 @@ describe('formatSkillsForSystemPrompt', () => {
     expect(formatSkillsForSystemPrompt(hidden)).toBe('');
   });
 });
+
+describe('loadSkills with Windows-style paths (regression)', () => {
+  // Reproduce a Windows ExecutionEnv: a drive-letter root and native
+  // (backslash) paths from listDir/fileInfo. The real test FS is POSIX, so a
+  // thin wrapper maps a fake `C:\\skills` root onto the temp dir and back.
+  //
+  // Before the fix, relativeEnvPath compared backslash paths with a forward
+  // slash and leaked the ABSOLUTE path into ignoreMatcher.ignores(): on older
+  // `ignore` versions that threw outright; on current ones it silently breaks
+  // .gitignore matching (an ignored skill gets loaded). This test asserts the
+  // ignore rule is honored, so it fails without the fix regardless of `ignore`
+  // version.
+  const WIN_ROOT = 'C:\\skills';
+  let winRoot: string;
+  let realRoot: string;
+
+  beforeAll(() => {
+    realRoot = mkdtempSync(join(tmpdir(), 'dome-skills-win-'));
+    writeSkill(join(realRoot, 'visible'), 'name: visible-skill\ndescription: Should load');
+    writeSkill(join(realRoot, 'secret'), 'name: secret-skill\ndescription: Should be ignored');
+    writeFileSync(join(realRoot, '.gitignore'), 'secret/\n');
+    winRoot = WIN_ROOT;
+  });
+  afterAll(() => rmSync(realRoot, { recursive: true, force: true }));
+
+  const toReal = (p: string) => p.replace(/\\/g, '/').replace(WIN_ROOT.replace(/\\/g, '/'), realRoot);
+  const toWin = (p: string) => WIN_ROOT + p.replace(realRoot, '').replace(/\//g, '\\');
+  const mapInfo = (i: { path: string }) => ({ ...i, path: toWin(i.path) });
+
+  const winEnv = {
+    fileInfo: async (p: string) => {
+      const r = await env.fileInfo(toReal(p));
+      return r.ok ? { ok: true as const, value: mapInfo(r.value) } : r;
+    },
+    listDir: async (p: string) => {
+      const r = await env.listDir(toReal(p));
+      return r.ok ? { ok: true as const, value: r.value.map(mapInfo) } : r;
+    },
+    readTextFile: (p: string) => env.readTextFile(toReal(p)),
+    canonicalPath: async (p: string) => {
+      const r = await env.canonicalPath(toReal(p));
+      return r.ok ? { ok: true as const, value: toWin(r.value) } : r;
+    },
+  } as unknown as typeof env;
+
+  it('loads skills and honors .gitignore on Windows-style paths', async () => {
+    const { skills } = await loadSkills(winEnv, winRoot);
+    const names = skills.map((s) => s.name);
+    expect(names).toContain('visible-skill');
+    // Without the path fix, the absolute path bypasses the `secret/` rule and
+    // this skill is wrongly loaded.
+    expect(names).not.toContain('secret-skill');
+  });
+});


### PR DESCRIPTION
## Summary
- **Bug de Windows** (de la captura): cargar skills lanzaba \`path should be a \`path.relative()\`d string, but got "C:\Users\alder.dome\skills\frontend-design/"\`.
- **Causa**: los helpers de ruta de \`skills.ts\` asumían forward slashes, pero en Windows \`listDir\`/\`fileInfo\` devuelven backslashes. \`relativeEnvPath\` fallaba el \`startsWith(root + "/")\` por el separador y filtraba la ruta **absoluta** a \`ignoreMatcher.ignores()\` → crash en versiones antiguas de \`ignore\`; en la actual (5.3.2) rompe el matching de \`.gitignore\` (skill que debería ignorarse se carga).
- **Fix**: normalizar backslashes → forward slashes en los 4 helpers (\`relativeEnvPath\`/\`joinEnvPath\`/\`dirnameEnvPath\`/\`basenameEnvPath\`).
- **Test de regresión fiel**: env Windows simulado (root \`C:\\skills\`, paths con backslash) + \`.gitignore\` con \`secret/\`; asserta que la skill ignorada NO se carga. **Falla sin el fix, pasa con él** (verificado en ambos sentidos), independiente de la versión de \`ignore\`.

## Type
- [x] Bug fix

## Checklist
- [x] `pnpm run build:packages` / `typecheck` / `lint` passes
- [x] agent-core tests 42/42 (incluye el nuevo de regresión Windows)
- [x] Verificado que el test falla sin el fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)