### PR TITLE
fix(calendar): stop reminders double-stringify OOM + DB bloat (v2.7.7)

### DIFF
--- a/electron/__tests__/calendar-reminders.test.mjs
+++ b/electron/__tests__/calendar-reminders.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  DEFAULT_REMINDERS_JSON,
+  normalizeRemindersForStorage,
+  isRemindersJsonBloated,
+} = require('../calendar/calendar-reminders.cjs');
+
+describe('calendar-reminders', () => {
+  it('passes array through as canonical JSON once', () => {
+    assert.equal(normalizeRemindersForStorage([{ minutes: 30 }]), '[{"minutes":30}]');
+  });
+
+  it('does not double-stringify an already stored JSON string', () => {
+    const once = DEFAULT_REMINDERS_JSON;
+    assert.equal(normalizeRemindersForStorage(once), once);
+    const twice = JSON.stringify(once);
+    assert.equal(normalizeRemindersForStorage(twice), once);
+  });
+
+  it('peels deeply nested stringify corruption', () => {
+    let corrupted = DEFAULT_REMINDERS_JSON;
+    for (let i = 0; i < 5; i += 1) corrupted = JSON.stringify(corrupted);
+    assert.equal(normalizeRemindersForStorage(corrupted), DEFAULT_REMINDERS_JSON);
+  });
+
+  it('detects bloated reminders', () => {
+    assert.equal(isRemindersJsonBloated(DEFAULT_REMINDERS_JSON), false);
+    assert.equal(isRemindersJsonBloated('x'.repeat(9000)), true);
+  });
+});

--- a/electron/__tests__/db-maintenance.test.mjs
+++ b/electron/__tests__/db-maintenance.test.mjs
@@ -6,6 +6,7 @@ const require = createRequire(import.meta.url);
 const {
   reclaimSpaceIfBloated,
   incrementalVacuum,
+  repairBloatedCalendarReminders,
   readPageStats,
 } = require('../core/db-maintenance.cjs');
 
