### PR TITLE
fix(github): harden OOM fix — pagination + calendar slim (v2.7.4)

### DIFF
--- a/app/lib/ai/tools/github-tools.ts
+++ b/app/lib/ai/tools/github-tools.ts
@@ -173,13 +173,10 @@ export function createGithubListIssuesTool(): AnyAgentTool {
       const params = args as Record<string, unknown>;
       const repoId = readStringParam(params, 'repo_id', { required: true });
       const state = readStringParam(params, 'state') ?? 'all';
-      const res = await githubClient.issues.list(repoId!);
+      const filterState = state === 'open' || state === 'closed' ? state : undefined;
+      const res = await githubClient.issues.list(repoId!, { state: filterState });
       if (!res.success) return jsonResult({ success: false, error: res.error });
-      let issues = res.issues ?? [];
-      if (state === 'open' || state === 'closed') {
-        issues = issues.filter((i) => i.state === state);
-      }
-      return jsonResult({ success: true, source: 'github', issues });
+      return jsonResult({ success: true, source: 'github', issues: res.issues ?? [] });
     },
   };
 }

--- a/app/lib/github/client.ts
+++ b/app/lib/github/client.ts
@@ -21,6 +21,22 @@ export function normalizeGithubHtmlImages(markdown: string): string {
   );
 }
 
