### PR TITLE
fix: bound persisted tool results + reclaim SQLite bloat (ELECTRON-7) (v2.7.6)

### DIFF
--- a/electron/__tests__/db-maintenance.test.mjs
+++ b/electron/__tests__/db-maintenance.test.mjs
@@ -1,0 +1,106 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  reclaimSpaceIfBloated,
+  incrementalVacuum,
+  readPageStats,
+} = require('../core/db-maintenance.cjs');
+
+/**
+ * Stub of the better-sqlite3 surface db-maintenance uses (pragma + exec).
+ * VACUUM compacts the file to its live pages; incremental_vacuum drops the
+ * freelist. Lets us assert the decision logic without a native better-sqlite3
+ * (which is compiled for Electron's ABI, not plain Node).
+ */
+function makeFakeDb({ pageSize = 4096, pageCount, freelistCount, autoVacuum = 0 }) {
+  const state = { pageSize, pageCount, freelistCount, autoVacuum };
+  const calls = { execs: [], pragmas: [] };
+  const db = {
+    state,
+    calls,
+    pragma(arg) {
+      calls.pragmas.push(arg);
+      const a = String(arg).trim();
+      if (a === 'page_size') return state.pageSize;
+      if (a === 'page_count') return state.pageCount;
+      if (a === 'freelist_count') return state.freelistCount;
+      if (a === 'auto_vacuum') return state.autoVacuum;
+      if (/^auto_vacuum\s*=\s*incremental$/i.test(a)) {
+        state.autoVacuum = 2;
+        return undefined;
+      }
+      throw new Error(`Unexpected pragma: ${arg}`);
+    },
+    exec(sql) {
+      calls.execs.push(sql);
+      const s = String(sql).trim().toUpperCase();
+      if (s === 'VACUUM') {
+        // Compact: only live pages remain.
+        state.pageCount = state.pageCount - state.freelistCount;
+        state.freelistCount = 0;
+        return;
+      }
+      if (s === 'PRAGMA INCREMENTAL_VACUUM') {
+        state.pageCount = state.pageCount - state.freelistCount;
+        state.freelistCount = 0;
+        return;
+      }
+      throw new Error(`Unexpected exec: ${sql}`);
+    },
+  };
+  return db;
+}
+
+describe('db-maintenance — ELECTRON-7 space reclaim', () => {
+  it('readPageStats derives free/file bytes from pragmas', () => {
+    const db = makeFakeDb({ pageCount: 1000, freelistCount: 900 });
+    const stats = readPageStats(db);
+    assert.equal(stats.freeBytes, 900 * 4096);
+    assert.equal(stats.fileBytes, 1000 * 4096);
+  });
+
+  it('does NOT VACUUM when free space is below the threshold', () => {
+    // ~4MB free — trivial, should be left alone.
+    const db = makeFakeDb({ pageCount: 2000, freelistCount: 1000 });
+    const res = reclaimSpaceIfBloated(db);
+    assert.equal(res.ran, false);
+    assert.equal(res.reason, 'below_threshold');
+    assert.ok(!db.calls.execs.includes('VACUUM'));
+  });
+
+  it('VACUUMs a bloated DB (mostly free pages) and reclaims the file', () => {
+    // Mirror the real incident: ~6.85GB free out of ~6.9GB, only live data kept.
+    const db = makeFakeDb({ pageCount: 1_685_579, freelistCount: 1_672_810, autoVacuum: 0 });
+    const before = readPageStats(db);
+    const res = reclaimSpaceIfBloated(db);
+    assert.equal(res.ran, true);
+    assert.ok(db.calls.execs.includes('VACUUM'));
+    // It switched to INCREMENTAL auto-vacuum first.
+    assert.equal(db.state.autoVacuum, 2);
+    assert.ok(res.after.fileBytes < before.fileBytes);
+    // Live data is what remains (~12,769 pages).
+    assert.equal(res.after.freeBytes, 0);
+  });
+
+  it('skips gracefully when no usable db handle is provided', () => {
+    assert.equal(reclaimSpaceIfBloated(null).ran, false);
+    assert.equal(reclaimSpaceIfBloated({}).ran, false);
+  });
+
+  it('incrementalVacuum is a no-op unless the DB is in INCREMENTAL mode', () => {
+    const none = makeFakeDb({ pageCount: 100, freelistCount: 50, autoVacuum: 0 });
+    assert.deepEqual(incrementalVacuum(none), { ran: false, reason: 'not_incremental' });
+    assert.ok(!none.calls.execs.includes('PRAGMA incremental_vacuum'));
+  });
+
+  it('incrementalVacuum reclaims freed pages when INCREMENTAL', () => {
+    const inc = makeFakeDb({ pageCount: 100, freelistCount: 50, autoVacuum: 2 });
+    const res = incrementalVacuum(inc);
+    assert.equal(res.ran, true);
+    assert.ok(inc.calls.execs.includes('PRAGMA incremental_vacuum'));
+    assert.equal(inc.state.freelistCount, 0);
+  });
+});

