### PR TITLE
hotfix(v2.7.2): Sentry production error reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,8 @@ VITE_POSTHOG_HOST=https://us.i.posthog.com
 
 # Sentry — errores, crashes nativos y rendimiento (opcional).
 # El DSN es público por diseño (viaja en el cliente). Mismo DSN para main y renderer.
-# Sentry respeta el toggle `analytics_enabled` de la app: si el usuario desactiva analytics, no se envía nada.
+# Errores/crashes se envían siempre que haya DSN; las trazas de rendimiento respetan
+# el toggle `analytics_enabled` de la app.
 VITE_SENTRY_DSN=https://...@oXXXX.ingest.de.sentry.io/XXXX   # renderer (import.meta.env)
 SENTRY_DSN=https://...@oXXXX.ingest.de.sentry.io/XXXX        # main process (process.env)
 # Solo para BUILD/CI — subir source maps (NUNCA commitear el token real):

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
           pnpm run verify:workspace-deps
           pnpm run verify:natives
           node scripts/embed-env.cjs
+          node scripts/verify-sentry-build.cjs
           if [ -z "$CSC_LINK" ] || [ "$CSC_LINK" = "" ]; then
             echo "No code signing credentials, building without signing..."
             export CSC_IDENTITY_AUTO_DISCOVERY=false
@@ -90,6 +91,9 @@ jobs:
           # Both fall back to the same DSN secret so one value drives both.
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN || secrets.VITE_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: alder-dario-velasquez-obando
+          SENTRY_PROJECT: electron
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
@@ -131,6 +135,7 @@ jobs:
           pnpm run verify:workspace-deps
           pnpm run verify:natives
           node scripts/embed-env.cjs
+          node scripts/verify-sentry-build.cjs
           pnpm run electron:pack -- --win --publish never
         env:
           DOME_GOOGLE_DRIVE_CLIENT_ID: ${{ secrets.DOME_GOOGLE_DRIVE_CLIENT_ID }}
@@ -148,6 +153,9 @@ jobs:
           # Both fall back to the same DSN secret so one value drives both.
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN || secrets.VITE_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: alder-dario-velasquez-obando
+          SENTRY_PROJECT: electron
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
@@ -222,6 +230,7 @@ jobs:
           pnpm run verify:workspace-deps
           pnpm run verify:natives
           node scripts/embed-env.cjs
+          node scripts/verify-sentry-build.cjs
           pnpm run electron:pack -- --linux AppImage flatpak --publish never
         env:
           DOME_GOOGLE_DRIVE_CLIENT_ID: ${{ secrets.DOME_GOOGLE_DRIVE_CLIENT_ID }}
@@ -237,6 +246,9 @@ jobs:
           # Both fall back to the same DSN secret so one value drives both.
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN || secrets.VITE_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: alder-dario-velasquez-obando
+          SENTRY_PROJECT: electron
 
       - name: Verify Linux artifacts
         run: |

--- a/app/lib/analytics/sentry.ts
+++ b/app/lib/analytics/sentry.ts
@@ -2,16 +2,17 @@
  * Sentry for the RENDERER process — errors and performance (Web Vitals).
  *
  * Mirrors the shape of `posthog.ts`. Sentry is the single source of truth for
- * errors/crashes/performance; PostHog stays for product analytics (its own
- * exception capture is disabled to avoid duplicates).
+ * errors/crashes; PostHog stays for product analytics (its own exception capture
+ * is disabled to avoid duplicates).
  *
  * Events route through the main process via IPC (`@sentry/electron/renderer` +
  * the `@sentry/electron/preload` bridge), so the main-process SDK must be
  * initialized too (see electron/core/sentry-main.cjs).
  *
- * Consent: only initialized when the `analytics_enabled` toggle is on, and the
- * same consent value is forwarded to the main process so its native-crash / error
- * capture honours the opt-in. Toggling off calls `shutdownSentry()`.
+ * Consent model (split):
+ * - Error capture: initialized whenever VITE_SENTRY_DSN is configured.
+ * - Performance spans: gated by `analytics_enabled` (forwarded to main via IPC).
+ * - Toggling analytics off stops spans but keeps error reporting active.
  */
 
 import * as Sentry from '@sentry/electron/renderer';
@@ -24,8 +25,8 @@ export function isSentryConfigured(): boolean {
   return !!DSN && DSN.length > 0 && !DSN.includes('...');
 }
 