+export interface GitHubIssuesListOptions {
+  state?: 'open' | 'closed';
+  limit?: number;
+  offset?: number;
+}
+
+export interface GitHubIssuesListResult {
+  success: boolean;
+  issues?: GitHubIssueRow[];
+  total?: number;
+  limit?: number;
+  offset?: number;
+  truncated?: boolean;
+  error?: string;
+}
+
 export const githubClient = {
   auth: {
     start: () => gh().auth.start(),
@@ -40,7 +56,7 @@ export const githubClient = {
     update: (id: string, patch: Record<string, unknown>) => gh().milestones.update(id, patch),
   },
   issues: {
-    list: (repoId: string) => gh().issues.list(repoId),
+    list: (repoId: string, opts?: GitHubIssuesListOptions) => gh().issues.list(repoId, opts) as Promise<GitHubIssuesListResult>,
     get: (id: string) => gh().issues.get(id),
     create: (repoId: string, data: { title: string; body?: string; milestoneNumber?: number; labels?: string[]; assignees?: string[] }) =>
       gh().issues.create(repoId, data),

--- a/app/lib/store/useGitHubStore.ts
+++ b/app/lib/store/useGitHubStore.ts
@@ -11,6 +11,23 @@ let _unsubDataUpdated: (() => void) | null = null;
 let _subscribed = false;
 let _refreshDebounce: ReturnType<typeof setTimeout> | null = null;
 const REFRESH_DEBOUNCE_MS = 500;
+const ISSUES_PAGE_SIZE = 5000;
+
+/** Reuse in-flight loadRepoData for the same repo (sync burst + tab open). */
+let _loadRepoInflight: { repoId: string; promise: Promise<void> } | null = null;
+
+async function fetchAllIssues(repoId: string): Promise<GitHubIssueRow[]> {
+  const all: GitHubIssueRow[] = [];
+  let offset = 0;
+  for (;;) {
+    const res = await githubClient.issues.list(repoId, { limit: ISSUES_PAGE_SIZE, offset });
+    if (!res.success) throw new Error(res.error ?? 'Failed to load issues');
+    all.push(...(res.issues ?? []));
+    if (!res.truncated) break;
+    offset += res.limit ?? ISSUES_PAGE_SIZE;
+  }
+  return all;
+}
 
 interface GitHubState {
   connected: boolean;
@@ -129,23 +146,42 @@ export const useGitHubStore = create<GitHubState>((set, get) => ({
   },
 
   loadRepoData: async (repoId) => {
-    set({ loading: true, error: null });
+    if (_loadRepoInflight?.repoId === repoId) {
+      await _loadRepoInflight.promise;
+      return;
+    }
+
+    const run = (async () => {
+      set({ loading: true, error: null });
+      try {
+        const ms = await githubClient.milestones.list(repoId);
+        if (!ms.success) throw new Error(ms.error ?? 'Failed to load milestones');
+
+        const issues = await fetchAllIssues(repoId);
+
+        const br = await githubClient.branches.list(repoId);
+        if (!br.success) throw new Error(br.error ?? 'Failed to load branches');
+
+        const rel = await githubClient.releases.list(repoId);
+        if (!rel.success) throw new Error(rel.error ?? 'Failed to load releases');
+
+        set({
+          milestones: ms.milestones ?? [],
+          issues,
+          branches: br.branches ?? [],
+          releases: rel.releases ?? [],
+          loading: false,
+        });
+      } catch (e) {
+        set({ loading: false, error: e instanceof Error ? e.message : String(e) });
+      }
+    })();
+
+    _loadRepoInflight = { repoId, promise: run };
     try {
-      const [ms, iss, br, rel] = await Promise.all([
-        githubClient.milestones.list(repoId),
-        githubClient.issues.list(repoId),
-        githubClient.branches.list(repoId),
-        githubClient.releases.list(repoId),
-      ]);
-      set({
-        milestones: ms.milestones ?? [],
-        issues: iss.issues ?? [],
-        branches: br.branches ?? [],
-        releases: rel.releases ?? [],
-        loading: false,
-      });
-    } catch (e) {
-      set({ loading: false, error: e instanceof Error ? e.message : String(e) });
+      await run;
+    } finally {
+      if (_loadRepoInflight?.repoId === repoId) _loadRepoInflight = null;
     }
   },
 

--- a/app/types/global.d.ts
+++ b/app/types/global.d.ts
@@ -204,7 +204,7 @@ declare global {
     repo_id: string;
     number: number;
     title: string;
-    body: string | null;
+    body?: string | null;
     state: 'open' | 'closed';
     milestone_number: number | null;
     due_date: number | null;
@@ -607,7 +607,18 @@ declare global {
           update: (id: string, patch: Record<string, unknown>) => Promise<{ success: boolean; milestone?: GitHubMilestoneRow; error?: string }>;
         };
         issues: {
-          list: (repoId: string) => Promise<{ success: boolean; issues?: GitHubIssueRow[]; error?: string }>;
+          list: (
+            repoId: string,
+            opts?: { state?: 'open' | 'closed'; limit?: number; offset?: number },
+          ) => Promise<{
+            success: boolean;
+            issues?: GitHubIssueRow[];
+            total?: number;
+            limit?: number;
+            offset?: number;
+            truncated?: boolean;
+            error?: string;
+          }>;
           get: (id: string) => Promise<{ success: boolean; issue?: GitHubIssueRow; error?: string }>;
           create: (repoId: string, data: { title: string; body?: string; milestoneNumber?: number; labels?: string[]; assignees?: string[] }) => Promise<{ success: boolean; issue?: GitHubIssueRow; error?: string }>;
           update: (id: string, patch: Record<string, unknown>) => Promise<{ success: boolean; issue?: GitHubIssueRow; error?: string }>;

--- a/docs/architecture/ipc-channels.md
+++ b/docs/architecture/ipc-channels.md
@@ -1,7 +1,7 @@
 # Canales IPC (autogenerado)
 
 > **No edites a mano.** Regenera con `pnpm run generate:ipc-inventory`.
-> Última generación: 2026-06-25T20:13:39.784Z
+> Última generación: 2026-06-25T21:37:17.472Z
 
 Canales detectados vía `ipcMain.handle` / `ipcMain.on` en `electron/ipc/**/*.cjs`.
 
@@ -311,29 +311,29 @@ Canales detectados vía `ipcMain.handle` / `ipcMain.on` en `electron/ipc/**/*.cj
 | `get-home-path` | `electron/ipc/core/system.cjs:17` |
 | `get-theme` | `electron/ipc/core/system.cjs:184` |
 | `get-user-data-path` | `electron/ipc/core/system.cjs:7` |
-| `github:auth:disconnect` | `electron/ipc/integrations/github.cjs:68` |
-| `github:auth:poll` | `electron/ipc/integrations/github.cjs:46` |
-| `github:auth:start` | `electron/ipc/integrations/github.cjs:35` |
-| `github:auth:status` | `electron/ipc/integrations/github.cjs:59` |
-| `github:branches:list` | `electron/ipc/integrations/github.cjs:154` |
-| `github:image:resolve` | `electron/ipc/integrations/github.cjs:338` |
-| `github:issues:create` | `electron/ipc/integrations/github.cjs:203` |
-| `github:issues:createComment` | `electron/ipc/integrations/github.cjs:225` |
-| `github:issues:get` | `electron/ipc/integrations/github.cjs:144` |
-| `github:issues:list` | `electron/ipc/integrations/github.cjs:122` |
-| `github:issues:listComments` | `electron/ipc/integrations/github.cjs:214` |
-| `github:issues:listMentionables` | `electron/ipc/integrations/github.cjs:247` |
-| `github:issues:listTimeline` | `electron/ipc/integrations/github.cjs:236` |
-| `github:issues:move` | `electron/ipc/integrations/github.cjs:188` |
-| `github:issues:update` | `electron/ipc/integrations/github.cjs:175` |
-| `github:milestones:create` | `electron/ipc/integrations/github.cjs:270` |
-| `github:milestones:list` | `electron/ipc/integrations/github.cjs:112` |
-| `github:milestones:update` | `electron/ipc/integrations/github.cjs:258` |
-| `github:releases:list` | `electron/ipc/integrations/github.cjs:164` |
-| `github:repos:list` | `electron/ipc/integrations/github.cjs:80` |
-| `github:repos:refresh` | `electron/ipc/integrations/github.cjs:89` |
-| `github:repos:setSelected` | `electron/ipc/integrations/github.cjs:99` |
-| `github:sync:now` | `electron/ipc/integrations/github.cjs:380` |
+| `github:auth:disconnect` | `electron/ipc/integrations/github.cjs:106` |
+| `github:auth:poll` | `electron/ipc/integrations/github.cjs:84` |
+| `github:auth:start` | `electron/ipc/integrations/github.cjs:73` |
+| `github:auth:status` | `electron/ipc/integrations/github.cjs:97` |
+| `github:branches:list` | `electron/ipc/integrations/github.cjs:202` |
+| `github:image:resolve` | `electron/ipc/integrations/github.cjs:390` |
+| `github:issues:create` | `electron/ipc/integrations/github.cjs:255` |
+| `github:issues:createComment` | `electron/ipc/integrations/github.cjs:277` |
+| `github:issues:get` | `electron/ipc/integrations/github.cjs:192` |
+| `github:issues:list` | `electron/ipc/integrations/github.cjs:162` |
+| `github:issues:listComments` | `electron/ipc/integrations/github.cjs:266` |
+| `github:issues:listMentionables` | `electron/ipc/integrations/github.cjs:299` |
+| `github:issues:listTimeline` | `electron/ipc/integrations/github.cjs:288` |
+| `github:issues:move` | `electron/ipc/integrations/github.cjs:240` |
+| `github:issues:update` | `electron/ipc/integrations/github.cjs:227` |
+| `github:milestones:create` | `electron/ipc/integrations/github.cjs:322` |
+| `github:milestones:list` | `electron/ipc/integrations/github.cjs:150` |
+| `github:milestones:update` | `electron/ipc/integrations/github.cjs:310` |
+| `github:releases:list` | `electron/ipc/integrations/github.cjs:214` |
+| `github:repos:list` | `electron/ipc/integrations/github.cjs:118` |
+| `github:repos:refresh` | `electron/ipc/integrations/github.cjs:127` |
+| `github:repos:setSelected` | `electron/ipc/integrations/github.cjs:137` |
+| `github:sync:now` | `electron/ipc/integrations/github.cjs:432` |
 | `image:crop` | `electron/ipc/media/images.cjs:11` |
 | `image:metadata` | `electron/ipc/media/images.cjs:82` |
 | `image:resize` | `electron/ipc/media/images.cjs:37` |

--- a/electron/github/github-calendar-bridge.cjs
+++ b/electron/github/github-calendar-bridge.cjs
@@ -169,7 +169,7 @@ async function syncCalendar() {
 
   for (const repo of repos) {
     // Milestones — always on due_on (fecha de entrega), open or closed
-    for (const m of store.listMilestones(repo.id)) {
+    for (const m of store.listMilestonesWithDueOn(repo.id)) {
       // Remove legacy completion-date events from earlier bridge versions
       await removeEvent('milestone', completedMilestoneLinkId(m.id));
 
@@ -193,8 +193,8 @@ async function syncCalendar() {
       await breathe();
     }
     // Issues with a parsed due date
-    for (const issue of store.listIssues(repo.id)) {
-      if (issuesOn && issue.due_date && issue.state === 'open') {
+    for (const issue of store.listIssuesForCalendar(repo.id)) {
+      if (issuesOn) {
         await upsertEvent('issue', issue.id, {
           title: `#${issue.number} ${issue.title}`,
           description: issue.body,

--- a/electron/github/github-store.cjs
+++ b/electron/github/github-store.cjs
@@ -127,6 +127,24 @@ function listMilestones(rId) {
   return db().prepare('SELECT * FROM github_milestones WHERE repo_id = ? ORDER BY due_on IS NULL, due_on').all(rId);
 }
 
+/** Metadata-only list for IPC/UI — excludes `description`. */
+function listMilestonesSummary(rId) {
+  return db()
+    .prepare(
+      `SELECT id, repo_id, number, title, due_on, closed_at, state, open_issues, closed_issues, html_url,
+              remote_updated_at, dome_updated_at, dirty, created_at, updated_at
+       FROM github_milestones WHERE repo_id = ? ORDER BY due_on IS NULL, due_on`,
+    )
+    .all(rId);
+}
+
+/** Milestones with a due date — for calendar projection (includes description). */
+function listMilestonesWithDueOn(rId) {
+  return db()
+    .prepare('SELECT * FROM github_milestones WHERE repo_id = ? AND due_on IS NOT NULL ORDER BY due_on')
+    .all(rId);
+}
+
 function getMilestone(id) {
   return db().prepare('SELECT * FROM github_milestones WHERE id = ?').get(id);
 }
@@ -224,19 +242,51 @@ function listIssues(rId) {
 }
 
 /** Metadata-only list for IPC/UI — excludes `body` to avoid OOM on large repos. */
-function listIssuesSummary(rId) {
-  return db()
-    .prepare(
-      `SELECT id, repo_id, number, title, state, milestone_number, due_date, labels, assignees, is_pull_request, html_url
-       FROM github_issues WHERE repo_id = ? AND is_pull_request = 0 ORDER BY number DESC`,
-    )
-    .all(rId);
+const ISSUE_LIST_DEFAULT_LIMIT = 5000;
+const ISSUE_LIST_MAX_LIMIT = 8000;
+
+function listIssuesSummary(rId, opts = {}) {
+  const state = opts.state === 'open' || opts.state === 'closed' ? opts.state : null;
+  const limit = Math.min(
+    Math.max(1, Number.isFinite(opts.limit) ? opts.limit : ISSUE_LIST_DEFAULT_LIMIT),
+    ISSUE_LIST_MAX_LIMIT,
+  );
+  const offset = Math.max(0, Number.isFinite(opts.offset) ? opts.offset : 0);
+
+  let sql = `SELECT id, repo_id, number, title, state, milestone_number, due_date, labels, assignees, is_pull_request, html_url
+       FROM github_issues WHERE repo_id = ? AND is_pull_request = 0`;
+  const params = [rId];
+  if (state) {
+    sql += ' AND state = ?';
+    params.push(state);
+  }
+  sql += ' ORDER BY number DESC LIMIT ? OFFSET ?';
+  params.push(limit, offset);
+  return db().prepare(sql).all(...params);
 }
 
-function countIssues(rId) {
+function countIssues(rId, state) {
+  if (state === 'open' || state === 'closed') {
+    return db()
+      .prepare(
+        'SELECT COUNT(*) AS count FROM github_issues WHERE repo_id = ? AND is_pull_request = 0 AND state = ?',
+      )
+      .get(rId, state).count;
+  }
   return db()
     .prepare('SELECT COUNT(*) AS count FROM github_issues WHERE repo_id = ? AND is_pull_request = 0')
     .get(rId).count;
+}
+
+/** Open issues with a parsed due date — for calendar projection (includes body). */
+function listIssuesForCalendar(rId) {
+  return db()
+    .prepare(
+      `SELECT id, repo_id, number, title, body, state, due_date, html_url
+       FROM github_issues
+       WHERE repo_id = ? AND is_pull_request = 0 AND state = 'open' AND due_date IS NOT NULL`,
+    )
+    .all(rId);
 }
 
 function getIssue(id) {
@@ -382,6 +432,8 @@ module.exports = {
   setEtag,
   upsertMilestoneFromRemote,
   listMilestones,
+  listMilestonesSummary,
+  listMilestonesWithDueOn,
   getMilestone,
   listDirtyMilestones,
   updateLocalMilestone,
@@ -389,7 +441,10 @@ module.exports = {
   upsertIssueFromRemote,
   listIssues,
   listIssuesSummary,
+  listIssuesForCalendar,
   countIssues,
+  ISSUE_LIST_DEFAULT_LIMIT,
+  ISSUE_LIST_MAX_LIMIT,
   getIssue,
   listDirtyIssues,
   updateLocalIssue,

--- a/electron/github/github-sync-service.cjs
+++ b/electron/github/github-sync-service.cjs
@@ -18,6 +18,7 @@
 const api = require('./github-api.cjs');
 const store = require('./github-store.cjs');
 const calendarBridge = require('./github-calendar-bridge.cjs');
+const memoryMonitor = require('../core/memory-monitor.cjs');
 
 let _syncing = false;
 let _windowManager = null;
@@ -311,7 +312,11 @@ async function syncNow() {
     for (const repo of repos) {
       await pullRepo(repo);
     }
-    await calendarBridge.syncCalendar();
+    if (memoryMonitor.isMemoryPressureHigh()) {
+      console.warn('[github-sync] skipping calendar projection — memory pressure');
+    } else {
+      await calendarBridge.syncCalendar();
+    }
     broadcast('github:sync:status', { status: 'idle', lastSync: Date.now() });
     broadcast('github:data:updated', {});
     return { success: true, repos: repos.length };

--- a/electron/ipc/integrations/github.cjs
+++ b/electron/ipc/integrations/github.cjs
@@ -11,6 +11,44 @@ const store = require('../../github/github-store.cjs');
 
 const ISSUE_LIST_WARN_THRESHOLD = 10_000;
 
+const IssuesListOptsSchema = z
+  .object({
+    state: z.enum(['open', 'closed']).optional(),
+    limit: z.number().int().positive().max(store.ISSUE_LIST_MAX_LIMIT).optional(),
+    offset: z.number().int().nonnegative().optional(),
+  })
+  .optional();
+
+/** Coalesce concurrent identical issues:list reads (sync broadcast + UI open). */
+const _issuesListInflight = new Map();
+
+function memoryPressureFail(label) {
+  if (!memoryMonitor.isMemoryPressureHigh()) return null;
+  const m = memoryMonitor.getMemoryInfo();
+  console.warn(
+    `[github IPC] ${label} skipped — memory pressure ${(m.heapUsedRatio * 100).toFixed(1)}% ` +
+    `(heapUsed ${(m.heapUsed / 1024 / 1024).toFixed(0)}MB / ${(m.heapTotal / 1024 / 1024).toFixed(0)}MB)`,
+  );
+  return { success: false, error: 'Memory pressure too high to load GitHub data. Try again in a moment.' };
+}
+
+async function fetchIssuesListPage(repoId, opts = {}) {
+  const parsed = IssuesListOptsSchema.safeParse(opts);
+  const safe = parsed.success ? parsed.data ?? {} : {};
+  const state = safe.state;
+  const limit = safe.limit ?? store.ISSUE_LIST_DEFAULT_LIMIT;
+  const offset = safe.offset ?? 0;
+  const total = store.countIssues(repoId, state);
+  const issues = store.listIssuesSummary(repoId, { state, limit, offset });
+  return {
+    issues,
+    total,
+    limit,
+    offset,
+    truncated: offset + issues.length < total,
+  };
+}
+
 const PollSchema = z.object({
   deviceCode: z.string().min(1),
   interval: z.number().int().positive().max(60).optional(),
@@ -112,30 +150,40 @@ function register({ ipcMain, windowManager }) {
   ipcMain.handle('github:milestones:list', async (event, repoId) => {
     if (!guard(event)) return fail('Unauthorized');
     if (typeof repoId !== 'string') return fail('Invalid repoId');
+    const memFail = memoryPressureFail('github:milestones:list');
+    if (memFail) return memFail;
     try {
-      return ok({ milestones: store.listMilestones(repoId) });
+      return ok({ milestones: store.listMilestonesSummary(repoId) });
     } catch (err) {
       return fail(err);
     }
   });
 
-  ipcMain.handle('github:issues:list', async (event, repoId) => {
+  ipcMain.handle('github:issues:list', async (event, repoId, opts) => {
     if (!guard(event)) return fail('Unauthorized');
     if (typeof repoId !== 'string') return fail('Invalid repoId');
+    const memFail = memoryPressureFail('github:issues:list');
+    if (memFail) return memFail;
     try {
-      const count = store.countIssues(repoId);
-      if (count > ISSUE_LIST_WARN_THRESHOLD) {
-        console.warn(`[github IPC] github:issues:list repo ${repoId} has ${count} issues (threshold ${ISSUE_LIST_WARN_THRESHOLD})`);
+      const cacheKey = `${repoId}:${JSON.stringify(opts ?? {})}`;
+      if (_issuesListInflight.has(cacheKey)) {
+        return ok(await _issuesListInflight.get(cacheKey));
       }
-      if (memoryMonitor.isMemoryPressureHigh()) {
-        const m = memoryMonitor.getMemoryInfo();
-        console.warn(
-          `[github IPC] github:issues:list skipped — memory pressure ${(m.heapUsedRatio * 100).toFixed(1)}% ` +
-          `(heapUsed ${(m.heapUsed / 1024 / 1024).toFixed(0)}MB / ${(m.heapTotal / 1024 / 1024).toFixed(0)}MB)`,
-        );
-        return fail('Memory pressure too high to load issues. Try again in a moment.');
+      const work = (async () => {
+        const total = store.countIssues(repoId);
+        if (total > ISSUE_LIST_WARN_THRESHOLD) {
+          console.warn(
+            `[github IPC] github:issues:list repo ${repoId} has ${total} issues (threshold ${ISSUE_LIST_WARN_THRESHOLD})`,
+          );
+        }
+        return fetchIssuesListPage(repoId, opts);
+      })();
+      _issuesListInflight.set(cacheKey, work);
+      try {
+        return ok(await work);
+      } finally {
+        _issuesListInflight.delete(cacheKey);
       }
-      return ok({ issues: store.listIssuesSummary(repoId) });
     } catch (err) {
       return fail(err);
     }
@@ -154,6 +202,8 @@ function register({ ipcMain, windowManager }) {
   ipcMain.handle('github:branches:list', async (event, repoId) => {
     if (!guard(event)) return fail('Unauthorized');
     if (typeof repoId !== 'string') return fail('Invalid repoId');
+    const memFail = memoryPressureFail('github:branches:list');
+    if (memFail) return memFail;
     try {
       return ok({ branches: store.listBranches(repoId) });
     } catch (err) {
@@ -164,6 +214,8 @@ function register({ ipcMain, windowManager }) {
   ipcMain.handle('github:releases:list', async (event, repoId) => {
     if (!guard(event)) return fail('Unauthorized');
     if (typeof repoId !== 'string') return fail('Invalid repoId');
+    const memFail = memoryPressureFail('github:releases:list');
+    if (memFail) return memFail;
     try {
       return ok({ releases: store.listReleases(repoId) });
     } catch (err) {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1083,7 +1083,7 @@ const electronHandler = {
       update: (id, patch) => ipcRenderer.invoke('github:milestones:update', id, patch),
     },
     issues: {
-      list: (repoId) => ipcRenderer.invoke('github:issues:list', repoId),
+      list: (repoId, opts) => ipcRenderer.invoke('github:issues:list', repoId, opts),
       get: (id) => ipcRenderer.invoke('github:issues:get', id),
       create: (repoId, data) => ipcRenderer.invoke('github:issues:create', repoId, data),
       update: (id, patch) => ipcRenderer.invoke('github:issues:update', id, patch),

--- a/electron/tools/ai-tools-handler.cjs
+++ b/electron/tools/ai-tools-handler.cjs
@@ -3011,8 +3011,8 @@ async function githubUpcomingMilestones({ limit = 30, state = 'all', include_pas
 async function githubListIssues({ repo_id, state = 'all' } = {}) {
   try {
     if (!repo_id) return { success: false, error: 'repo_id is required' };
-    let issues = githubStore().listIssues(repo_id);
-    if (state === 'open' || state === 'closed') issues = issues.filter((i) => i.state === state);
+    const filterState = state === 'open' || state === 'closed' ? state : undefined;
+    const issues = githubStore().listIssuesSummary(repo_id, { state: filterState });
     return {
       success: true,
       source: 'github',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {


### PR DESCRIPTION
## Diagnóstico Sentry (ELECTRON-7 sigue en v2.7.3)

- 1 evento nuevo en `dome@2.7.3` (25 Jun, ~105s tras arranque)
- Mismo stack: `JsonStringify` → V8 Zone OOM en main process
- Peak working set ~2.5 GB

El fix v2.7.3 (excluir `body` en `issues:list`) no bastó porque:

1. **`github-calendar-bridge`** seguía haciendo `store.listIssues()` → `SELECT *` con **body de todos los issues** al final de cada sync (coincide con el broadcast `github:data:updated` → `loadRepoData`).
2. **`loadRepoData`** lanzaba 4 IPC en paralelo (`Promise.all`), amplificando picos de serialización concurrente.
3. **Sin paginación**: un solo IPC aún podía devolver decenas de miles de filas metadata en un solo stringify.

## Fix v2.7.4

- `listIssuesForCalendar` / `listMilestonesWithDueOn`: solo filas necesarias para calendario (con body solo donde hace falta).
- `issues:list` paginado (`limit`/`offset`, default 5000, max 8000) + coalescing de requests concurrentes.
- `milestones:list` usa summary sin `description`.
- Guards de memory pressure en todos los list IPC de GitHub.
- Sync omite calendar projection bajo presión de memoria.
- Renderer: carga secuencial, dedupe in-flight, fetch paginado de issues.

Fixes ELECTRON-7

## Test plan
- [ ] Abrir GitHub con repo grande tras sync automático (~120s) — no crash
- [ ] Kanban/minimal cargan; abrir issue muestra body vía `issues:get`
- [ ] Issues con `due:` siguen apareciendo en calendario
- [ ] Sentry: sin nuevos eventos ELECTRON-7 en `dome@2.7.4`