### PR TITLE
hotfix(v2.6.2): fix onboarding modal z-index and visual styling

### DIFF
--- a/app/components/onboarding/Onboarding.tsx
+++ b/app/components/onboarding/Onboarding.tsx
@@ -1,5 +1,6 @@
 
 import { useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useUserStore } from '@/lib/store/useUserStore';
 import { applyOnboardingConfig } from '@/lib/onboarding/applyOnboardingConfig';
 import type { RoleId } from '@/lib/onboarding/roles';
@@ -19,15 +20,12 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
     roleId: RoleId;
     freeText: string;
   }) => {
-    // Applies profile, agent soul/memory, feature visibility and recommended
-    // skills, then marks onboarding complete. Each step is best-effort.
     try {
       await applyOnboardingConfig(data);
     } catch (err) {
       console.error('[Onboarding] applyOnboardingConfig failed:', err);
     }
 
-    // Close modal with animation
     setIsVisible(false);
     setTimeout(() => {
       if (onComplete) {
@@ -40,20 +38,24 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
     return null;
   }
 
-  return (
+  // Rendered via portal so it escapes any filter/transform containing block
+  // created by ancestor components (e.g. TabPaneShell's reveal animation).
+  return createPortal(
     <div
       className="fixed inset-0 flex items-center justify-center"
       style={{
-        zIndex: 'var(--z-modal)',
-        backgroundColor: 'color-mix(in srgb, var(--dome-text) 40%, transparent)',
+        zIndex: 10000,
+        backgroundColor: 'rgba(0, 0, 0, 0.55)',
         backdropFilter: 'blur(8px)',
+        WebkitBackdropFilter: 'blur(8px)',
       }}
     >
       <div
-        className="relative rounded-2xl shadow-2xl max-w-2xl max-h-[85vh] w-full mx-4 flex flex-col overflow-hidden animate-fade-in"
+        className="relative rounded-2xl shadow-2xl max-w-2xl max-h-[85vh] w-full mx-4 flex flex-col overflow-hidden animate-modal"
         style={{
           backgroundColor: 'var(--dome-bg)',
           border: '1px solid var(--dome-border)',
+          minHeight: '420px',
         }}
       >
         <MartinOnboarding
@@ -62,6 +64,7 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
           onComplete={handleComplete}
         />
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/app/components/shell/TabPaneShell.tsx
+++ b/app/components/shell/TabPaneShell.tsx
@@ -156,7 +156,7 @@ export default function TabPaneShell({
           className="relative flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden"
           style={{
             opacity: revealPhase === 'shown' ? 1 : 0,
-            filter: revealPhase === 'shown' ? 'blur(0px)' : `blur(${BLUR_PX}px)`,
+            filter: revealPhase === 'shown' ? 'none' : `blur(${BLUR_PX}px)`,
             transition:
               revealPhase === 'animating' || revealPhase === 'shown'
                 ? `opacity ${REVEAL_MS}ms ease-out, filter ${REVEAL_MS}ms ease-out`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {


### PR DESCRIPTION
Root cause: TabPaneShell applied `filter: blur(0px)` in the 'shown'
phase, which per CSS spec creates a new containing block for
position:fixed descendants — trapping the onboarding overlay inside
the content pane instead of covering the full viewport (sidebars,
header, etc.).

Fixes:
- TabPaneShell: change `filter: 'blur(0px)'` → `filter: 'none'` when
  revealPhase is 'shown'. This removes the spurious containing block
  once the tab reveal animation completes, restoring correct fixed
  positioning for all content inside tabs.
- Onboarding: render via createPortal into document.body so the overlay
  escapes any ancestor filter/transform stacking contexts (belt-and-
  suspenders against future regressions).
- Onboarding: raise z-index to 10000 (above --z-max:9999 used by sidebar
  menus) so the modal always renders above every UI surface.
- Onboarding: fix backdrop from theme-text color-mix (wrong in dark mode)
  to a consistent rgba(0,0,0,0.55) + WebkitBackdropFilter.
- Onboarding: replace non-existent `animate-fade-in` with `animate-modal`
  (defined in globals.css as modal-appear keyframe).
- Onboarding: add minHeight:420px so the card never collapses to a thin
  sliver on the welcome step.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G5V2rQhC2vsDgGQY33H8ts