--- a/electron/__tests__/run-helpers.test.mjs
+++ b/electron/__tests__/run-helpers.test.mjs
@@ -47,6 +47,15 @@ describe('run-helpers', () => {
     assert.ok(patch.content.includes('success'));
   });
 
+  it('getToolStepPatch caps a multi-MB string result so it cannot bloat the DB (ELECTRON-7)', () => {
+    const huge = 'a'.repeat(9_000_000); // ~9MB, like the chrome_devtools snapshots we found in the DB
+    const patch = getToolStepPatch('tc3', huge);
+    assert.equal(patch.status, 'done');
+    assert.ok(patch.content.length < huge.length);
+    assert.ok(patch.content.length <= 64 * 1024);
+    assert.ok(patch.content.includes('truncated for storage'));
+  });
+
   it('isRunAbortedError detects abort signals and abort-like errors', () => {
     const controller = new AbortController();
     controller.abort();

--- a/electron/__tests__/tool-result-cap.test.mjs
+++ b/electron/__tests__/tool-result-cap.test.mjs
@@ -7,8 +7,10 @@ const {
   safeStringify,
   boundToolDetails,
   capToolResultString,
+  capResultText,
   DETAILS_BUDGET_CHARS,
   SAFE_STRINGIFY_BUDGET_CHARS,
+  PERSIST_RESULT_BUDGET_CHARS,
 } = require('../tools/tool-result-cap.cjs');
 
 /** Build an object that serializes far beyond `budget` chars without itself being huge to allocate. */
@@ -85,5 +87,38 @@ describe('tool-result-cap — ELECTRON-7 OOM guards', () => {
     const capped = capToolResultString('some_tool', long, { maxChars: 10_000 });
     assert.ok(capped.length < long.length);
     assert.ok(capped.includes('truncated'));
+  });
+
+  it('capResultText slices oversized STRINGS (the gap safeStringify left open)', () => {
+    const huge = 'q'.repeat(PERSIST_RESULT_BUDGET_CHARS + 500_000);
+    const capped = capResultText(huge);
+    assert.equal(typeof capped, 'string');
+    assert.ok(capped.length < huge.length);
+    assert.ok(capped.length <= PERSIST_RESULT_BUDGET_CHARS);
+    assert.ok(capped.includes('truncated for storage'));
+  });
+
+  it('capResultText passes through strings within budget unchanged', () => {
+    assert.equal(capResultText('small result'), 'small result');
+  });
+
+  it('capResultText bounds oversized OBJECTS to a small notice (no OOM)', () => {
+    const huge = makeOversizedObject(PERSIST_RESULT_BUDGET_CHARS + 2_000_000);
+    const capped = capResultText(huge);
+    assert.equal(typeof capped, 'string');
+    assert.ok(capped.length <= PERSIST_RESULT_BUDGET_CHARS);
+    const parsed = JSON.parse(capped);
+    assert.equal(parsed.error, 'tool_result_too_large');
+  });
+
+  it('capResultText serializes normal objects within budget', () => {
+    assert.equal(capResultText({ a: 1, b: 'x' }), '{"a":1,"b":"x"}');
+  });
+
+  it('capResultText respects a custom budget and leaves null/undefined intact', () => {
+    const capped = capResultText('a'.repeat(20_000), { budgetChars: 4_000 });
+    assert.ok(capped.length <= 4_000);
+    assert.equal(capResultText(null), null);
+    assert.equal(capResultText(undefined), undefined);
   });
 });