@@ -15,9 +16,9 @@ const {
  * freelist. Lets us assert the decision logic without a native better-sqlite3
  * (which is compiled for Electron's ABI, not plain Node).
  */
-function makeFakeDb({ pageSize = 4096, pageCount, freelistCount, autoVacuum = 0 }) {
-  const state = { pageSize, pageCount, freelistCount, autoVacuum };
-  const calls = { execs: [], pragmas: [] };
+function makeFakeDb({ pageSize = 4096, pageCount, freelistCount, autoVacuum = 0, calendarRows = [] }) {
+  const state = { pageSize, pageCount, freelistCount, autoVacuum, calendarRows: [...calendarRows] };
+  const calls = { execs: [], pragmas: [], updates: [] };
   const db = {
     state,
     calls,
@@ -33,6 +34,34 @@ function makeFakeDb({ pageSize = 4096, pageCount, freelistCount, autoVacuum = 0 
         return undefined;
       }
       throw new Error(`Unexpected pragma: ${arg}`);
+    },
+    prepare(sql) {
+      const s = String(sql);
+      if (s.includes('COUNT(*)') && s.includes('calendar_events')) {
+        return {
+          get(threshold) {
+            const c = state.calendarRows.filter((len) => len > threshold).length;
+            return { c };
+          },
+        };
+      }
+      if (s.startsWith('UPDATE calendar_events')) {
+        return {
+          run(remindersJson, updatedAt, threshold) {
+            calls.updates.push({ remindersJson, updatedAt, threshold });
+            let changes = 0;
+            state.calendarRows = state.calendarRows.map((len) => {
+              if (len > threshold) {
+                changes += 1;
+                return remindersJson.length;
+              }
+              return len;
+            });
+            return { changes };
+          },
+        };
+      }
+      throw new Error(`Unexpected prepare: ${sql}`);
     },
     exec(sql) {
       calls.execs.push(sql);
@@ -102,5 +131,12 @@ describe('db-maintenance — ELECTRON-7 space reclaim', () => {
     assert.equal(res.ran, true);
     assert.ok(inc.calls.execs.includes('PRAGMA incremental_vacuum'));
     assert.equal(inc.state.freelistCount, 0);
+  });
+
+  it('repairBloatedCalendarReminders resets oversized reminders rows', () => {
+    const db = makeFakeDb({ calendarRows: [20, 9000, 100] });
+    const res = repairBloatedCalendarReminders(db);
+    assert.equal(res.repaired, 1);
+    assert.ok(db.calls.updates.length > 0);
   });
 });

--- a/electron/calendar/calendar-reminders.cjs
+++ b/electron/calendar/calendar-reminders.cjs
@@ -1,0 +1,81 @@
+'use strict';
+
+/**
+ * Normalize calendar event reminders for SQLite storage.
+ *
+ * Bug: updateEvent merges DB rows into validateEventData, where `reminders` is
+ * already a JSON string. JSON.stringify(string) double-encodes on every GitHub
+ * calendar sync tick → exponential growth (~256MB/event) → OOM + multi-GB DB.
+ */
+
+const DEFAULT_REMINDER_MINUTES = 15;
+const DEFAULT_REMINDERS_JSON = JSON.stringify([{ minutes: DEFAULT_REMINDER_MINUTES }]);
+
+/** Stored reminders JSON should stay tiny; anything larger is corruption. */
+const MAX_REMINDERS_JSON_CHARS = 8192;
+
+/**
+ * @param {unknown} value
+ * @returns {string | undefined} canonical JSON string, or undefined when absent
+ */
+function normalizeRemindersForStorage(value) {
+  if (value == null) return undefined;
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return DEFAULT_REMINDERS_JSON;
+    try {
+      let parsed = JSON.parse(trimmed);
+      // Peel onion layers from historical double-stringify corruption.
+      let depth = 0;
+      while (typeof parsed === 'string' && depth < 32) {
+        parsed = JSON.parse(parsed);
+        depth += 1;
+      }
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        const normalized = parsed.map((r) => ({
+          minutes:
+            typeof r?.minutes === 'number' && Number.isFinite(r.minutes)
+              ? r.minutes
+              : DEFAULT_REMINDER_MINUTES,
+        }));
+        return JSON.stringify(normalized);
+      }
+    } catch {
+      /* fall through to reset */
+    }
+    return DEFAULT_REMINDERS_JSON;
+  }
+
+  if (Array.isArray(value)) {
+    const normalized = value.map((r) => ({
+      minutes:
+        typeof r?.minutes === 'number' && Number.isFinite(r.minutes)
+          ? r.minutes
+          : DEFAULT_REMINDER_MINUTES,
+    }));
+    return JSON.stringify(normalized.length > 0 ? normalized : [{ minutes: DEFAULT_REMINDER_MINUTES }]);
+  }
+
+  return DEFAULT_REMINDERS_JSON;
+}
+
+/**
+ * @param {string | null | undefined} remindersJson
+ * @param {{ thresholdChars?: number }} [opts]
+ */
+function isRemindersJsonBloated(remindersJson, opts = {}) {
+  const threshold =
+    typeof opts.thresholdChars === 'number' && opts.thresholdChars > 0
+      ? opts.thresholdChars
+      : MAX_REMINDERS_JSON_CHARS;
+  return typeof remindersJson === 'string' && remindersJson.length > threshold;
+}
+
+module.exports = {
+  DEFAULT_REMINDER_MINUTES,
+  DEFAULT_REMINDERS_JSON,
+  MAX_REMINDERS_JSON_CHARS,
+  normalizeRemindersForStorage,
+  isRemindersJsonBloated,
+};

--- a/electron/calendar/calendar-service.cjs
+++ b/electron/calendar/calendar-service.cjs
@@ -7,6 +7,7 @@
 
 const crypto = require('crypto');
 const database = require('../core/database.cjs');
+const { normalizeRemindersForStorage } = require('./calendar-reminders.cjs');
 
 const DEFAULT_REMINDER_MINUTES = 15;
 const MAX_TITLE_LENGTH = 200;
@@ -139,7 +140,8 @@ function validateEventData(data, isUpdate = false) {
       end_at: endAt ?? data.end_at,
       timezone: data.timezone ?? undefined,
       all_day: data.all_day ? 1 : 0,
-      reminders: data.reminders != null ? JSON.stringify(data.reminders) : undefined,
+      reminders:
+        data.reminders != null ? normalizeRemindersForStorage(data.reminders) : undefined,
     },
   };
 }

--- a/electron/core/database.cjs
+++ b/electron/core/database.cjs
@@ -12,7 +12,7 @@ const { app } = require('electron');
 const { buildQueries } = require('./db/queries.cjs');
 const { applyMigrations } = require('./db/migrations.cjs');
 const { createBaseSchema } = require('./db/schema.cjs');
