### PR TITLE
fix(ci): bootstrap Node 24 on Jenkins agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,9 @@ pipeline {
 
   environment {
     PNPM_VERSION = '11.8.0'
+    NODE_VERSION = '24.13.0'
+    NODE_HOME = "${WORKSPACE}/.jenkins-node"
+    PATH = "${WORKSPACE}/.jenkins-node/bin:${env.PATH}"
   }
 
   stages {
@@ -15,9 +18,21 @@ pipeline {
     stage('Setup') {
       steps {
         sh '''
-          corepack enable
-          corepack prepare pnpm@${PNPM_VERSION} --activate
+          set -eux
+          if ! command -v node >/dev/null 2>&1 || ! node --version | grep -q '^v24'; then
+            ARCH="$(uname -m)"
+            case "$ARCH" in
+              x86_64) NODE_ARCH=linux-x64 ;;
+              aarch64|arm64) NODE_ARCH=linux-arm64 ;;
+              *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+            esac
+            mkdir -p "$NODE_HOME"
+            curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${NODE_ARCH}.tar.xz" \
+              | tar -xJ --strip-components=1 -C "$NODE_HOME"
+          fi
           node --version
+          npm --version
+          npm install -g "pnpm@${PNPM_VERSION}"
           pnpm --version
         '''
       }


### PR DESCRIPTION
## Summary
- Fixes `corepack: not found` on the Jenkins agent (`dome-sonar` job)
- Bootstraps Node.js 24.13.0 into the workspace when the agent lacks it
- Installs pnpm 11.8.0 via `npm install -g` (no corepack required)
- Exposes Node/pnpm to all stages via `PATH`

## Test plan
- [ ] Merge to main
- [ ] Re-run Jenkins job `dome-sonar`
- [ ] Setup stage passes (`node`, `pnpm` versions printed)