### PR TITLE
chore: release v2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump `package.json` version to **2.5.1** after merge of #398 (email + Seguimiento UX).

## Test plan
- [x] Version string only; no code changes
- [ ] After merge: `gh release create v2.5.1` triggers Electron build workflow