### PR TITLE
fix(ci): release build ignored --publish never (v2.8.2 build failure)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,13 @@ jobs:
       - name: Bootstrap release dependencies (trusted scripts only)
         run: pnpm run bootstrap:release-deps
 
+      # NOTE: call electron-builder directly via `pnpm exec` (NOT
+      # `pnpm run electron:pack -- …`). For a compound script ending in a direct
+      # command, pnpm forwards a literal leading `--`, which yargs treats as
+      # end-of-options, so `--publish never` (and the platform/arch flags) were
+      # silently ignored — electron-builder then tried to publish to GitHub and
+      # failed on the missing GH_TOKEN (#451 removed it). build:packages /
+      # materialize / verify already ran in bootstrap:release-deps + the steps below.
       - name: Build Vite, natives, embed env, pack (macOS)
         run: |
           pnpm run materialize:workspace-deps
@@ -64,10 +71,10 @@ jobs:
           if [ -z "$CSC_LINK" ] || [ "$CSC_LINK" = "" ]; then
             echo "No code signing credentials, building without signing..."
             export CSC_IDENTITY_AUTO_DISCOVERY=false
-            pnpm run electron:pack -- --mac --arm64 --x64 --config.mac.identity=null --config.mac.notarize=false --publish never
+            DEBUG= pnpm exec electron-builder --mac --arm64 --x64 --config.mac.identity=null --config.mac.notarize=false --publish never
           else
             echo "Code signing credentials found, building with signing..."
-            pnpm run electron:pack -- --mac --arm64 --x64 --publish never
+            DEBUG= pnpm exec electron-builder --mac --arm64 --x64 --publish never
           fi
         env:
           DOME_GOOGLE_DRIVE_CLIENT_ID: ${{ secrets.DOME_GOOGLE_DRIVE_CLIENT_ID }}
@@ -135,7 +142,7 @@ jobs:
           pnpm run verify:natives
           node scripts/embed-env.cjs
           node scripts/verify-sentry-build.cjs
-          pnpm run electron:pack -- --win --publish never
+          DEBUG= pnpm exec electron-builder --win --publish never
         env:
           DOME_GOOGLE_DRIVE_CLIENT_ID: ${{ secrets.DOME_GOOGLE_DRIVE_CLIENT_ID }}
           DOME_GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.DOME_GOOGLE_DRIVE_CLIENT_SECRET }}
@@ -231,7 +238,7 @@ jobs:
           pnpm run verify:natives
           node scripts/embed-env.cjs
           node scripts/verify-sentry-build.cjs
-          pnpm run electron:pack -- --linux AppImage flatpak --publish never
+          DEBUG= pnpm exec electron-builder --linux AppImage flatpak --publish never
         env:
           DOME_GOOGLE_DRIVE_CLIENT_ID: ${{ secrets.DOME_GOOGLE_DRIVE_CLIENT_ID }}
           DOME_GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.DOME_GOOGLE_DRIVE_CLIENT_SECRET }}


### PR DESCRIPTION
## Why the v2.8.2 release build failed

All three build jobs failed at the pack step with:
```
Error: GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"
  at PublishManager.artifactCreatedWithoutExplicitPublishConfig
```

### Root cause
The jobs ran `pnpm run electron:pack -- <flags>`. `electron:pack` is a **compound** script ending in a **direct** command (`cross-env … electron-builder`). For that shape, pnpm forwards a **literal leading `--`** to the command. yargs treats `--` as *end-of-options*, so `--publish never` — and the `--mac/--arm64/--x64`, `--linux AppImage flatpak` flags — were **silently dropped**. electron-builder then defaulted to publish-on-tag (because of `build.publish: github` in `package.json`) and crashed on the missing `GH_TOKEN`, which **#451 removed** from the build jobs.

This was latent: v2.8.1 "worked" only because it still had the workflow-level token (it published despite the flag being ignored). v2.8.2 is the first release after #451 → exposed.

### Fix
Call electron-builder directly: `DEBUG= pnpm exec electron-builder <flags>` (clean args, no leading `--`). All prep (`build:packages`, `materialize`, `verify`, natives) already runs in `bootstrap:release-deps` + the build steps. Now `--publish never` takes effect → the build doesn't publish → `attach-artifacts` uploads the binaries as designed, **no token needed in the build jobs** (honors #451). Also restores the ignored platform/arch/target flags.

After merge: recreate the v2.8.2 release on the fixed `main` so the build runs with this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)