### PR TITLE
chore: release v2.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {


### PR DESCRIPTION
Release **v2.8.2** — version bump.

Bundles the work merged in #454:
- Vault truth isolation + markdown note editor; agent `resource_create` writes physical vault files.
- Many chat: live tool/thinking streaming, header/indicator dedup, redesigned menu.
- Many history: global (un-scoped), real titles from first message, dev browser-shim `threads:get-state` fix.
- Multimodal: image paste unblocked on vision models after model switch (closes #453).

Cutting the GitHub Release for v2.8.2 (build workflow) right after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)