### PR TITLE
hotfix: v2.6.1 — CI/packaging guards against app.asar native-binary regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Design system ratchet (hardcoded colors)
         run: pnpm run check:design-system
 
+      - name: asarUnpack guard (native addons & bundled binaries)
+        run: pnpm run check:asar-unpack
+
       - name: Security unit tests
         run: pnpm run test:security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,7 +305,23 @@ Plugins loaded via `electron/marketplace/plugin-loader.cjs`. Marketplace config 
 
 - **Dev**: Vite on port 5173, Electron loads `http://localhost:5173`
 - **Prod**: Vite builds to `dist/`, Electron loads via `app://dome/` protocol
-- **Native modules** unpacked from asar: `better-sqlite3`, `sharp`, `@napi-rs/canvas`, `archiver`, `yauzl`
+- **Native modules** unpacked from asar: `better-sqlite3`, `sharp`, `@napi-rs/canvas`, `archiver`, `yauzl`, `@ffmpeg-installer`
+
+### ⚠️ asarUnpack: native modules & bundled binaries (NEVER FORGET)
+
+**Any dependency that ships a native `.node` addon OR an executable binary that gets `spawn`/`exec`'d MUST be added to `asarUnpack` in `package.json`.** Inside `app.asar` files cannot be executed (`spawn` → `ENOTDIR`) and many native loaders cannot `dlopen` from the archive. In packaged builds this fails as an **uncaught async error that aborts the main process** — and it is invisible in dev (where modules live in plain `node_modules/`). This is exactly what crashed v2.6.0 (ffmpeg path inside `app.asar`, see PR #405).
+
+When adding a dependency that calls a binary or loads a native addon:
+
+1. Add its path to `asarUnpack` in `package.json` (e.g. `node_modules/<pkg>/**/*`).
+2. Never pass an installer's raw `.path` to `spawn`/`setFfmpegPath`/etc. — a path inside `app.asar` is unrunnable. Rewrite `…/app.asar/…` → `…/app.asar.unpacked/…` before use. For ffmpeg/ffprobe use the helper `electron/media/ffmpeg-paths.cjs` (`toSpawnSafePath` / `configureFluentFfmpeg`); follow the same pattern for any new binary.
+3. Add the module to `criticalModules` in `scripts/after-pack.cjs` so the packaged build is verified to contain the unpacked binary.
+4. Degrade gracefully if the binary is missing (warn + disable the feature) — never let it throw an uncaught exception.
+5. Test in a **packaged** build (`pnpm run electron:build`), not just dev — these failures only manifest after packaging.
+
+**Enforced automatically (don't rely on memory):**
+- `pnpm run check:asar-unpack` (`scripts/check-asar-unpack.cjs`) runs in CI on **every PR and every push to `main`** (CI `Lint` job). It discovers every production dependency that ships a `.node` addon or a bundled binary and **fails** if any isn't covered by an `asarUnpack` glob. It also keeps `after-pack.cjs` `criticalModules` consistent with `asarUnpack`. For a new spawned-binary installer with no `.node` file, add its name prefix to `BINARY_PACKAGE_PREFIXES` in that script.
+- `scripts/after-pack.cjs` is a **hard gate** during `electron:build` / release: it throws (fails the build) if a critical module isn't in `app.asar.unpacked`, or if the platform ffmpeg binary is missing/inside `app.asar`/not executable. A broken release build cannot be produced.
 
 ## Security Requirements
 
@@ -321,6 +337,7 @@ Plugins loaded via `electron/marketplace/plugin-loader.cjs`. Marketplace config 
 3. **New IPC channel**: Must be added in both `electron/ipc/<group>/<domain>.cjs` AND `electron/preload.cjs` ALLOWED_CHANNELS (and imported with its subfolder path in `electron/ipc/index.cjs`)
 4. **Type-only imports**: Use `import type { }` due to `verbatimModuleSyntax: true`
 5. **File paths**: Always use IPC handlers, never access filesystem directly from renderer
+6. **Native addons / bundled binaries**: Any new dep with a `.node` addon or a spawned executable MUST be added to `asarUnpack` (and `after-pack.cjs` `criticalModules`), and its path rewritten from `app.asar` → `app.asar.unpacked` before `spawn`. See **Build & Packaging → asarUnpack**. Forgetting this crashes the packaged app only (dev is fine).
 
 ## File-based skills (Claude / Agent Skills)
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "check:ipc-zod": "node scripts/check-ipc-zod.mjs",
     "check:tool-coverage": "node scripts/verify-tool-coverage.mjs",
     "check:design-system": "node scripts/check-hardcoded-colors.mjs",
+    "check:asar-unpack": "node scripts/check-asar-unpack.cjs",
     "test:db": "tsx scripts/test-db.ts",
     "test:filesystem-tools": "node --test scripts/test-filesystem-tools.mjs",
     "test:feeders": "node --test scripts/test-feeders.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {

--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -127,14 +127,22 @@ exports.default = async function afterPack(context) {
 
   // Check if app.asar.unpacked exists
   const asarUnpackedPath = path.join(resourcesPath, 'app.asar.unpacked');
+  // Collected hard failures — we throw at the end so the packaged build never
+  // ships with a missing native module / binary (which crashes only in prod).
+  const fatal = [];
+
   if (fs.existsSync(asarUnpackedPath)) {
     console.log('[AfterPack] ✅ app.asar.unpacked exists');
 
-    // Verify critical native modules
+    // Verify critical native modules / binaries are actually unpacked.
+    // Keep in sync with build.asarUnpack in package.json — scripts/check-asar-unpack.cjs
+    // enforces that every entry here is covered by an asarUnpack glob.
     const criticalModules = [
       'node_modules/better-sqlite3',
       'node_modules/sharp',
       'node_modules/@ffmpeg-installer',
+      'node_modules/@napi-rs/canvas',
+      'node_modules/@lancedb/lancedb',
     ];
 
     for (const modulePath of criticalModules) {
@@ -151,12 +159,23 @@ exports.default = async function afterPack(context) {
           });
         }
       } else {
-        console.warn(`[AfterPack] ⚠️  ${modulePath} is NOT unpacked - this may cause errors!`);
+        fatal.push(`${modulePath} is NOT unpacked (add to build.asarUnpack)`);
+        console.error(`[AfterPack] ❌ ${modulePath} is NOT unpacked!`);
       }
     }
