### PR TITLE
fix(ci): Node bootstrap via tar.gz on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,8 +27,8 @@ pipeline {
               *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
             esac
             mkdir -p "$NODE_HOME"
-            curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${NODE_ARCH}.tar.xz" \
-              | tar -xJ --strip-components=1 -C "$NODE_HOME"
+            curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${NODE_ARCH}.tar.gz" \
+              | tar -xzf - --strip-components=1 -C "$NODE_HOME"
           fi
           node --version
           npm --version


### PR DESCRIPTION
## Summary
- Fixes `xz: Cannot exec: No such file or directory` when extracting Node.js on the Jenkins agent
- Uses `node-v24.13.0-linux-*.tar.gz` with `tar -xzf` instead of `.tar.xz`

## Test plan
- [ ] Merge to main
- [ ] Re-run Jenkins job `dome-sonar` — Setup stage should pass