-/** Forward consent to the main process so its SDK gates events the same way. */
-function setMainConsent(enabled: boolean): void {
+/** Forward span consent to the main process (performance only). */
+function setMainSpanConsent(enabled: boolean): void {
   try {
     void window.electron?.invoke?.('sentry:set-consent', enabled);
   } catch {
@@ -33,27 +34,30 @@ function setMainConsent(enabled: boolean): void {
   }
 }
 
-export function initSentry(analyticsEnabled: boolean): void {
-  // Always sync main-process consent, even if the renderer SDK isn't configured.
-  setMainConsent(analyticsEnabled);
-
-  if (!isSentryConfigured() || !analyticsEnabled || initialized) {
-    return;
-  }
+function ensureRendererInitialized(analyticsEnabled: boolean): void {
+  if (!isSentryConfigured() || initialized) return;
 
   try {
     Sentry.init({
       dsn: DSN!,
       environment: import.meta.env.PROD ? 'production' : 'development',
-      // Performance: page-load + navigation spans and Web Vitals.
       integrations: [Sentry.browserTracingIntegration()],
-      tracesSampleRate: import.meta.env.PROD ? 0.2 : 1.0,
+      tracesSampleRate: analyticsEnabled
+        ? import.meta.env.PROD
+          ? 0.2
+          : 1.0
+        : 0,
       sendDefaultPii: false,
     });
     initialized = true;
   } catch (error) {
     console.warn('[Analytics] Sentry init failed:', error);
   }
+}
+
+export function initSentry(analyticsEnabled: boolean): void {
+  setMainSpanConsent(analyticsEnabled);
+  ensureRendererInitialized(analyticsEnabled);
 }
 
 export function setSentryUser(userId: string, traits?: Record<string, unknown>): void {
@@ -69,6 +73,8 @@ export function captureExceptionSentry(
   error: Error,
   context?: Record<string, unknown>,
 ): void {
+  // Lazy-init so manual captures work even if AnalyticsProvider hasn't mounted yet.
+  ensureRendererInitialized(false);
   if (!initialized) return;
   try {
     Sentry.captureException(error, context ? { extra: context } : undefined);
@@ -78,14 +84,6 @@ export function captureExceptionSentry(
 }
 
 export function shutdownSentry(): void {
-  // Revoke consent in the main process so it stops sending too.
-  setMainConsent(false);
-  if (!initialized) return;
-  try {
-    void Sentry.getClient()?.close();
-    Sentry.setUser(null);
-    initialized = false;
-  } catch {
-    // ignore
-  }
+  // Stop performance spans; keep the client alive for error reporting.
+  setMainSpanConsent(false);
 }

--- a/app/lib/analytics/useAnalytics.ts
+++ b/app/lib/analytics/useAnalytics.ts
@@ -22,13 +22,12 @@ export function useAnalytics(enabled: boolean) {
     [canTrack]
   );
 
-  // Errors go to Sentry (single source of truth); no-ops unless Sentry is initialized.
+  // Errors go to Sentry (single source of truth); always captured when Sentry is configured.
   const captureError = useCallback(
     (error: Error, context?: Record<string, unknown>) => {
-      if (!enabled) return;
       captureExceptionSentry(error, context);
     },
-    [enabled]
+    [],
   );
 
   return { track, captureError, ANALYTICS_EVENTS };

--- a/electron/core/sentry-main.cjs
+++ b/electron/core/sentry-main.cjs
@@ -9,11 +9,11 @@
  * Activation: set `SENTRY_DSN` (the DSN is public by design — it ships in clients).
  * If unset, every export here is a silent no-op (same pattern as observability.cjs).
  *
- * Consent: Sentry honours the app's existing `analytics_enabled` toggle. The main
- * process starts with consent OFF (privacy-safe, opt-in) and the renderer flips it on
- * via `setSentryConsent(true)` once it resolves the setting (see AnalyticsProvider +
- * the `sentry:set-consent` IPC). `beforeSend` drops every event while consent is OFF,
- * so nothing leaves the machine unless the user opted in.
+ * Consent model (split):
+ * - Errors / crashes: always sent when DSN is configured (observability, not product analytics).
+ * - Performance spans: gated by the app's `analytics_enabled` toggle via `beforeSendTransaction`.
+ *   Consent is synced from SQLite on startup (`syncSentryConsentFromDatabase`) and mirrored
+ *   from the renderer via `sentry:set-consent` IPC when the user toggles settings.
  */
 
 let Sentry = null; // lazy-required @sentry/electron/main
@@ -70,14 +70,17 @@ function initSentryMain(app) {
       tracesSampleRate: isProd(app) ? 0.2 : 1.0,
       // Never attach IP / cookies / user PII automatically.
       sendDefaultPii: false,
-      // Consent gate: drop everything (incl. events built from native crashes)
-      // until the user has opted in via the analytics toggle.
+      // Errors/crashes always leave the machine when DSN is set.
       beforeSend(event) {
+        return event;
+      },
+      // Product-analytics consent gates performance spans only.
+      beforeSendTransaction(event) {
         return consentEnabled ? event : null;
       },
     });
     initialized = true;
-    console.log(`[Sentry] main process initialized → ${release || 'no release'} (consent pending)`);
+    console.log(`[Sentry] main process initialized → ${release || 'no release'} (spans consent pending)`);
   } catch (err) {
     console.warn('[Sentry] main init failed:', err?.message || err);
     Sentry = null;
@@ -86,14 +89,29 @@ function initSentryMain(app) {
 }
 
 /**
- * Flip the consent gate. Called from the renderer (`sentry:set-consent`) once the
- * `analytics_enabled` setting is known, and whenever the user toggles it.
+ * Flip the performance-span consent gate. Called from SQLite sync on startup and
+ * from the renderer (`sentry:set-consent`) when the user toggles analytics.
  * @param {boolean} enabled
  */
 function setSentryConsent(enabled) {
   consentEnabled = !!enabled;
   if (initialized) {
-    console.log(`[Sentry] consent → ${consentEnabled ? 'enabled' : 'disabled'}`);
+    console.log(`[Sentry] span consent → ${consentEnabled ? 'enabled' : 'disabled'}`);
+  }
+}
+
+/**
+ * Read `analytics_enabled` from SQLite and sync span consent before the renderer loads.
+ * @param {{ getQueries: () => { getSetting: { get: (key: string) => { value?: string } | undefined } } }} database
+ */
+function syncSentryConsentFromDatabase(database) {
+  if (!database || typeof database.getQueries !== 'function') return;
+  try {
+    const row = database.getQueries().getSetting.get('analytics_enabled');
+    const enabled = !row || row.value === 'true' || row.value === undefined;
+    setSentryConsent(enabled);
+  } catch (err) {
+    console.warn('[Sentry] consent sync from DB failed:', err?.message || err);
   }
 }
 
@@ -102,12 +120,12 @@ function isSentryConsentEnabled() {
 }
 
 /**
- * Report a main-process error directly to Sentry (no-op unless initialized AND consented).
+ * Report a main-process error directly to Sentry (no-op unless initialized).
  * @param {unknown} error
  * @param {Record<string, unknown>} [context]
  */
 function captureExceptionMain(error, context) {
-  if (!initialized || !consentEnabled || !Sentry) return;
+  if (!initialized || !Sentry) return;
   try {
     const err = error instanceof Error ? error : new Error(String(error));
     Sentry.captureException(err, context ? { extra: context } : undefined);
@@ -132,6 +150,7 @@ async function closeSentryMain(timeoutMs = 2000) {
 module.exports = {
   initSentryMain,
   setSentryConsent,
+  syncSentryConsentFromDatabase,
   isSentryConsentEnabled,
   captureExceptionMain,
   closeSentryMain,

--- a/electron/ipc/core/system.cjs
+++ b/electron/ipc/core/system.cjs
@@ -34,8 +34,8 @@ function register({ ipcMain, app, windowManager, validateSender, sanitizePath, v
     }
   });
 
-  // Sentry consent gate — the renderer mirrors the analytics_enabled toggle here so
-  // the main-process SDK (errors + native crashes) honours the same opt-in.
+  // Sentry span consent — renderer mirrors the analytics_enabled toggle here so
+  // main-process performance spans honour the same opt-in. Errors are always sent.
   ipcMain.handle('sentry:set-consent', (event, enabled) => {
     try {
       validateSender(event, windowManager);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -60,8 +60,9 @@ const {
 
 // Initialize Sentry (main process) as EARLY as possible — before any domain module
 // loads — so native-addon load failures and early crashes are captured. No-op unless
-// SENTRY_DSN is set; events are gated behind the analytics_enabled consent toggle
-// (renderer flips it on via the `sentry:set-consent` IPC). See electron/core/sentry-main.cjs.
+// SENTRY_DSN is set; errors always report when DSN is set; performance spans are gated
+// behind the analytics_enabled toggle (synced from SQLite + `sentry:set-consent` IPC).
+// See electron/core/sentry-main.cjs.
 const sentryMain = require('./core/sentry-main.cjs');
 sentryMain.initSentryMain(app);
 
@@ -991,6 +992,14 @@ app
       }
     } catch (mcpErr) {
       console.warn('[Main] DomeMCP auto-start check failed:', mcpErr?.message);
+    }
+
+    // Sync Sentry span consent from SQLite before the renderer loads so main-process
+    // performance spans honour analytics_enabled without waiting for IPC.
+    try {
+      sentryMain.syncSentryConsentFromDatabase(database);
+    } catch (e) {
+      console.warn('[Main] Sentry consent sync:', e?.message || e);
     }
 
     // Crear ventana principal en cuanto la base de datos está lista (LanceDB ya se inicializó arriba).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {
@@ -23,6 +23,7 @@
     "electron:pack:verbose": "cross-env DEBUG=electron-builder electron-builder",
     "rebuild:natives": "electron-rebuild -f -w=better-sqlite3,sharp,@ffmpeg-installer/ffmpeg,@napi-rs/canvas,@lancedb/lancedb",
     "verify:natives": "node scripts/verify-natives.cjs",
+    "verify:sentry-build": "node scripts/verify-sentry-build.cjs",
     "copy:pdf-worker": "node scripts/copy-pdf-worker.cjs",
     "patch:pptx-preview": "node scripts/patch-pptx-preview.mjs",
     "postinstall": "electron-builder install-app-deps && pnpm run build:packages && pnpm run rebuild:natives && pnpm run copy:pdf-worker && pnpm run patch:pptx-preview",

--- a/scripts/verify-sentry-build.cjs
+++ b/scripts/verify-sentry-build.cjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * CI gate: ensure Sentry DSN is baked into both the main-process credentials
+ * file and the Vite renderer bundle before electron-builder runs.
+ *
+ * Usage: node scripts/verify-sentry-build.cjs
+ * Expects: pnpm run build + node scripts/embed-env.cjs already executed.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const credPath = path.join(__dirname, '../electron/app-credentials.cjs');
+const distAssetsDir = path.join(__dirname, '../dist/assets');
+
+function fail(message) {
+  console.error('[verify-sentry-build] FAIL:', message);
+  process.exit(1);
+}
+
+function ok(message) {
+  console.log('[verify-sentry-build] OK:', message);
+}
+
+if (!fs.existsSync(credPath)) {
+  fail('electron/app-credentials.cjs missing — run node scripts/embed-env.cjs first');
+}
+
+let creds;
+try {
+  // eslint-disable-next-line import/no-dynamic-require, global-require
+  creds = require(credPath);
+} catch (err) {
+  fail(`could not load app-credentials.cjs: ${err?.message || err}`);
+}
+
+const dsn = String(creds.SENTRY_DSN || '').trim();
+if (!dsn || dsn.includes('...') || !dsn.startsWith('https://')) {
+  fail('SENTRY_DSN empty or invalid in electron/app-credentials.cjs');
+}
+
+const hostMatch = dsn.match(/@([^/]+)/);
+const ingestHost = hostMatch ? hostMatch[1] : null;
+ok(`main SENTRY_DSN set (${ingestHost || 'unknown host'})`);
+
+if (!fs.existsSync(distAssetsDir)) {
+  fail('dist/assets/ missing — run pnpm run build first');
+}
+
+const jsFiles = fs.readdirSync(distAssetsDir).filter((name) => name.endsWith('.js'));
+if (jsFiles.length === 0) {
+  fail('no JS bundles found in dist/assets/');
+}
+
+const needles = [ingestHost, 'ingest.de.sentry.io', 'ingest.sentry.io'].filter(Boolean);
+let foundInDist = false;
+
+for (const file of jsFiles) {
+  const content = fs.readFileSync(path.join(distAssetsDir, file), 'utf8');
+  if (needles.some((needle) => content.includes(needle))) {
+    foundInDist = true;
+    break;
+  }
+}
+
+if (!foundInDist) {
+  fail(
+    'renderer bundle does not reference Sentry ingest host — VITE_SENTRY_DSN may be missing at build time',
+  );
+}
+
+ok('renderer bundle contains Sentry ingest host reference');
+console.log('[verify-sentry-build] All checks passed');


### PR DESCRIPTION
## Summary
- Fix asymmetric Sentry consent gate that blocked all production errors while performance spans still reached Sentry.
- Sync span consent from SQLite in main process before window creation.
- Always report errors/crashes when DSN is configured; gate performance spans with analytics_enabled.
- Add CI verify-sentry-build gate and Sentry source map upload env vars.

## Test plan
- [x] pnpm run typecheck
- [x] verify-sentry-build passes with baked DSN
- [ ] GitHub Release build attaches installers
- [ ] Packaged app shows new issues under environment:production in Sentry

Made with [Cursor](https://cursor.com)