+
+    // The 2.6.0 crash: the ffmpeg binary must exist OUTSIDE app.asar and be
+    // executable. Verify the actual platform binary is present and not in-asar.
+    const ffmpegErr = verifyFfmpegBinary(asarUnpackedPath, electronPlatformName);
+    if (ffmpegErr) {
+      fatal.push(ffmpegErr);
+      console.error(`[AfterPack] ❌ ${ffmpegErr}`);
+    } else {
+      console.log('[AfterPack] ✅ ffmpeg binary is unpacked and executable');
+    }
   } else {
+    fatal.push('app.asar.unpacked does NOT exist — native modules will not work in production');
     console.error('[AfterPack] ❌ app.asar.unpacked does NOT exist!');
-    console.error('[AfterPack] Native modules will not work in production!');
   }
 
   if (electronPlatformName === 'darwin') {
@@ -168,8 +187,50 @@ exports.default = async function afterPack(context) {
     }
   }
 
+  if (fatal.length > 0) {
+    console.error('\n[AfterPack] ❌ Packaging gate failed — refusing to ship a broken build:');
+    for (const f of fatal) console.error(`[AfterPack]   • ${f}`);
+    throw new Error(`after-pack: ${fatal.length} critical packaging problem(s) — see log above`);
+  }
+
   console.log('[AfterPack] After-pack hook completed');
 };
