### PR TITLE
feat(ci): Jenkins + SonarQube analysis for dome

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,60 @@
+pipeline {
+  agent any
+
+  environment {
+    PNPM_VERSION = '11.8.0'
+  }
+
+  stages {
+    stage('Checkout') {
+      steps {
+        checkout scm
+      }
+    }
+
+    stage('Setup') {
+      steps {
+        sh '''
+          corepack enable
+          corepack prepare pnpm@${PNPM_VERSION} --activate
+          node --version
+          pnpm --version
+        '''
+      }
+    }
+
+    stage('Install') {
+      steps {
+        sh 'pnpm install --frozen-lockfile --ignore-scripts'
+      }
+    }
+
+    stage('Quality checks') {
+      parallel {
+        stage('Typecheck') {
+          steps { sh 'pnpm run typecheck' }
+        }
+        stage('Lint') {
+          steps { sh 'pnpm run lint' }
+        }
+        stage('Security tests') {
+          steps { sh 'pnpm run test:security' }
+        }
+      }
+    }
+
+    stage('SonarQube analysis') {
+      steps {
+        withSonarQubeEnv('SonarQube') {
+          sh 'pnpm dlx @sonar/scan'
+        }
+      }
+    }
+  }
+
+  post {
+    always {
+      cleanWs()
+    }
+  }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,28 @@
+sonar.projectKey=maxprain12_dome_0330e2dd-e81b-4cb7-b746-e05da0c325af
+sonar.projectName=dome
+sonar.sourceEncoding=UTF-8
+
+# Analyzable code (renderer + main process + workspace packages)
+sonar.sources=app,electron,packages,shared
+
+# Exclusions aligned with CI noise and generated files
+sonar.exclusions=\
+  **/node_modules/**,\
+  **/dist/**,\
+  **/release/**,\
+  **/build/**,\
+  **/.next/**,\
+  **/coverage/**,\
+  **/*.generated.ts,\
+  packages/ai/src/models.generated.ts,\
+  public/**,\
+  docs/**
+
+# TypeScript (monorepo tsconfigs)
+sonar.typescript.tsconfigPaths=tsconfig.json,packages/*/tsconfig.json
+
+# Coverage — phase 2 (when lcov.info exists)
+# sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# ESLint — phase 2 optional
+# sonar.eslint.reportPaths=eslint-report.json


### PR DESCRIPTION
## Summary
- Add `Jenkinsfile` with pnpm install, typecheck, lint, security tests, and `@sonar/scan` via `withSonarQubeEnv('SonarQube')`
- Add `sonar-project.properties` for project `maxprain12_dome_0330e2dd-e81b-4cb7-b746-e05da0c325af` covering `app/`, `electron/`, `packages/`, `shared/`

## Jenkins setup (manual)
- SonarQube server in Jenkins System: name `SonarQube`, URL `https://sonar.dowi.es`, analysis token
- Job `dome-sonar` with GitHub hook trigger; webhook `https://jenkins.dowi.es/github-webhook/`

## Test plan
- [ ] Merge to main
- [ ] Jenkins job `dome-sonar` runs green
- [ ] Analysis appears on https://sonar.dowi.es for project `dome`