### PR TITLE
fix(ci): explicit sonar-scanner binary for pnpm dlx

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
     stage('SonarQube analysis') {
       steps {
         withSonarQubeEnv('SonarQube') {
-          sh 'pnpm dlx @sonar/scan'
+          sh 'pnpm --package=@sonar/scan dlx sonar-scanner'
         }
       }
     }


### PR DESCRIPTION
## Summary
- Fixes `ERR_PNPM_DLX_MULTIPLE_BINS` on the SonarQube analysis stage
- Uses `pnpm --package=@sonar/scan dlx sonar-scanner` instead of bare `pnpm dlx @sonar/scan`

## Test plan
- [ ] Merge to main
- [ ] Re-run Jenkins job `dome-sonar` — SonarQube analysis stage should complete