+
+/**
+ * Verify the ffmpeg binary is unpacked (outside app.asar) and executable.
+ * Returns an error string on failure, or null on success.
+ * This is the exact regression that crashed Dome 2.6.0 (spawn ENOTDIR from
+ * an app.asar ffmpeg path).
+ */
+function verifyFfmpegBinary(asarUnpackedPath, electronPlatformName) {
+  const platformDir = {
+    darwin: process.arch === 'arm64' ? 'darwin-arm64' : 'darwin-x64',
+    win32: process.arch === 'ia32' ? 'win32-ia32' : 'win32-x64',
+    linux: process.arch === 'arm64' ? 'linux-arm64' : 'linux-x64',
+  }[electronPlatformName];
+
+  if (!platformDir) {
+    // Unknown platform: confirm at least one ffmpeg binary is unpacked.
+    const base = path.join(asarUnpackedPath, 'node_modules', '@ffmpeg-installer');
+    return fs.existsSync(base) ? null : '@ffmpeg-installer not unpacked';
+  }
+
+  const binName = electronPlatformName === 'win32' ? 'ffmpeg.exe' : 'ffmpeg';
+  const binPath = path.join(
+    asarUnpackedPath, 'node_modules', '@ffmpeg-installer', platformDir, binName,
+  );
+  if (!fs.existsSync(binPath)) {
+    return `ffmpeg binary missing at ${path.relative(asarUnpackedPath, binPath)} (must be in app.asar.unpacked, not app.asar)`;
+  }
+  if (electronPlatformName !== 'win32') {
+    try {
+      fs.accessSync(binPath, fs.constants.X_OK);
+    } catch {
+      return `ffmpeg binary not executable: ${binPath}`;
+    }
+  }
+  return null;
+}
 
 /**
  * Recursively find all .node files in a directory

--- a/scripts/check-asar-unpack.cjs
+++ b/scripts/check-asar-unpack.cjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+'use strict';
+
+/**
+ * Guard: native addons & bundled binaries MUST be in `build.asarUnpack`.
+ *
+ * Why this exists
+ * ---------------
+ * Files inside `app.asar` cannot be executed (`spawn` -> ENOTDIR) and many
+ * native loaders cannot `dlopen` from the archive. In a packaged build this
+ * surfaces as an UNCAUGHT async error that aborts the main process — and it is
+ * invisible in dev (modules live in a plain `node_modules/`). This is exactly
+ * what crashed Dome 2.6.0: `@ffmpeg-installer` resolved the ffmpeg binary to a
+ * path inside `app.asar`, fluent-ffmpeg's capability probe `spawn`ed it, threw
+ * ENOTDIR from a timer callback, and killed CrBrowserMain ~30–90s after launch.
+ *
+ * What it checks (fast, no electron-builder packaging needed — runs on every PR)
+ * -----------------------------------------------------------------------------
+ *  1. Every PRODUCTION dependency that ships a native `.node` addon (or a
+ *     `binding.gyp`) is covered by an `asarUnpack` glob.
+ *  2. Every known binary-shipping installer (see BINARY_PACKAGE_PREFIXES) is
+ *     covered by an `asarUnpack` glob.
+ *  3. `scripts/after-pack.cjs` `criticalModules` are all covered by an
+ *     `asarUnpack` glob (the two lists must stay consistent).
+ *
+ * Only PRODUCTION deps are considered — electron-builder only bundles those.
+ * Build/dev-only native modules (rollup, @parcel/watcher, fsevents,
+ * iconv-corefoundation, …) are intentionally ignored.
+ *
+ * If you add a dependency that loads a `.node` addon or `spawn`s a binary:
+ *   - add a `node_modules/<pkg>/` glob to `build.asarUnpack` in package.json
+ *   - if it ships a binary (no `.node`), also add its name prefix below
+ *   - never pass an installer's raw `.path` to spawn/setFfmpegPath: rewrite
+ *     `…/app.asar/…` -> `…/app.asar.unpacked/…` first (see
+ *     electron/media/ffmpeg-paths.cjs).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+
+// Binary-shipping installers that DON'T contain a `.node` file (so the native
+// scan won't catch them). Matched as name prefixes. Add new ones here.
+const BINARY_PACKAGE_PREFIXES = ['@ffmpeg-installer/'];
+
+function fail(lines) {
+  console.error('\n❌ asar-unpack check FAILED\n');
+  for (const l of lines) console.error('   ' + l);
+  console.error('\nFix: add the package(s) to `build.asarUnpack` in package.json');
+  console.error('     (and, if a spawned binary, to BINARY_PACKAGE_PREFIXES /');
+  console.error('      after-pack.cjs criticalModules). See scripts/check-asar-unpack.cjs.\n');
+  process.exit(1);
+}
+
+/** Package name = segment after the LAST `node_modules/` in a path. */
+function pkgNameFromPath(p) {
+  const idx = p.lastIndexOf('node_modules' + path.sep);
+  if (idx === -1) return null;
+  const rest = p.slice(idx + ('node_modules' + path.sep).length);
+  const parts = rest.split(path.sep);
+  if (!parts[0]) return null;
+  return parts[0].startsWith('@') && parts[1] ? `${parts[0]}/${parts[1]}` : parts[0];
+}
+
+/** Set of production dependency package names (via pnpm prod tree). */
+function getProdPackages() {
+  let out;
+  try {
+    out = execSync('pnpm ls --prod --depth Infinity --parseable', {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (e) {
+    // Non-zero exit can still carry usable stdout
+    out = (e.stdout && e.stdout.toString()) || '';
+  }
+  const set = new Set();
+  for (const line of out.split('\n')) {
+    const name = pkgNameFromPath(line.trim());
+    if (name) set.add(name);
+  }
+  if (set.size === 0) {
+    fail(['Could not resolve the production dependency tree (pnpm ls returned nothing).']);
+  }
+  return set;
+}
+
+/** Walk a dir, calling fn(fullPath) for each file; bounded depth, no inner node_modules recursion beyond pnpm layout. */
+function walk(dir, fn) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const ent of entries) {
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) walk(full, fn);
+    else fn(full);
+  }
+}
+
+/** Discover packages (in the pnpm store) that contain a native `.node` file or a root binding.gyp. */
+function discoverNativePackages() {
+  const store = path.join(ROOT, 'node_modules', '.pnpm');
+  const found = new Set();
+  if (!fs.existsSync(store)) {
+    // Fallback: scan top-level node_modules (non-pnpm layouts)
+    walk(path.join(ROOT, 'node_modules'), (f) => {
+      if (f.endsWith('.node') || path.basename(f) === 'binding.gyp') {
+        const n = pkgNameFromPath(f);
+        if (n && !n.startsWith('.')) found.add(n);
+      }
+    });
+    return found;
+  }
+  for (const variant of fs.readdirSync(store)) {
+    const nm = path.join(store, variant, 'node_modules');
+    if (!fs.existsSync(nm)) continue;
+    walk(nm, (f) => {
+      if (f.endsWith('.node') || path.basename(f) === 'binding.gyp') {
+        const n = pkgNameFromPath(f);
+        if (n && !n.startsWith('.')) found.add(n);
+      }
+    });
+  }
+  return found;
+}
+
+/** Convert an asarUnpack glob into a RegExp matching a probe path under the package. */
+function globToRegExp(glob) {
+  // normalize to forward slashes for matching
+  let g = glob.replace(/\\/g, '/');
+  let re = '^';
+  for (let i = 0; i < g.length; i++) {
+    const c = g[i];
+    if (c === '*') {
+      if (g[i + 1] === '*') {
+        re += '.*';
+        i++;
+        if (g[i + 1] === '/') i++; // consume `**/`
+      } else {
+        re += '[^/]*';
+      }
+    } else if ('.+?^${}()|[]\\'.includes(c)) {
+      re += '\\' + c;
+    } else {
+      re += c;
+    }
+  }
+  re += '$';
+  return new RegExp(re);
+}
+
+function isCovered(pkgName, unpackRegexes) {
+  const probe = `node_modules/${pkgName}/__probe__.node`;
+  return unpackRegexes.some((r) => r.test(probe));
+}
+
+function main() {
+  const pkgJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  const unpack = (pkgJson.build && pkgJson.build.asarUnpack) || [];
+  if (!Array.isArray(unpack) || unpack.length === 0) {
+    fail(['package.json build.asarUnpack is missing or empty.']);
+  }
+  const unpackRegexes = unpack.map(globToRegExp);
+
+  const prod = getProdPackages();
+  const native = discoverNativePackages();
+
+  // Production native packages that must be unpacked.
+  const mustUnpack = new Set();
+  for (const n of native) if (prod.has(n)) mustUnpack.add(n);
+
+  // Production binary-installer packages (by name prefix) that must be unpacked.
+  for (const name of prod) {
+    if (BINARY_PACKAGE_PREFIXES.some((pre) => name.startsWith(pre))) mustUnpack.add(name);
+  }
+
+  const uncovered = [...mustUnpack].filter((n) => !isCovered(n, unpackRegexes)).sort();
+
+  // Consistency: after-pack criticalModules must each be covered by an asarUnpack glob.
+  const afterPackSrc = fs.readFileSync(path.join(ROOT, 'scripts', 'after-pack.cjs'), 'utf8');
+  const cmBlock = afterPackSrc.match(/criticalModules\s*=\s*\[([\s\S]*?)\]/);
+  const criticalModules = cmBlock
+    ? [...cmBlock[1].matchAll(/['"]([^'"]+)['"]/g)].map((m) => m[1])
+    : [];
+  const criticalUncovered = criticalModules
+    .filter((m) => {
+      const name = m.replace(/^node_modules\//, '');
+      return !isCovered(name, unpackRegexes);
+    })
+    .sort();
+
+  const problems = [];
+  if (uncovered.length) {
+    problems.push('Production native/binary packages NOT in asarUnpack:');
+    for (const n of uncovered) problems.push(`  • ${n}`);
+  }
+  if (criticalUncovered.length) {
+    problems.push('after-pack.cjs criticalModules NOT covered by asarUnpack:');
+    for (const n of criticalUncovered) problems.push(`  • ${n}`);
+  }
+  if (problems.length) fail(problems);
+
+  console.log('✅ asar-unpack check passed');
+  console.log(`   ${mustUnpack.size} production native/binary package(s) verified in asarUnpack:`);
+  for (const n of [...mustUnpack].sort()) console.log(`     - ${n}`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Follow-up to #405 (the ffmpeg-in-`app.asar` crash). Adds automated guards so a build that ships a native module or spawned binary **inside `app.asar`** can never reach production or land on `main` again, and bumps the hotfix release to **v2.6.1**.

## Why

#405 fixed the specific ffmpeg path, but nothing stopped the next native dependency from re-introducing the same class of crash (files inside `app.asar` can't be `spawn`'d / `dlopen`'d → uncaught async error aborts the main process; invisible in dev). These guards make it structurally impossible to miss `asarUnpack`.

## Changes

### 1. `scripts/check-asar-unpack.cjs` (new) — fast PR-time guard
- Discovers **every production dependency** that ships a `.node` addon (or `binding.gyp`) by scanning the pnpm store, plus known binary installers (`BINARY_PACKAGE_PREFIXES`, currently `@ffmpeg-installer/`).
- **Fails** if any isn't covered by a `build.asarUnpack` glob.
- Also asserts `after-pack.cjs` `criticalModules` stay consistent with `asarUnpack`.
- Scoped to **prod** deps only (build/dev natives like rollup/@parcel/watcher/fsevents are ignored — electron-builder never bundles them).
- No electron-builder packaging needed → runs in seconds.

### 2. CI wiring (`.github/workflows/ci.yml`)
- New step **"asarUnpack guard"** in the `Lint` job → runs on **every PR and every push to `main`**.

### 3. `scripts/after-pack.cjs` — hard release gate
- Was warn-only; now **throws (fails `electron:build`)** if a critical module isn't in `app.asar.unpacked`, or if the platform **ffmpeg binary is missing / inside `app.asar` / not executable**.
- Adds `@napi-rs/canvas` and `@lancedb/lancedb` to `criticalModules`.
- A broken release artifact can no longer be produced.

### 4. Docs (`CLAUDE.md`)
- New **Build & Packaging → asarUnpack** rule + Common Pitfall, documenting the requirement and the automated guards.

### 5. `chore: release v2.6.1`

## Verification

```
pnpm run check:asar-unpack        # ✅ passes; lists 14 prod native/binary pkgs
# negative test: removing the @ffmpeg-installer glob → check FAILS (exit 1)
node -c scripts/after-pack.cjs    # syntax OK
```

## Release steps (after merge)
1. Merge this PR to `main`.
2. `gh release create v2.6.1 --title v2.6.1 --latest` → triggers `build.yml` (macOS arm64/x64 + Windows artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)