### PR TITLE
fix(preload): TypeScript syntax crashes the sandboxed preload script in v2.8.2

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1082,14 +1082,9 @@ const electronHandler = {
       disconnect: () => ipcRenderer.invoke('github:auth:disconnect'),
     },
     repos: {
-      list: (payload?: { projectId?: string }) => ipcRenderer.invoke('github:repos:list', payload),
-      refresh: (payload?: { projectId?: string }) => ipcRenderer.invoke('github:repos:refresh', payload),
-      setSelected: (payload: {
-        projectId: string;
-        selected: boolean;
-        repoId?: string;
-        remote?: { id: number; full_name: string; name: string; owner?: string | { login: string }; private?: boolean; html_url?: string | null };
-      }) => ipcRenderer.invoke('github:repos:setSelected', payload),
+      list: (payload) => ipcRenderer.invoke('github:repos:list', payload),
+      refresh: (payload) => ipcRenderer.invoke('github:repos:refresh', payload),
+      setSelected: (payload) => ipcRenderer.invoke('github:repos:setSelected', payload),
     },
     milestones: {
       list: (repoId, opts) => ipcRenderer.invoke('github:milestones:list', repoId, opts),

--- a/scripts/materialize-workspace-deps.cjs
+++ b/scripts/materialize-workspace-deps.cjs
@@ -39,6 +39,15 @@ function copyPackage(realPkgDir, destDir) {
     fail(`dist/ missing in ${realPkgDir} — run pnpm run build:packages first`);
   }
   fs.cpSync(distSrc, path.join(destDir, 'dist'), { recursive: true });
+
+  // @dome/db ships its Drizzle SQL migrations alongside dist/ (resolved at
+  // runtime via getMigrationsFolder() = <package-root>/../drizzle). Without
+  // this, packaged builds silently skip every Drizzle migration — see
+  // electron/core/db/drizzle-bridge.cjs ("Drizzle migrations folder missing").
+  const drizzleSrc = path.join(realPkgDir, 'drizzle');
+  if (fs.existsSync(drizzleSrc)) {
+    fs.cpSync(drizzleSrc, path.join(destDir, 'drizzle'), { recursive: true });
+  }
 }
 
 if (!fs.existsSync(scopeDir)) {


### PR DESCRIPTION
## Summary

- **Root cause of "Dome 2.8.2 no carga datos de la DB":** #454 (`b777def1`) leaked TypeScript parameter type annotations into `electron/preload.cjs`, which is a plain `.cjs` file, not TypeScript:
  ```js
  list: (payload?: { projectId?: string }) => ipcRenderer.invoke('github:repos:list', payload),
  setSelected: (payload: { projectId: string; ... }) => ...
  ```
  Since the main window uses `sandbox: true` (`electron/core/window-manager.cjs`), Electron's strict preload parser throws `SyntaxError: Unexpected token ':'` on load. `window.electron` is never exposed via `contextBridge`, so **every** renderer→main IPC call fails app-wide (`Database API not available`, `Electron no disponible`, etc.) — not just GitHub/Pipelines. This shipped in the v2.8.2 release.
  - Fix: drop the type annotations, keep the same runtime behavior (params still pass through unchanged).
- **Secondary, currently-harmless bug also fixed:** `scripts/materialize-workspace-deps.cjs` only copied `dist/` + `package.json` when materializing `@dome/db` for packaging, silently dropping `packages/db/drizzle/`. Every packaged build logs `[DB] Drizzle migrations folder missing` and skips Drizzle migrations entirely. Harmless today (the only migration is a no-op baseline `SELECT 1;`), but would silently break the next real Drizzle migration if not fixed now.

## Verification

- Confirmed the exact crash by relaunching the installed v2.8.2 production app with `--enable-logging=stderr`: `Unable to load preload script ... SyntaxError: Unexpected token ':'` immediately followed by app-wide `Database API not available` errors in every store/page.
- After the fix, ran Electron in dev with `--remote-debugging-port` and used CDP `Runtime.evaluate` to confirm end-to-end:
  - `window.electron` is exposed again with the full channel set (`db`, `github`, `runs`, …).
  - `window.electron.invoke('db:projects:getAll')` returns real project data.
- Ran `scripts/materialize-workspace-deps.cjs` locally and confirmed `node_modules/@dome/db/drizzle/` is now populated (`0000_baseline_v53.sql`, `meta/`).

## Test plan

- [ ] CI (typecheck, lint, build, ipc-inventory, depcruise) green
- [ ] Cut a v2.8.3 hotfix release and confirm a fresh packaged install loads DB-backed data (Proyectos, Ajustes, Seguimiento, etc.) on first launch

Made with [Cursor](https://cursor.com)