### PR TITLE
fix: resolve ELECTRON-7 OOM by bounding tool-result details (v2.7.5)

### DIFF
--- a/electron/__tests__/tool-result-cap.test.mjs
+++ b/electron/__tests__/tool-result-cap.test.mjs
@@ -1,0 +1,89 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  safeStringify,
+  boundToolDetails,
+  capToolResultString,
+  DETAILS_BUDGET_CHARS,
+  SAFE_STRINGIFY_BUDGET_CHARS,
+} = require('../tools/tool-result-cap.cjs');
+
+/** Build an object that serializes far beyond `budget` chars without itself being huge to allocate. */
+function makeOversizedObject(targetChars) {
+  const nodes = [];
+  // Each node ~ 90 chars serialized; size the array to blow well past the budget.
+  const count = Math.ceil(targetChars / 90) + 1;
+  for (let i = 0; i < count; i++) {
+    nodes.push({ role: 'cell', name: 'x'.repeat(64), id: i });
+  }
+  return { nodes };
+}
+
+describe('tool-result-cap — ELECTRON-7 OOM guards', () => {
+  it('safeStringify passes strings through untouched (no quoting/escaping growth)', () => {
+    assert.equal(safeStringify('hello world'), 'hello world');
+  });
+
+  it('safeStringify serializes normal objects like JSON.stringify', () => {
+    assert.equal(safeStringify({ a: 1, b: 'x' }), '{"a":1,"b":"x"}');
+  });
+
+  it('safeStringify aborts oversized objects into a too_large notice instead of OOM-ing', () => {
+    const huge = makeOversizedObject(SAFE_STRINGIFY_BUDGET_CHARS + 1_000_000);
+    const out = safeStringify(huge);
+    assert.equal(typeof out, 'string');
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.error, 'tool_result_too_large');
+  });
+
+  it('safeStringify still propagates circular-reference errors', () => {
+    const circ = {};
+    circ.self = circ;
+    assert.throws(() => safeStringify(circ), /circular|Converting circular/i);
+  });
+
+  it('boundToolDetails returns small objects by reference (structured details preserved)', () => {
+    const small = { a: 1, nested: { ok: true } };
+    assert.equal(boundToolDetails(small), small);
+  });
+
+  it('boundToolDetails passes small strings through and marks oversized ones', () => {
+    assert.equal(boundToolDetails('short'), 'short');
+    const big = 'y'.repeat(DETAILS_BUDGET_CHARS + 10);
+    const marked = boundToolDetails(big);
+    assert.equal(marked._domeOmitted, 'tool_result_too_large');
+    assert.equal(marked.approxChars, big.length);
+  });
+
+  it('boundToolDetails collapses an oversized object to a tiny marker (no OOM)', () => {
+    const huge = makeOversizedObject(DETAILS_BUDGET_CHARS + 2_000_000);
+    const marked = boundToolDetails(huge);
+    assert.equal(marked._domeOmitted, 'tool_result_too_large');
+    // The marker itself must be trivially small to persist.
+    assert.ok(JSON.stringify(marked).length < 100);
+  });
+
+  it('boundToolDetails reports unserializable (circular) details without throwing', () => {
+    const circ = {};
+    circ.self = circ;
+    const marked = boundToolDetails(circ);
+    assert.equal(marked._domeOmitted, 'tool_result_unserializable');
+  });
+
+  it('boundToolDetails passes null/undefined/primitives through', () => {
+    assert.equal(boundToolDetails(null), null);
+    assert.equal(boundToolDetails(undefined), undefined);
+    assert.equal(boundToolDetails(42), 42);
+    assert.equal(boundToolDetails(true), true);
+  });
+
+  it('capToolResultString truncates past the cap and keeps a hint suffix', () => {
+    const long = 'z'.repeat(60_000);
+    const capped = capToolResultString('some_tool', long, { maxChars: 10_000 });
+    assert.ok(capped.length < long.length);
+    assert.ok(capped.includes('truncated'));
+  });
+});

--- a/electron/agents/agent-runtime.cjs
+++ b/electron/agents/agent-runtime.cjs
@@ -16,6 +16,10 @@
  * ESM runtime into the CommonJS main process at load time.
  */
 