--- a/electron/agents/run-engine.cjs
+++ b/electron/agents/run-engine.cjs
@@ -25,6 +25,7 @@ const {
   mergeLlmUsage,
   getToolStepPatch,
 } = require('./run-helpers.cjs');
+const { capResultText } = require('../tools/tool-result-cap.cjs');
 const runStore = require('./run-store.cjs');
 const { topologicalLevels, mergePayloads, getInputPayloads } = require('./workflow-dag.cjs');
 
@@ -465,7 +466,11 @@ function createRunChunkEmitter(runId, context) {
       const entry = context.toolCalls.find((item) => item.id === data.toolCallId);
       if (entry) {
         entry.status = stepPatch.status === 'failed' ? 'error' : 'success';
-        entry.result = data.result;
+        // Bound the result we KEEP in context.toolCalls — it is persisted verbatim
+        // into automation_runs.metadata (and chat_messages.tool_calls) at run end.
+        // An unbounded multi-MB MCP result here is what made JSON.stringify(metadata)
+        // OOM the main process (ELECTRON-7) and bloated the DB with free pages.
+        entry.result = capResultText(data.result);
       }
       const stepId = context.toolStepIds.get(data.toolCallId);
       if (stepId) {

--- a/electron/agents/run-helpers.cjs
+++ b/electron/agents/run-helpers.cjs
@@ -4,7 +4,7 @@
  */
 
 // Pure-CJS leaf (no Electron/DB deps) — keeps this module unit-testable.
-const { safeStringify } = require('../tools/tool-result-cap.cjs');
+const { safeStringify, capResultText } = require('../tools/tool-result-cap.cjs');
 
 function isRunAbortedError(error, signal) {
   if (signal?.aborted) return true;
@@ -82,13 +82,18 @@ function getToolStepPatch(toolCallId, result, extraMetadata = {}) {
     ? (typeof parsedResult.error === 'string' ? parsedResult.error : serializedResult)
     : null;
 
+  // capResultText bounds the persisted step content. serializeToolResult /
+  // safeStringify pass strings through untouched, so a multi-MB MCP result (e.g.
+  // a chrome_devtools snapshot, already a string) would otherwise land verbatim
+  // in automation_run_steps.content — bloating the DB and feeding the
+  // JSON.stringify OOM (ELECTRON-7). The model already got the full result.
   return {
     status: isErrorResult ? 'failed' : 'done',
-    content: errorMessage || serializedResult,
+    content: capResultText(errorMessage || serializedResult),
     metadata: {
       toolCallId,
       ...extraMetadata,
-      ...(isErrorResult ? { error: errorMessage } : {}),
+      ...(isErrorResult ? { error: capResultText(errorMessage, { budgetChars: 8192 }) } : {}),
     },
   };
 }

--- a/electron/agents/run-retention.cjs
+++ b/electron/agents/run-retention.cjs
@@ -11,6 +11,7 @@
  */
 
 const logger = require('../core/logger.cjs');
+const { incrementalVacuum } = require('../core/db-maintenance.cjs');
 
 const DEFAULT_RETENTION_DAYS = 90;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -116,6 +117,15 @@ async function purgeExpiredRuns({ now = Date.now(), deps = defaultDeps() } = {})
 
   if (result.purgedRuns > 0 || result.purgedFeederRuns > 0 || result.purgedSessions > 0) {
     logger.info('run-retention', 'Purged expired run history', result);
+    // Return the pages freed by the deletes to the OS (no-op unless the DB is in
+    // INCREMENTAL auto-vacuum mode) so run history can't silently bloat the file.
+    try {
+      incrementalVacuum(db);
+    } catch (error) {
+      logger.warn('run-retention', 'incremental_vacuum after purge failed', {
+        error: error?.message,
+      });
+    }
   }
   return result;
 }

--- a/electron/agents/run-store.cjs
+++ b/electron/agents/run-store.cjs
@@ -7,6 +7,7 @@
  */
 
 const crypto = require('crypto');
+const { safeStringify } = require('../tools/tool-result-cap.cjs');
 
 const RUN_EVENT_CHANNEL = 'runs:updated';
 const RUN_STEP_CHANNEL = 'runs:step';
@@ -46,7 +47,12 @@ function parseJsonSafely(value, fallback) {
 }
 
 function toJson(value) {
-  return value == null ? null : JSON.stringify(value);
+  // Backstop against ELECTRON-7: a raw JSON.stringify of run/step metadata (e.g.
+  // metadata.toolCalls with large tool results) that grew past the heap would
+  // OOM the main process inside V8's JsonStringify. safeStringify bounds the
+  // serialization and degrades to a small notice instead of crashing. Strings
+  // and normal-sized objects pass through unchanged.
+  return value == null ? null : safeStringify(value);
 }
 
 function emit(channel, payload) {

--- a/electron/core/database.cjs
+++ b/electron/core/database.cjs
@@ -12,6 +12,7 @@ const { app } = require('electron');
 const { buildQueries } = require('./db/queries.cjs');
 const { applyMigrations } = require('./db/migrations.cjs');
 const { createBaseSchema } = require('./db/schema.cjs');
+const { reclaimSpaceIfBloated } = require('./db-maintenance.cjs');
 const {
   removeWalSidecars,
   findLatestBackup,
@@ -137,6 +138,16 @@ function initDatabase() {
 
       console.log('✅ Database schema initialized');
       _schemaInitialized = true;
+
+      // One-time reclaim of historical bloat (ELECTRON-7): older builds stored
+      // unbounded multi-MB tool results that, once replaced/purged, left the file
+      // full of unreclaimable free pages (auto_vacuum was NONE). VACUUM here is
+      // cheap (only live pages are copied) and never blocks boot on failure.
+      try {
+        reclaimSpaceIfBloated(_db);
+      } catch (maintErr) {
+        console.warn('[DB] Space reclaim skipped:', maintErr?.message || maintErr);
+      }
       return;
     } catch (err) {
       lastError = err;

--- a/electron/core/db-maintenance.cjs
+++ b/electron/core/db-maintenance.cjs
@@ -1,0 +1,123 @@
+/* eslint-disable no-console */
+/**
+ * SQLite space maintenance (ELECTRON-7 follow-up).
+ *
+ * Large, unbounded tool-result rows (run metadata/steps, chat messages) that are
+ * later replaced or purged leave behind free pages. With `auto_vacuum = NONE`
+ * (the historical default for Dome DBs) those pages are NEVER returned to the OS,
+ * so the file only ever grows — real-world installs ballooned to ~6.4GB while
+ * holding only a few MB of live data.
+ *
+ * - `reclaimSpaceIfBloated(db)`: one-time `VACUUM` (after switching to
+ *   `auto_vacuum = INCREMENTAL`) when free space exceeds a threshold. Cheap here
+ *   because VACUUM only copies live pages (a few MB), not the free ones.
+ * - `incrementalVacuum(db)`: return already-freed pages to the OS without a full
+ *   rebuild. Safe to call often (e.g. after retention purges).
+ *
+ * Pure-ish: only depends on the better-sqlite3 handle passed in + the logger.
+ */
+
+const logger = require('./logger.cjs');
+
+/** Reclaim once free space crosses ~200MB — well below any healthy working set. */
+const RECLAIM_FREE_BYTES_THRESHOLD = 200 * 1024 * 1024;
+
+const AUTO_VACUUM_INCREMENTAL = 2;
+
+function readPageStats(db) {
+  const pageSize = Number(db.pragma('page_size', { simple: true })) || 0;
+  const pageCount = Number(db.pragma('page_count', { simple: true })) || 0;
+  const freelistCount = Number(db.pragma('freelist_count', { simple: true })) || 0;
+  const autoVacuum = Number(db.pragma('auto_vacuum', { simple: true })) || 0;
+  return {
+    pageSize,
+    pageCount,
+    freelistCount,
+    autoVacuum,
+    freeBytes: pageSize * freelistCount,
+    fileBytes: pageSize * pageCount,
+  };
+}
+
+/**
+ * Run a one-time VACUUM when the DB file is mostly free pages. Switches the DB to
+ * INCREMENTAL auto-vacuum first so future deletes can be reclaimed cheaply.
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @param {{ thresholdBytes?: number }} [opts]
+ * @returns {{ ran: boolean, reason?: string, before?: object, after?: object, error?: string }}
+ */
+function reclaimSpaceIfBloated(db, opts = {}) {
+  if (!db || typeof db.pragma !== 'function') return { ran: false, reason: 'no_db' };
+  const threshold =
+    typeof opts.thresholdBytes === 'number' && opts.thresholdBytes >= 0
+      ? opts.thresholdBytes
+      : RECLAIM_FREE_BYTES_THRESHOLD;
+
+  let before;
+  try {
+    before = readPageStats(db);
+  } catch (err) {
+    return { ran: false, reason: 'pragma_failed', error: err?.message };
+  }
+
+  if (before.freeBytes <= threshold) {
+    return { ran: false, reason: 'below_threshold', before };
+  }
+
+  logger.warn('db-maintenance', 'Excessive free space — reclaiming with VACUUM', {
+    freeMB: Math.round(before.freeBytes / 1e6),
+    fileMB: Math.round(before.fileBytes / 1e6),
+    autoVacuum: before.autoVacuum,
+  });
+
+  try {
+    // VACUUM rewrites the file; setting auto_vacuum first makes the rebuilt DB
+    // INCREMENTAL so incrementalVacuum() works for future deletes. A VACUUM
+    // cannot run inside a transaction — callers must invoke this outside one.
+    if (before.autoVacuum !== AUTO_VACUUM_INCREMENTAL) {
+      db.pragma('auto_vacuum = INCREMENTAL');
+    }
+    const startedAt = Date.now();
+    db.exec('VACUUM');
+    const after = readPageStats(db);
+    logger.info('db-maintenance', 'VACUUM complete', {
+      ms: Date.now() - startedAt,
+      beforeMB: Math.round(before.fileBytes / 1e6),
+      afterMB: Math.round(after.fileBytes / 1e6),
+      reclaimedMB: Math.round((before.fileBytes - after.fileBytes) / 1e6),
+    });
+    return { ran: true, before, after };
+  } catch (err) {
+    logger.error('db-maintenance', 'VACUUM failed', { error: err?.message });
+    return { ran: false, reason: 'vacuum_failed', error: err?.message };
+  }
+}
+
+/**
+ * Return already-freed pages to the OS (no full rebuild). No-op unless the DB is
+ * in INCREMENTAL auto-vacuum mode.
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @returns {{ ran: boolean, reason?: string, error?: string }}
+ */
+function incrementalVacuum(db) {
+  if (!db || typeof db.pragma !== 'function') return { ran: false, reason: 'no_db' };
+  try {
+    const autoVacuum = Number(db.pragma('auto_vacuum', { simple: true })) || 0;
+    if (autoVacuum !== AUTO_VACUUM_INCREMENTAL) {
+      return { ran: false, reason: 'not_incremental' };
+    }
+    db.exec('PRAGMA incremental_vacuum');
+    return { ran: true };
+  } catch (err) {
+    return { ran: false, reason: 'failed', error: err?.message };
+  }
+}
+
+module.exports = {
+  reclaimSpaceIfBloated,
+  incrementalVacuum,
+  readPageStats,
+  RECLAIM_FREE_BYTES_THRESHOLD,
+};

--- a/electron/core/db/schema.cjs
+++ b/electron/core/db/schema.cjs
@@ -34,6 +34,16 @@ function createBaseSchema(db) {
   db.exec('PRAGMA synchronous = NORMAL');
   db.exec('PRAGMA temp_store = MEMORY');
   db.exec('PRAGMA mmap_size = 30000000000');
+  // INCREMENTAL auto-vacuum lets us reclaim freed pages (PRAGMA incremental_vacuum)
+  // after deleting large rows instead of letting the file grow forever. On a FRESH
+  // DB this takes effect immediately (set before any CREATE TABLE); on an EXISTING
+  // DB it only sticks after a VACUUM — db-maintenance.reclaimSpaceIfBloated runs
+  // that one-time VACUUM when the file is mostly free pages (ELECTRON-7 bloat).
+  try {
+    db.exec('PRAGMA auto_vacuum = INCREMENTAL');
+  } catch (err) {
+    console.warn('[DB] Could not set auto_vacuum = INCREMENTAL:', err?.message || err);
+  }
 
   // Projects table
   db.exec(`

--- a/electron/tools/tool-result-cap.cjs
+++ b/electron/tools/tool-result-cap.cjs
@@ -156,6 +156,45 @@ function boundToolDetails(value, opts = {}) {
 }
 
 /**
+ * Per-tool-call result budget for *persistence* (run metadata, run steps,
+ * chat_messages). This is independent of what the model sees: the harness
+ * already delivered the full (or harness-capped) result to the model during the
+ * run. We only bound the copy we WRITE TO SQLITE so it can neither (a) bloat the
+ * DB with multi-MB rows that pile up as unreclaimable free pages, nor (b) make a
+ * later `JSON.stringify(metadata.toolCalls)` OOM the main process (ELECTRON-7).
+ * 64k chars (~128KB UTF-16) is a generous human-readable preview yet keeps even
+ * a long run's aggregated toolCalls comfortably small.
+ */
+const PERSIST_RESULT_BUDGET_CHARS = 64 * 1024;
+
+/**
+ * Bound a tool result for persistence, ALWAYS returning a string no larger than
+ * roughly `budgetChars`. Unlike `safeStringify` (which passes strings through
+ * untouched — the exact gap that left 9MB strings in the DB), this also slices
+ * oversized *strings*. Objects are serialized within budget first; anything that
+ * still overflows is sliced with a truncation marker.
+ *
+ * @param {unknown} value
+ * @param {{ budgetChars?: number }} [opts]
+ * @returns {string | null | undefined}
+ */
+function capResultText(value, opts = {}) {
+  if (value == null) return value;
+  const budget =
+    typeof opts.budgetChars === 'number' && opts.budgetChars > 2000
+      ? opts.budgetChars
+      : PERSIST_RESULT_BUDGET_CHARS;
+  const text = typeof value === 'string' ? value : safeStringify(value, { budgetChars: budget });
+  if (typeof text !== 'string' || text.length <= budget) return text;
+  const head = Math.floor(budget * 0.5);
+  return (
+    `${text.slice(0, head)}\n\n` +
+    `[Dome: result truncated for storage — ${text.length} chars → ~${head} kept. ` +
+    'The full result was delivered to the model during the run.]'
+  );
+}
+
+/**
  * @param {string} toolName
  * @param {string} text
  * @param {{ maxChars?: number }} [opts]
@@ -174,12 +213,14 @@ function capToolResultString(toolName, text, opts = {}) {
 
 module.exports = {
   capToolResultString,
+  capResultText,
   safeStringify,
   boundToolDetails,
   getCapForTool,
   DEFAULT_MAX_CHARS,
   SAFE_STRINGIFY_BUDGET_CHARS,
   DETAILS_BUDGET_CHARS,
+  PERSIST_RESULT_BUDGET_CHARS,
   TOOL_RESULT_CAPS,
   DIRECTORY_TREE_HINT,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {
@@ -40,7 +40,7 @@
     "test:filesystem-tools": "node --test scripts/test-filesystem-tools.mjs",
     "test:feeders": "node --test scripts/test-feeders.mjs",
     "test:web-search": "node --test scripts/test-web-search.mjs",
-    "test:security": "node --test electron/__tests__/shell-policy.test.mjs electron/__tests__/url-guard.test.mjs electron/__tests__/migration-backup.test.mjs electron/__tests__/db-backup.test.mjs electron/__tests__/settings-secrets.test.mjs electron/__tests__/security-path.test.mjs electron/__tests__/logger.test.mjs electron/__tests__/tool-call-policy.test.mjs electron/__tests__/run-retention.test.mjs electron/__tests__/run-recovery.test.mjs electron/__tests__/himalaya-binary.test.mjs electron/__tests__/error-notify.test.mjs electron/__tests__/workflow-dag.test.mjs electron/__tests__/provider-keys.test.mjs electron/__tests__/run-helpers.test.mjs electron/__tests__/ffmpeg-paths.test.mjs electron/__tests__/tool-result-cap.test.mjs",
+    "test:security": "node --test electron/__tests__/shell-policy.test.mjs electron/__tests__/url-guard.test.mjs electron/__tests__/migration-backup.test.mjs electron/__tests__/db-backup.test.mjs electron/__tests__/settings-secrets.test.mjs electron/__tests__/security-path.test.mjs electron/__tests__/logger.test.mjs electron/__tests__/tool-call-policy.test.mjs electron/__tests__/run-retention.test.mjs electron/__tests__/run-recovery.test.mjs electron/__tests__/himalaya-binary.test.mjs electron/__tests__/error-notify.test.mjs electron/__tests__/workflow-dag.test.mjs electron/__tests__/provider-keys.test.mjs electron/__tests__/run-helpers.test.mjs electron/__tests__/ffmpeg-paths.test.mjs electron/__tests__/tool-result-cap.test.mjs electron/__tests__/db-maintenance.test.mjs",
     "test": "pnpm run test:security && pnpm --filter @dome/agent-core run test",
     "test:studio": "node scripts/test-studio-validators.mjs",
     "test:studio:tools": "node scripts/test-studio-tools.mjs",


### PR DESCRIPTION
## Summary

Definitive fix for **ELECTRON-7** (V8 OOM in `JSON.stringify`) — still reproducing on 2.7.5 during GitHub sync runs — plus the **6.4GB SQLite bloat** that shares the same root cause.

Diagnosed against a real `dome.db`: **6.90GB file, 99.2% free pages** (1,672,810 of 1,685,579), only ~52MB live data. The bloat comes from large tool-call results stored verbatim in `automation_runs.metadata` / `automation_run_steps.content` (single results up to **9.4MB**, duplicated as `text` + `structuredContent.content`; one run had **96 tool-calls**).

### Why 2.7.5 didn't fully fix it
- `safeStringify` passes **strings** through untouched, and the harness hands the run-engine tool results as already-serialized strings (up to ~16MB) — so nothing capped them.
- `run-store.toJson` did a **raw `JSON.stringify`** of run metadata. At completion, `metadata.toolCalls` (every result) was serialized in one shot → OOM once a run accumulated several large MCP results.
- `auto_vacuum = NONE` meant replaced/purged multi-MB rows left free pages that were **never returned to the OS** → the file only grew.

## Changes
- **`capResultText`** (`electron/tools/tool-result-cap.cjs`): caps tool results by **string length** too (64KB), not just object size. Applied to `entry.result` (run-engine) and step `content` (`run-helpers.getToolStepPatch`). The model still receives the full result during the run; only the **persisted** copy is bounded.
- **`run-store.toJson`** now uses `safeStringify` as an anti-OOM backstop.
- **DB space maintenance**: `auto_vacuum = INCREMENTAL` for new DBs (`schema.cjs`); new `electron/core/db-maintenance.cjs` runs a **one-time `VACUUM` on startup** when the file is mostly free pages (reclaims historical bloat) and `incremental_vacuum` after each retention purge. Wired into `database.cjs` init and `run-retention.cjs`.
- Version bump to **2.7.6**.

On the next launch with this build, an affected `dome.db` compacts automatically (e.g. **6.9GB → ~52MB**) and stops re-bloating.

## Test plan
- [x] `pnpm run typecheck` — pass
- [x] `pnpm run lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm run build` — pass
- [x] `pnpm run check:ipc-inventory` — pass (522 channels)
- [x] `pnpm run depcruise` — no violations
- [x] `pnpm run test:security` — new/updated suites pass (`tool-result-cap`, `run-helpers`, `db-maintenance`, `run-retention`); the 3 `security-path` failures are pre-existing/environmental (Windows `~/.ssh` denylist), unrelated to this change
- [ ] Packaged smoke (`pnpm run electron:build`) + launch
- [ ] Verify a bloated DB auto-reclaims on first launch and a GitHub sync run no longer OOMs
