### PR TITLE
fix(github): prevent OOM on issues:list IPC (v2.7.3)

### DIFF
--- a/app/components/github/IssueDetailPanel.tsx
+++ b/app/components/github/IssueDetailPanel.tsx
@@ -199,9 +199,11 @@ export default function IssueDetailPanel({ issueId, onClose }: { issueId: string
   }, [issueId]);
 
   useEffect(() => {
+    let cancelled = false;
+
     if (initial) {
       setTitle(initial.title);
-      setBody(initial.body ?? '');
+      setBody('');
       setState(initial.state);
       setMilestoneChoice(initial.milestone_number != null ? String(initial.milestone_number) : 'none');
       setAssignees(parseAssignees(initial.assignees));
@@ -211,7 +213,21 @@ export default function IssueDetailPanel({ issueId, onClose }: { issueId: string
       setAssigneePickerQuery('');
       setTab('comments');
     }
-  }, [issueId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    void (async () => {
+      const res = await githubClient.issues.get(issueId);
+      if (cancelled || !res.success || !res.issue) return;
+      setTitle(res.issue.title);
+      setBody(res.issue.body ?? '');
+      setState(res.issue.state);
+      setMilestoneChoice(res.issue.milestone_number != null ? String(res.issue.milestone_number) : 'none');
+      setAssignees(parseAssignees(res.issue.assignees));
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [issueId, initial]);
 
   useEffect(() => {
     if (!editing) {

--- a/docs/architecture/ipc-channels.md
+++ b/docs/architecture/ipc-channels.md
@@ -1,7 +1,7 @@
 # Canales IPC (autogenerado)
 
 > **No edites a mano.** Regenera con `pnpm run generate:ipc-inventory`.
-> Última generación: 2026-06-23T14:27:33.413Z
+> Última generación: 2026-06-25T20:13:39.784Z
 
 Canales detectados vía `ipcMain.handle` / `ipcMain.on` en `electron/ipc/**/*.cjs`.
 
@@ -311,29 +311,29 @@ Canales detectados vía `ipcMain.handle` / `ipcMain.on` en `electron/ipc/**/*.cj
 | `get-home-path` | `electron/ipc/core/system.cjs:17` |
 | `get-theme` | `electron/ipc/core/system.cjs:184` |
 | `get-user-data-path` | `electron/ipc/core/system.cjs:7` |
-| `github:auth:disconnect` | `electron/ipc/integrations/github.cjs:65` |
-| `github:auth:poll` | `electron/ipc/integrations/github.cjs:43` |
-| `github:auth:start` | `electron/ipc/integrations/github.cjs:32` |
-| `github:auth:status` | `electron/ipc/integrations/github.cjs:56` |
-| `github:branches:list` | `electron/ipc/integrations/github.cjs:139` |
-| `github:image:resolve` | `electron/ipc/integrations/github.cjs:323` |
-| `github:issues:create` | `electron/ipc/integrations/github.cjs:188` |
-| `github:issues:createComment` | `electron/ipc/integrations/github.cjs:210` |
-| `github:issues:get` | `electron/ipc/integrations/github.cjs:129` |
-| `github:issues:list` | `electron/ipc/integrations/github.cjs:119` |
-| `github:issues:listComments` | `electron/ipc/integrations/github.cjs:199` |
-| `github:issues:listMentionables` | `electron/ipc/integrations/github.cjs:232` |
-| `github:issues:listTimeline` | `electron/ipc/integrations/github.cjs:221` |
-| `github:issues:move` | `electron/ipc/integrations/github.cjs:173` |
-| `github:issues:update` | `electron/ipc/integrations/github.cjs:160` |
-| `github:milestones:create` | `electron/ipc/integrations/github.cjs:255` |
-| `github:milestones:list` | `electron/ipc/integrations/github.cjs:109` |
-| `github:milestones:update` | `electron/ipc/integrations/github.cjs:243` |
-| `github:releases:list` | `electron/ipc/integrations/github.cjs:149` |
-| `github:repos:list` | `electron/ipc/integrations/github.cjs:77` |
-| `github:repos:refresh` | `electron/ipc/integrations/github.cjs:86` |
-| `github:repos:setSelected` | `electron/ipc/integrations/github.cjs:96` |
-| `github:sync:now` | `electron/ipc/integrations/github.cjs:365` |
+| `github:auth:disconnect` | `electron/ipc/integrations/github.cjs:68` |
+| `github:auth:poll` | `electron/ipc/integrations/github.cjs:46` |
+| `github:auth:start` | `electron/ipc/integrations/github.cjs:35` |
+| `github:auth:status` | `electron/ipc/integrations/github.cjs:59` |
+| `github:branches:list` | `electron/ipc/integrations/github.cjs:154` |
+| `github:image:resolve` | `electron/ipc/integrations/github.cjs:338` |
+| `github:issues:create` | `electron/ipc/integrations/github.cjs:203` |
+| `github:issues:createComment` | `electron/ipc/integrations/github.cjs:225` |
+| `github:issues:get` | `electron/ipc/integrations/github.cjs:144` |
+| `github:issues:list` | `electron/ipc/integrations/github.cjs:122` |
+| `github:issues:listComments` | `electron/ipc/integrations/github.cjs:214` |
+| `github:issues:listMentionables` | `electron/ipc/integrations/github.cjs:247` |
+| `github:issues:listTimeline` | `electron/ipc/integrations/github.cjs:236` |
+| `github:issues:move` | `electron/ipc/integrations/github.cjs:188` |
+| `github:issues:update` | `electron/ipc/integrations/github.cjs:175` |
+| `github:milestones:create` | `electron/ipc/integrations/github.cjs:270` |
+| `github:milestones:list` | `electron/ipc/integrations/github.cjs:112` |
+| `github:milestones:update` | `electron/ipc/integrations/github.cjs:258` |
+| `github:releases:list` | `electron/ipc/integrations/github.cjs:164` |
+| `github:repos:list` | `electron/ipc/integrations/github.cjs:80` |
+| `github:repos:refresh` | `electron/ipc/integrations/github.cjs:89` |
+| `github:repos:setSelected` | `electron/ipc/integrations/github.cjs:99` |
+| `github:sync:now` | `electron/ipc/integrations/github.cjs:380` |
 | `image:crop` | `electron/ipc/media/images.cjs:11` |
 | `image:metadata` | `electron/ipc/media/images.cjs:82` |
 | `image:resize` | `electron/ipc/media/images.cjs:37` |

--- a/electron/github/github-store.cjs
+++ b/electron/github/github-store.cjs
@@ -223,6 +223,22 @@ function listIssues(rId) {
   return db().prepare('SELECT * FROM github_issues WHERE repo_id = ? AND is_pull_request = 0 ORDER BY number DESC').all(rId);
 }
 
+/** Metadata-only list for IPC/UI — excludes `body` to avoid OOM on large repos. */
+function listIssuesSummary(rId) {
+  return db()
+    .prepare(
+      `SELECT id, repo_id, number, title, state, milestone_number, due_date, labels, assignees, is_pull_request, html_url
+       FROM github_issues WHERE repo_id = ? AND is_pull_request = 0 ORDER BY number DESC`,
+    )
+    .all(rId);
+}
+
+function countIssues(rId) {
+  return db()
+    .prepare('SELECT COUNT(*) AS count FROM github_issues WHERE repo_id = ? AND is_pull_request = 0')
+    .get(rId).count;
+}
+
 function getIssue(id) {
   return db().prepare('SELECT * FROM github_issues WHERE id = ?').get(id);
 }
@@ -372,6 +388,8 @@ module.exports = {
   markMilestoneClean,
   upsertIssueFromRemote,
   listIssues,
+  listIssuesSummary,
+  countIssues,
   getIssue,
   listDirtyIssues,
   updateLocalIssue,

--- a/electron/ipc/integrations/github.cjs
+++ b/electron/ipc/integrations/github.cjs
@@ -5,8 +5,11 @@
 const { z } = require('zod');
 const { shell } = require('electron');
 const githubOAuth = require('../../auth/github-oauth.cjs');
+const memoryMonitor = require('../../core/memory-monitor.cjs');
 const syncService = require('../../github/github-sync-service.cjs');
 const store = require('../../github/github-store.cjs');
+
+const ISSUE_LIST_WARN_THRESHOLD = 10_000;
 
 const PollSchema = z.object({
   deviceCode: z.string().min(1),
@@ -120,7 +123,19 @@ function register({ ipcMain, windowManager }) {
     if (!guard(event)) return fail('Unauthorized');
     if (typeof repoId !== 'string') return fail('Invalid repoId');
     try {
-      return ok({ issues: store.listIssues(repoId) });
+      const count = store.countIssues(repoId);
+      if (count > ISSUE_LIST_WARN_THRESHOLD) {
+        console.warn(`[github IPC] github:issues:list repo ${repoId} has ${count} issues (threshold ${ISSUE_LIST_WARN_THRESHOLD})`);
+      }
+      if (memoryMonitor.isMemoryPressureHigh()) {
+        const m = memoryMonitor.getMemoryInfo();
+        console.warn(
+          `[github IPC] github:issues:list skipped — memory pressure ${(m.heapUsedRatio * 100).toFixed(1)}% ` +
+          `(heapUsed ${(m.heapUsed / 1024 / 1024).toFixed(0)}MB / ${(m.heapTotal / 1024 / 1024).toFixed(0)}MB)`,
+        );
+        return fail('Memory pressure too high to load issues. Try again in a moment.');
+      }
+      return ok({ issues: store.listIssuesSummary(repoId) });
     } catch (err) {
       return fail(err);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {


### PR DESCRIPTION
## Summary
- Add `listIssuesSummary` / `countIssues` in github-store and use summary (no `body`) in `github:issues:list` IPC to avoid fatal main-process OOM during JSON serialization (Sentry ELECTRON-7).
- Load full issue body in `IssueDetailPanel` via `github:issues:get` when opening detail.
- Add defensive memory-pressure guard and warning log when issue count exceeds 10k.

## Test plan
- [ ] Open GitHub tab with a repo that has many issues — app should not crash.
- [ ] Kanban / minimal tracker render issue metadata correctly.
- [ ] Open an issue detail — body loads via `issues:get`.
- [ ] Confirm no new ELECTRON-7 events in Sentry after release.