+// Pure-CJS leaf (imports nothing) — safe to require at load without violating
+// the "never pull the ESM runtime at load time" guarantee documented above.
+const { safeStringify } = require('../tools/tool-result-cap.cjs');
+
 const DEFAULT_RECURSION_LIMIT = 25;
 
 /** Thrown when a tool requires HITL approval and the run should pause for resume. */
@@ -251,7 +255,9 @@ function toolResultText(result) {
   if (result.details == null) return '';
   if (typeof result.details === 'string') return result.details;
   try {
-    return JSON.stringify(result.details);
+    // safeStringify bounds serialization so a huge tool `details` payload can't
+    // OOM the main process inside V8's JsonStringify (ELECTRON-7).
+    return safeStringify(result.details);
   } catch {
     return String(result.details);
   }

--- a/electron/agents/dome-harness-bridge.cjs
+++ b/electron/agents/dome-harness-bridge.cjs
@@ -129,7 +129,7 @@ async function loadSkillsResources() {
  */
 async function buildMcpAgentTools(database, mcpServerIds) {
   if (!Array.isArray(mcpServerIds) || mcpServerIds.length === 0) return [];
-  const { capToolResultString, getCapForTool } = require('../tools/tool-result-cap.cjs');
+  const { capToolResultString, getCapForTool, safeStringify, boundToolDetails } = require('../tools/tool-result-cap.cjs');
   const { getMCPTools } = require('../mcp/mcp-client.cjs');
   const lcTools = await getMCPTools(database, mcpServerIds);
   if (!Array.isArray(lcTools) || lcTools.length === 0) return [];
@@ -149,9 +149,15 @@ async function buildMcpAgentTools(database, mcpServerIds) {
       parameters: schema,
       async execute(_toolCallId, params, signal) {
         const out = await lcTool.invoke(params, { signal });
-        const text = typeof out === 'string' ? out : JSON.stringify(out ?? '');
+        // safeStringify (not raw JSON.stringify): bounds serialization so a huge
+        // MCP payload can't OOM the main process before the char cap runs (ELECTRON-7).
+        const text = safeStringify(out ?? '');
         const capped = capToolResultString(name, text, { maxChars: getCapForTool(name) });
-        return { content: [{ type: 'text', text: capped }], details: out };
+        // boundToolDetails: the loop persists `details` verbatim into the session
+        // JSONL (createToolResultMessage → appendEntry → JSON.stringify). Returning
+        // the raw `out` would OOM the main process at persistence time even though
+        // `text` is capped — the actual ELECTRON-7 vector for huge snapshots.
+        return { content: [{ type: 'text', text: capped }], details: boundToolDetails(out) };
       },
     };
   });

--- a/electron/agents/run-helpers.cjs
+++ b/electron/agents/run-helpers.cjs
@@ -3,6 +3,9 @@
  * No Electron, no DB — unit-tested in electron/__tests__/run-helpers.test.mjs.
  */
 
+// Pure-CJS leaf (no Electron/DB deps) — keeps this module unit-testable.
+const { safeStringify } = require('../tools/tool-result-cap.cjs');
+
 function isRunAbortedError(error, signal) {
   if (signal?.aborted) return true;
   if (!error) return false;
@@ -50,7 +53,9 @@ function mergeLlmUsage(current, delta) {
 function serializeToolResult(result) {
   if (typeof result === 'string') return result;
   try {
-    return JSON.stringify(result ?? null);
+    // safeStringify bounds serialization so a huge tool result can't OOM the
+    // main process inside V8's JsonStringify (ELECTRON-7).
+    return safeStringify(result ?? null);
   } catch {
     return String(result);
   }

--- a/electron/ipc/index.cjs
+++ b/electron/ipc/index.cjs
@@ -145,7 +145,7 @@ function registerAll(deps) {
   chatHandlers.register({ ipcMain: secureIpcMain, windowManager, database, validateSender });
   runsHandlers.register({ ipcMain: secureIpcMain, windowManager, validateSender });
   pipelinesHandlers.register({ ipcMain: secureIpcMain, windowManager, database, validateSender });
-  marketplaceHandlers.register({ ipcMain: secureIpcMain, windowManager, validateSender });
+  marketplaceHandlers.register({ ipcMain: secureIpcMain, windowManager, validateSender, sanitizePath });
   cloudStorageHandlers.register({ ipcMain: secureIpcMain, windowManager, database, fileStorage });
   transcriptionSession.setWindowManager(windowManager);
   transcriptionHandlers.register({

--- a/electron/ipc/integrations/marketplace.cjs
+++ b/electron/ipc/integrations/marketplace.cjs
@@ -9,7 +9,7 @@
 
 const path = require('path');
 const fs = require('fs');
-const { app } = require('electron');
+const { app, dialog, BrowserWindow } = require('electron');
 const https = require('https');
 const http = require('http');
 const { URL } = require('url');
@@ -448,7 +448,7 @@ async function fetchSkills(config) {
 /**
  * Register IPC handlers
  */
-function register({ ipcMain, windowManager, validateSender }) {
+function register({ ipcMain, windowManager, validateSender, sanitizePath }) {
   /**
    * Fetch all marketplace items from all sources
    */

--- a/electron/mcp/mcp-client.cjs
+++ b/electron/mcp/mcp-client.cjs
@@ -11,7 +11,7 @@
  * - sse: url (required), SSE legacy transport
  */
 
-const { capToolResultString, getCapForTool } = require('../tools/tool-result-cap.cjs');
+const { capToolResultString, getCapForTool, safeStringify } = require('../tools/tool-result-cap.cjs');
 const {
   isMcpToolDisabledByDefault,
   normalizeMcpId,
@@ -335,7 +335,9 @@ function wrapMcpToolWithCap(tool) {
   const toolName = typeof tool.name === 'string' ? tool.name : 'mcp_tool';
   tool.invoke = async (input, config) => {
     const out = await originalInvoke(input, config);
-    const text = typeof out === 'string' ? out : JSON.stringify(out ?? '');
+    // safeStringify (not raw JSON.stringify): bounds serialization so a huge MCP
+    // payload can't OOM the main process before the char cap runs (ELECTRON-7).
+    const text = safeStringify(out ?? '');
     return capToolResultString(toolName, text, { maxChars: getCapForTool(toolName) });
   };
   return tool;

--- a/electron/tools/tool-result-cap.cjs
+++ b/electron/tools/tool-result-cap.cjs
@@ -48,6 +48,114 @@ function buildTruncateSuffix(toolName, originalLen, headLen) {
 }
 
 /**
+ * Hard ceiling (chars) on a single tool result's JSON serialization.
+ *
+ * The per-tool char caps above run AFTER `JSON.stringify`, so they cannot stop a
+ * runaway result (e.g. an MCP filesystem read of a multi-hundred-MB file/tree, or
+ * a huge unpaginated API response) from OOM-ing the MAIN process inside V8's
+ * JsonStringify ("Zone" OOM — the ELECTRON-7 crash signature). This budget bounds
+ * the serialization itself. 16M chars is ~32MB UTF-16 — far above any legitimate
+ * capped result (<=48k) yet far below the heap limit.
+ */
+const SAFE_STRINGIFY_BUDGET_CHARS = 16 * 1024 * 1024;
+
+/**
+ * `JSON.stringify` that aborts early instead of letting the output grow without
+ * bound. Returns the JSON string when within budget, or a small JSON notice when
+ * the value is too large to serialize safely. Strings pass through untouched
+ * (the caller's char cap slices them cheaply — no growth). Non-size serialization
+ * errors (circular refs, BigInt, throwing toJSON) propagate unchanged so callers
+ * keep their existing error handling.
+ *
+ * @param {unknown} value
+ * @param {{ budgetChars?: number }} [opts]
+ * @returns {string}
+ */
+function safeStringify(value, opts = {}) {
+  if (typeof value === 'string') return value;
+  const budget =
+    typeof opts.budgetChars === 'number' && opts.budgetChars > 2000
+      ? opts.budgetChars
+      : SAFE_STRINGIFY_BUDGET_CHARS;
+  let approx = 0;
+  const ABORT = {};
+  try {
+    return (
+      JSON.stringify(value, function (key, val) {
+        approx += key.length + 2;
+        const t = typeof val;
+        if (t === 'string') approx += val.length + 2;
+        else if (t === 'number' || t === 'boolean' || val === null) approx += 6;
+        if (approx > budget) throw ABORT;
+        return val;
+      }) ?? ''
+    );
+  } catch (err) {
+    if (err !== ABORT) throw err;
+    const mb = Math.max(1, Math.round(budget / 1024 / 1024));
+    return JSON.stringify({
+      error: 'tool_result_too_large',
+      message:
+        `Dome: tool result exceeded the ~${mb}MB serialization limit and was dropped to protect the app ` +
+        'from running out of memory. Retry with pagination, filters, or a narrower query.',
+    });
+  }
+}
+
+/**
+ * Structured `details` budget. The agent loop persists each tool result's
+ * `details` verbatim into the session JSONL (`createToolResultMessage` →
+ * `appendEntry` → `JSON.stringify(entry)`). A raw MCP payload (e.g. a
+ * `chrome_devtools` `take_snapshot` on a heavy page) carried as `details`
+ * therefore OOMs the MAIN process at persistence time — *even when the
+ * model-facing `content` text is already capped* (the ELECTRON-7 crash). 1M
+ * chars (~2MB UTF-16) keeps legitimate structured details while staying far
+ * below the heap limit.
+ */
+const DETAILS_BUDGET_CHARS = 1024 * 1024;
+
+/**
+ * Bound a tool result's `details` so it can never grow the persisted session
+ * entry without limit. Returns the value untouched when it serializes within
+ * budget (cheap walk that aborts early — it never builds an unbounded buffer),
+ * or a tiny marker object when it is too large / unserializable. Strings within
+ * budget pass through; oversized strings collapse to a marker.
+ *
+ * @param {unknown} value
+ * @param {{ budgetChars?: number }} [opts]
+ * @returns {unknown}
+ */
+function boundToolDetails(value, opts = {}) {
+  if (value == null) return value;
+  const budget =
+    typeof opts.budgetChars === 'number' && opts.budgetChars > 2000
+      ? opts.budgetChars
+      : DETAILS_BUDGET_CHARS;
+  if (typeof value === 'string') {
+    return value.length <= budget
+      ? value
+      : { _domeOmitted: 'tool_result_too_large', approxChars: value.length };
+  }
+  if (typeof value !== 'object') return value;
+  let approx = 0;
+  const ABORT = {};
+  try {
+    JSON.stringify(value, function (key, val) {
+      approx += key.length + 2;
+      const t = typeof val;
+      if (t === 'string') approx += val.length + 2;
+      else if (t === 'number' || t === 'boolean' || val === null) approx += 6;
+      if (approx > budget) throw ABORT;
+      return val;
+    });
+    return value;
+  } catch (err) {
+    if (err === ABORT) return { _domeOmitted: 'tool_result_too_large' };
+    return { _domeOmitted: 'tool_result_unserializable' };
+  }
+}
+
+/**
  * @param {string} toolName
  * @param {string} text
  * @param {{ maxChars?: number }} [opts]
@@ -66,8 +174,12 @@ function capToolResultString(toolName, text, opts = {}) {
 
 module.exports = {
   capToolResultString,
+  safeStringify,
+  boundToolDetails,
   getCapForTool,
   DEFAULT_MAX_CHARS,
+  SAFE_STRINGIFY_BUDGET_CHARS,
+  DETAILS_BUDGET_CHARS,
   TOOL_RESULT_CAPS,
   DIRECTORY_TREE_HINT,
 };

--- a/electron/tools/tool-result-format.cjs
+++ b/electron/tools/tool-result-format.cjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const { capToolResultString } = require('./tool-result-cap.cjs');
+const { capToolResultString, safeStringify } = require('./tool-result-cap.cjs');
 const { buildNativeContentBlocks, resolveModelCapabilities } = require('../ai/message-multimodal.cjs');
 
 /** Cap slide QA images per call — full deck base64 blows trim budget and empties history. */
@@ -89,7 +89,7 @@ function formatToolResultForModel(toolName, rawResult, opts = {}) {
     }
   }
 
-  const text = typeof rawResult === 'string' ? rawResult : JSON.stringify(rawResult ?? {});
+  const text = safeStringify(rawResult ?? {});
   return capToolResultString(toolName, text);
 }
 
@@ -121,7 +121,7 @@ function summarizeToolResultForUi(toolName, rawResult) {
     }
   }
 
-  const text = typeof rawResult === 'string' ? rawResult : JSON.stringify(rawResult ?? {});
+  const text = safeStringify(rawResult ?? {});
   return capToolResultString(toolName, text);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {
@@ -40,7 +40,7 @@
     "test:filesystem-tools": "node --test scripts/test-filesystem-tools.mjs",
     "test:feeders": "node --test scripts/test-feeders.mjs",
     "test:web-search": "node --test scripts/test-web-search.mjs",
-    "test:security": "node --test electron/__tests__/shell-policy.test.mjs electron/__tests__/url-guard.test.mjs electron/__tests__/migration-backup.test.mjs electron/__tests__/db-backup.test.mjs electron/__tests__/settings-secrets.test.mjs electron/__tests__/security-path.test.mjs electron/__tests__/logger.test.mjs electron/__tests__/tool-call-policy.test.mjs electron/__tests__/run-retention.test.mjs electron/__tests__/run-recovery.test.mjs electron/__tests__/himalaya-binary.test.mjs electron/__tests__/error-notify.test.mjs electron/__tests__/workflow-dag.test.mjs electron/__tests__/provider-keys.test.mjs electron/__tests__/run-helpers.test.mjs electron/__tests__/ffmpeg-paths.test.mjs",
+    "test:security": "node --test electron/__tests__/shell-policy.test.mjs electron/__tests__/url-guard.test.mjs electron/__tests__/migration-backup.test.mjs electron/__tests__/db-backup.test.mjs electron/__tests__/settings-secrets.test.mjs electron/__tests__/security-path.test.mjs electron/__tests__/logger.test.mjs electron/__tests__/tool-call-policy.test.mjs electron/__tests__/run-retention.test.mjs electron/__tests__/run-recovery.test.mjs electron/__tests__/himalaya-binary.test.mjs electron/__tests__/error-notify.test.mjs electron/__tests__/workflow-dag.test.mjs electron/__tests__/provider-keys.test.mjs electron/__tests__/run-helpers.test.mjs electron/__tests__/ffmpeg-paths.test.mjs electron/__tests__/tool-result-cap.test.mjs",
     "test": "pnpm run test:security && pnpm --filter @dome/agent-core run test",
     "test:studio": "node scripts/test-studio-validators.mjs",
     "test:studio:tools": "node scripts/test-studio-tools.mjs",

--- a/packages/tools/src/registry.ts
+++ b/packages/tools/src/registry.ts
@@ -43,12 +43,84 @@ export function normalizeToolParameters(raw: unknown): Record<string, unknown> {
   return obj;
 }
 
+/**
+ * Model-facing serialization ceiling. A raw tool output that serializes beyond
+ * this is dropped to a notice instead of letting V8 build an unbounded string
+ * (the ELECTRON-7 OOM signature — `JsonStringify` "Zone" exhaustion).
+ */
+const OUTPUT_BUDGET_CHARS = 16 * 1024 * 1024;
+
+/**
+ * Structured `details` ceiling. The agent loop persists `details` verbatim into
+ * the session JSONL (`createToolResultMessage` → `appendEntry` →
+ * `JSON.stringify(entry)`), so an unbounded `details` OOMs the main process at
+ * persistence time even when the model-facing text is small. ~1M chars.
+ */
+const DETAILS_BUDGET_CHARS = 1024 * 1024;
+
+/**
+ * `JSON.stringify` that aborts once the (approximate) output passes `budget`
+ * instead of growing without bound. The replacer is invoked for every node
+ * before it is written, so throwing stops V8 before the output buffer can
+ * exceed the budget. Returns `null` when the value is too large; rethrows
+ * genuine serialization errors (circular refs, BigInt) to the caller.
+ */
+function stringifyWithinBudget(value: unknown, budget: number): string | null {
+  let approx = 0;
+  const ABORT = {};
+  try {
+    return (
+      JSON.stringify(value, (key, val) => {
+        approx += key.length + 2;
+        const t = typeof val;
+        if (t === 'string') approx += (val as string).length + 2;
+        else if (t === 'number' || t === 'boolean' || val === null) approx += 6;
+        if (approx > budget) throw ABORT;
+        return val;
+      }) ?? ''
+    );
+  } catch (err) {
+    if (err === ABORT) return null;
+    throw err;
+  }
+}
+
+const TOO_LARGE_NOTICE = JSON.stringify({
+  error: 'tool_result_too_large',
+  message:
+    'Dome: tool output exceeded the serialization limit and was dropped to protect the app from ' +
+    'running out of memory. Retry with pagination, filters, or a narrower query.',
+});
+
 function stringifyToolOutput(raw: unknown): string {
   if (typeof raw === 'string') return raw;
   try {
-    return JSON.stringify(raw);
+    const s = stringifyWithinBudget(raw, OUTPUT_BUDGET_CHARS);
+    return s === null ? TOO_LARGE_NOTICE : s;
   } catch {
     return String(raw);
+  }
+}
+
+/**
+ * Bound a tool result's `details` so the persisted session entry can never grow
+ * without limit. Returns the value untouched when it fits the budget, or a tiny
+ * marker when it is too large / unserializable (ELECTRON-7 guard).
+ */
+function boundToolDetails(raw: unknown): unknown {
+  if (raw == null) return raw;
+  if (typeof raw === 'string') {
+    return raw.length <= DETAILS_BUDGET_CHARS
+      ? raw
+      : { _domeOmitted: 'tool_result_too_large', approxChars: raw.length };
+  }
+  if (typeof raw !== 'object') return raw;
+  try {
+    return stringifyWithinBudget(raw, DETAILS_BUDGET_CHARS) === null
+      ? { _domeOmitted: 'tool_result_too_large' }
+      : raw;
+  } catch {
+    return { _domeOmitted: 'tool_result_unserializable' };
   }
 }
 
@@ -66,7 +138,7 @@ export function createToolFromDefinition(def: ToolDefinition, ops: ToolOps): Age
     async execute(_toolCallId, params): Promise<AgentToolResult> {
       try {
         const raw = await ops.executeToolInMain(name, params);
-        return { content: [{ type: 'text', text: stringifyToolOutput(raw) }], details: raw };
+        return { content: [{ type: 'text', text: stringifyToolOutput(raw) }], details: boundToolDetails(raw) };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return {


### PR DESCRIPTION
## Summary

Resolves **ELECTRON-7** — the recurring V8 *"Zone"* OOM inside `JsonStringify` in the **main process** (`Fatal Error: Out of Memory`), still firing on `dome@2.7.4` (6 events, ~6.3 GB peak working set, crash ~74s after launch).

**Root cause (misattributed by Seer to GitHub).** The real vector is an **MCP browser tool** (`chrome_devtools` `take_snapshot`) returning a huge accessibility tree. That payload was carried **verbatim** as the tool result's `details` field, which the agent loop persists into the session JSONL:

`createToolResultMessage` (`details: result.details`) → `appendMessage` → `appendEntry` → **`JSON.stringify(entry)`**.

The model-facing `content` text was already capped, but `details` was **not** — so persisting the session OOM-ed the process. A V8 OOM is **not a catchable exception**, so the surrounding `try/catch` blocks gave zero protection.

## What changed

- **`boundToolDetails()`** (`electron/tools/tool-result-cap.cjs`): bounds a tool result's `details` **without ever building an unbounded buffer** — the `JSON.stringify` replacer aborts as soon as the approximate size passes the budget (1 MB). Returns the value untouched when small, or a tiny marker when too large / unserializable.
- Applied at **both** runtime tool-construction sites so the giant object can never escape `execute()`:
  - MCP bridge — `electron/agents/dome-harness-bridge.cjs` (`details: boundToolDetails(out)`)
  - Native registry — `packages/tools/src/registry.ts` (`details: boundToolDetails(raw)` + a 16 MB budget ceiling on the output stringify)
- Bundles the **ELECTRON-8** `ReferenceError` fix (`marketplace.cjs`: `BrowserWindow`/`dialog` imports + `sanitizePath` injection) and the earlier `safeStringify` hardening (`agent-runtime`, `run-helpers`, `mcp-client`, `tool-result-format`).
- New regression test `electron/__tests__/tool-result-cap.test.mjs` (wired into `test:security`).
- Version bump → **2.7.5**.

## Why this is the definitive fix

Bounding `details` at the source means the multi-GB object is dropped immediately and never reaches session persistence (or any other serializer / IPC / run store), and is GC-able right away — also reducing memory pressure. `content` was already capped, so the persisted entry is now small in every path.

## Test plan

- [x] `node --check` on modified `.cjs`
- [x] `pnpm run build:packages` (@dome/ai, @dome/agent-core, @dome/tools) — Done
- [x] Functional: oversized object → marker, **no OOM** (8/8)
- [x] `electron/__tests__/tool-result-cap.test.mjs` — 10/10
- [x] `pnpm run test:security` — only pre-existing Windows-specific failures remain (`security-path`, `skills`), unrelated to this change
- [ ] Packaged smoke (`pnpm run electron:build`) on the release runner
- [ ] Repro: run the browser agent over a heavy page (iDRAC) with `take_snapshot` and confirm no main-process OOM

Fixes ELECTRON-7