-const { reclaimSpaceIfBloated } = require('./db-maintenance.cjs');
+const { reclaimSpaceIfBloated, repairBloatedCalendarReminders } = require('./db-maintenance.cjs');
 const {
   removeWalSidecars,
   findLatestBackup,
@@ -143,6 +143,16 @@ function initDatabase() {
       // unbounded multi-MB tool results that, once replaced/purged, left the file
       // full of unreclaimable free pages (auto_vacuum was NONE). VACUUM here is
       // cheap (only live pages are copied) and never blocks boot on failure.
+      // Repair calendar reminders corrupted by double JSON.stringify on each sync,
+      // then reclaim the freed pages (can be multiple GB on long-running installs).
+      try {
+        const repair = repairBloatedCalendarReminders(_db);
+        if (repair.repaired > 0) {
+          console.log(`[DB] Repaired ${repair.repaired} bloated calendar reminder row(s)`);
+        }
+      } catch (repairErr) {
+        console.warn('[DB] Calendar reminders repair skipped:', repairErr?.message || repairErr);
+      }
       try {
         reclaimSpaceIfBloated(_db);
       } catch (maintErr) {

--- a/electron/core/db-maintenance.cjs
+++ b/electron/core/db-maintenance.cjs
@@ -18,6 +18,7 @@
  */
 
 const logger = require('./logger.cjs');
+const { DEFAULT_REMINDERS_JSON, MAX_REMINDERS_JSON_CHARS } = require('../calendar/calendar-reminders.cjs');
 
 /** Reclaim once free space crosses ~200MB — well below any healthy working set. */
 const RECLAIM_FREE_BYTES_THRESHOLD = 200 * 1024 * 1024;
@@ -115,9 +116,59 @@ function incrementalVacuum(db) {
   }
 }
 
+/**
+ * Reset calendar_events.reminders rows corrupted by repeated JSON.stringify(string)
+ * on every update (GitHub calendar sync). Each bloated row can reach hundreds of MB.
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @param {{ thresholdChars?: number }} [opts]
+ */
+function repairBloatedCalendarReminders(db, opts = {}) {
+  if (!db || typeof db.prepare !== 'function') return { repaired: 0, reason: 'no_db' };
+  const threshold =
+    typeof opts.thresholdChars === 'number' && opts.thresholdChars > 0
+      ? opts.thresholdChars
+      : MAX_REMINDERS_JSON_CHARS;
+
+  let count = 0;
+  try {
+    count =
+      db
+        .prepare(
+          'SELECT COUNT(*) AS c FROM calendar_events WHERE reminders IS NOT NULL AND length(reminders) > ?',
+        )
+        .get(threshold)?.c ?? 0;
+  } catch (err) {
+    return { repaired: 0, reason: 'count_failed', error: err?.message };
+  }
+
+  if (count <= 0) return { repaired: 0, reason: 'none_bloated' };
+
+  logger.warn('db-maintenance', 'Repairing bloated calendar_events.reminders', {
+    rows: count,
+    thresholdChars: threshold,
+  });
+
+  try {
+    const now = Date.now();
+    const result = db
+      .prepare(
+        `UPDATE calendar_events
+         SET reminders = ?, updated_at = ?
+         WHERE reminders IS NOT NULL AND length(reminders) > ?`,
+      )
+      .run(DEFAULT_REMINDERS_JSON, now, threshold);
+    return { repaired: result.changes ?? count };
+  } catch (err) {
+    logger.error('db-maintenance', 'calendar reminders repair failed', { error: err?.message });
+    return { repaired: 0, reason: 'update_failed', error: err?.message };
+  }
+}
+
 module.exports = {
   reclaimSpaceIfBloated,
   incrementalVacuum,
+  repairBloatedCalendarReminders,
   readPageStats,
   RECLAIM_FREE_BYTES_THRESHOLD,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.7.6",
+  "version": "2.7.7",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {
@@ -40,7 +40,7 @@
     "test:filesystem-tools": "node --test scripts/test-filesystem-tools.mjs",
     "test:feeders": "node --test scripts/test-feeders.mjs",
     "test:web-search": "node --test scripts/test-web-search.mjs",
-    "test:security": "node --test electron/__tests__/shell-policy.test.mjs electron/__tests__/url-guard.test.mjs electron/__tests__/migration-backup.test.mjs electron/__tests__/db-backup.test.mjs electron/__tests__/settings-secrets.test.mjs electron/__tests__/security-path.test.mjs electron/__tests__/logger.test.mjs electron/__tests__/tool-call-policy.test.mjs electron/__tests__/run-retention.test.mjs electron/__tests__/run-recovery.test.mjs electron/__tests__/himalaya-binary.test.mjs electron/__tests__/error-notify.test.mjs electron/__tests__/workflow-dag.test.mjs electron/__tests__/provider-keys.test.mjs electron/__tests__/run-helpers.test.mjs electron/__tests__/ffmpeg-paths.test.mjs electron/__tests__/tool-result-cap.test.mjs electron/__tests__/db-maintenance.test.mjs",
+    "test:security": "node --test electron/__tests__/shell-policy.test.mjs electron/__tests__/url-guard.test.mjs electron/__tests__/migration-backup.test.mjs electron/__tests__/db-backup.test.mjs electron/__tests__/settings-secrets.test.mjs electron/__tests__/security-path.test.mjs electron/__tests__/logger.test.mjs electron/__tests__/tool-call-policy.test.mjs electron/__tests__/run-retention.test.mjs electron/__tests__/run-recovery.test.mjs electron/__tests__/himalaya-binary.test.mjs electron/__tests__/error-notify.test.mjs electron/__tests__/workflow-dag.test.mjs electron/__tests__/provider-keys.test.mjs electron/__tests__/run-helpers.test.mjs electron/__tests__/ffmpeg-paths.test.mjs electron/__tests__/tool-result-cap.test.mjs electron/__tests__/db-maintenance.test.mjs electron/__tests__/calendar-reminders.test.mjs",
     "test": "pnpm run test:security && pnpm --filter @dome/agent-core run test",
     "test:studio": "node scripts/test-studio-validators.mjs",
     "test:studio:tools": "node scripts/test-studio-tools.mjs",

--- a/scripts/repair-calendar-reminders.py
+++ b/scripts/repair-calendar-reminders.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Emergency repair: reset bloated calendar_events.reminders + VACUUM."""
+import os
+import sqlite3
+import sys
+import time
+
+DB = sys.argv[1] if len(sys.argv) > 1 else os.path.join(os.environ.get("APPDATA", ""), "dome", "dome.db")
+DEFAULT = '[{"minutes":15}]'
+THRESHOLD = 8192
+
+def mb(n):
+    return f"{n/1e6:.2f} MB"
+
+if not os.path.isfile(DB):
+    print("DB not found:", DB)
+    sys.exit(1)
+
+before = os.path.getsize(DB)
+conn = sqlite3.connect(DB)
+cur = conn.cursor()
+
+cur.execute(
+    "SELECT COUNT(*) FROM calendar_events WHERE reminders IS NOT NULL AND length(reminders) > ?",
+    (THRESHOLD,),
+)
+bloated = cur.fetchone()[0]
+print(f"Bloated reminder rows: {bloated}")
+
+if bloated:
+    now = int(time.time() * 1000)
+    cur.execute(
+        "UPDATE calendar_events SET reminders = ?, updated_at = ? WHERE reminders IS NOT NULL AND length(reminders) > ?",
+        (DEFAULT, now, THRESHOLD),
+    )
+    conn.commit()
+    print(f"Repaired rows: {cur.rowcount}")
+
+print("Running VACUUM (may take a minute)…")
+started = time.time()
+cur.execute("VACUUM")
+conn.commit()
+conn.close()
+after = os.path.getsize(DB)
+print(f"Done in {time.time()-started:.1f}s")
+print(f"Before: {mb(before)}")
+print(f"After:  {mb(after)}")
+print(f"Saved:  {mb(before - after)}")


### PR DESCRIPTION
## Summary

Fixes the **recurring crash + ~8GB `dome.db` bloat** that still happened on v2.7.6 after leaving the app open (GitHub auto-sync).

**Root cause:** `calendar_events.reminders` was **double-JSON-stringified** on every `updateEvent`. The GitHub calendar bridge upserts release/milestone/issue events on each sync (~15 min). Because `validateEventData` merged the DB row (where `reminders` is already a string) and ran `JSON.stringify(string)`, each sync added another escape layer → **~268 MB per release event** → multi-GB DB + V8 OOM.

The v2.7.6 tool-result cap fix was working (recent runs had ~10 KB metadata); this was a **separate** calendar bug.

## Changes
- **`normalizeRemindersForStorage()`** (`calendar-reminders.cjs`) — canonical JSON once; peels historical corruption
- **`calendar-service.cjs`** — uses normalizer in `validateEventData`
- **`repairBloatedCalendarReminders()`** on startup + existing `reclaimSpaceIfBloated` VACUUM
- **`scripts/repair-calendar-reminders.py`** — one-shot emergency repair
- Version **2.7.7**

Real install verified: 30 bloated rows reset + VACUUM → **8.0 GB → 52 MB**.

## Test plan
- [x] `pnpm run typecheck` — pass
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run build` — pass
- [x] `pnpm run check:ipc-inventory` — pass
- [x] `calendar-reminders` + `db-maintenance` tests — 11/11 pass
- [ ] Packaged smoke + leave app open through 2+ GitHub sync ticks — `dome.db` stays ~50MB, no OOM
