### PR TITLE
fix(ci): auto-install gh/xvfb in Jenkins quality-loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ coverage
 # Sonar quality loop runtime artifacts (Jenkins / local harness)
 .quality-loop/
 .jenkins-display.env
+.jenkins-tools/
 *.lcov
 
 # logs

--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -9,7 +9,7 @@ pipeline {
     PNPM_VERSION = '11.8.0'
     NODE_VERSION = '24.13.0'
     NODE_HOME = "${WORKSPACE}/.jenkins-node"
-    PATH = "${WORKSPACE}/.jenkins-node/bin:${env.PATH}"
+    PATH = "${WORKSPACE}/.jenkins-tools/bin:${WORKSPACE}/.jenkins-node/bin:${env.PATH}"
     SONAR_HOST_URL = 'https://sonar.dowi.es'
     GITHUB_REPOSITORY = 'maxprain12/dome'
     XVFB_DISPLAY = ':99'
@@ -29,7 +29,7 @@ pipeline {
         ]) {
           sh '''
             set -eux
-            chmod +x scripts/jenkins/agent-preflight.sh scripts/jenkins/run-with-display.sh
+            chmod +x scripts/jenkins/bootstrap-agent-tools.sh scripts/jenkins/agent-preflight.sh scripts/jenkins/run-with-display.sh
             bash scripts/jenkins/agent-preflight.sh "$PWD"
             cat .jenkins-display.env || true
           '''

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -40,23 +40,16 @@ Variables de entorno en el job (Environment / pipeline):
 
 ### Agente Jenkins (Linux)
 
-El pipeline ejecuta **`scripts/jenkins/agent-preflight.sh`** al inicio:
+El pipeline ejecuta **`scripts/jenkins/bootstrap-agent-tools.sh`** + **`agent-preflight.sh`** al inicio:
 
-| Herramienta | Validación |
-|-------------|------------|
-| `git` | obligatorio |
-| `curl` | obligatorio |
-| `gh` | obligatorio (+ login con `GITHUB_TOKEN`) |
+| Herramienta | Comportamiento |
+|-------------|----------------|
+| `git`, `curl` | deben existir en la imagen (Jenkins estándar) |
+| **`gh`** | `apt-get` si hay root/sudo; si no, **descarga portable** a `.jenkins-tools/bin/` |
+| **`xvfb`** | `apt-get` si hay root/sudo; si no, warning (Electron usa `no-sandbox`) |
 | Node/pnpm | bootstrap en stage Setup |
-| **Xvfb** | auto: `DISPLAY=:99` o fallback `xvfb-run` |
 
-Instalación en el agente (Debian/Ubuntu):
-
-```bash
-apt-get update && apt-get install -y git curl gh xvfb
-```
-
-Si falta alguna herramienta, el job falla en **Agent preflight** con instrucciones.
+No hace falta instalar `gh` a mano en el agente salvo que `apt` y la descarga fallen (sin red).
 
 ## Flujo del pipeline
 

--- a/scripts/jenkins/agent-preflight.sh
+++ b/scripts/jenkins/agent-preflight.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 # Jenkins agent preflight for dome-quality-loop (Linux).
-# Validates required CLI tools and prepares a virtual display for Electron.
+# Bootstraps missing tools, validates CLI, prepares virtual display for Electron.
 set -euo pipefail
 
 ROOT="${1:-.}"
 cd "$ROOT"
+
+if [ -f .jenkins-tools.env ]; then
+  # shellcheck disable=SC1091
+  set -a
+  source ./.jenkins-tools.env
+  set +a
+fi
 
 ENV_FILE=".jenkins-display.env"
 : > "$ENV_FILE"
@@ -12,25 +19,24 @@ ENV_FILE=".jenkins-display.env"
 echo "=== Jenkins agent preflight ==="
 echo "uname: $(uname -a)"
 
-missing=0
+bash scripts/jenkins/bootstrap-agent-tools.sh "$ROOT"
+
+if [ -f .jenkins-tools.env ]; then
+  # shellcheck disable=SC1091
+  set -a
+  source ./.jenkins-tools.env
+  set +a
+fi
+
 for tool in git curl gh; do
   if command -v "$tool" >/dev/null 2>&1; then
     echo "OK: $tool → $($tool --version 2>&1 | head -1)"
   else
-    echo "ERROR: required tool not found: $tool"
-    missing=1
+    echo "ERROR: required tool not found after bootstrap: $tool"
+    exit 1
   fi
 done
 
-if [ "$missing" -ne 0 ]; then
-  echo ""
-  echo "Install on the Jenkins agent (Debian/Ubuntu example):"
-  echo "  apt-get update && apt-get install -y git curl gh xvfb"
-  echo "Or gh: https://github.com/cli/cli/blob/trunk/docs/install_linux.md"
-  exit 1
-fi
-
-# GitHub CLI must see a token when GITHUB_TOKEN is injected by Jenkins
 if [ -n "${GITHUB_TOKEN:-}" ]; then
   if ! echo "$GITHUB_TOKEN" | gh auth login --with-token >/dev/null 2>&1; then
     echo "WARN: gh auth login failed (check github-quality-loop credential)"
@@ -61,7 +67,6 @@ elif command -v xvfb-run >/dev/null 2>&1; then
   echo "XVFB_RUN=1" >> "$ENV_FILE"
 else
   echo "WARN: neither Xvfb nor xvfb-run found — Electron harness may fail"
-  echo "  apt-get install -y xvfb"
 fi
 
 echo "=== Preflight complete ==="

--- a/scripts/jenkins/bootstrap-agent-tools.sh
+++ b/scripts/jenkins/bootstrap-agent-tools.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Bootstrap missing Jenkins agent tools (gh, xvfb) without manual image setup.
+# Prefers apt when root/sudo is available; falls back to portable gh in workspace.
+set -euo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT"
+
+TOOLS_DIR="${ROOT}/.jenkins-tools"
+BIN_DIR="${TOOLS_DIR}/bin"
+ENV_FILE="${ROOT}/.jenkins-tools.env"
+
+mkdir -p "$BIN_DIR"
+
+write_env() {
+  cat > "$ENV_FILE" <<EOF
+export PATH="${BIN_DIR}:\${PATH}"
+EOF
+}
+
+write_env
+
+echo "=== Bootstrap agent tools ==="
+echo "tools dir: ${BIN_DIR}"
+
+run_apt() {
+  if ! command -v apt-get >/dev/null 2>&1; then
+    return 1
+  fi
+  local pkgs=( "$@" )
+  if [ "$(id -u)" = "0" ]; then
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    apt-get install -y -qq "${pkgs[@]}"
+    return 0
+  fi
+  if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+    export DEBIAN_FRONTEND=noninteractive
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq "${pkgs[@]}"
+    return 0
+  fi
+  return 1
+}
+
+# shellcheck source=/dev/null
+set -a
+# shellcheck disable=SC1091
+source "$ENV_FILE"
+set +a
+
+need_apt=()
+command -v gh >/dev/null 2>&1 || need_apt+=( gh )
+command -v Xvfb >/dev/null 2>&1 || command -v xvfb-run >/dev/null 2>&1 || need_apt+=( xvfb )
+command -v xdpyinfo >/dev/null 2>&1 || need_apt+=( x11-xserver-utils )
+
+if [ "${#need_apt[@]}" -gt 0 ]; then
+  echo "Trying apt-get for: ${need_apt[*]}"
+  if run_apt "${need_apt[@]}"; then
+    echo "OK: apt-get installed ${need_apt[*]}"
+  else
+    echo "apt-get skipped (no root/sudo or not Debian/Ubuntu)"
+  fi
+fi
+
+install_gh_portable() {
+  if command -v gh >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local arch raw_arch
+  raw_arch="$(uname -m)"
+  case "$raw_arch" in
+    x86_64) arch=amd64 ;;
+    aarch64|arm64) arch=arm64 ;;
+    *)
+      echo "ERROR: unsupported architecture for portable gh: $raw_arch"
+      return 1
+      ;;
+  esac
+
+  local version="${GH_VERSION:-2.65.0}"
+  local name="gh_${version}_linux_${arch}"
+  local url="https://github.com/cli/cli/releases/download/v${version}/${name}.tar.gz"
+  local tmp="${TOOLS_DIR}/gh.tgz"
+
+  echo "Installing portable gh v${version} (${arch})..."
+  curl -fsSL "$url" -o "$tmp"
+  tar -xzf "$tmp" -C "$TOOLS_DIR" "${name}/bin/gh"
+  ln -sf "${TOOLS_DIR}/${name}/bin/gh" "${BIN_DIR}/gh"
+  rm -f "$tmp"
+  echo "OK: portable gh → ${BIN_DIR}/gh"
+}
+
+if ! command -v gh >/dev/null 2>&1; then
+  install_gh_portable
+fi
+
+# shellcheck disable=SC1091
+source "$ENV_FILE"
+
+for tool in git curl gh; do
+  if command -v "$tool" >/dev/null 2>&1; then
+    echo "OK: $tool → $($tool --version 2>&1 | head -1)"
+  else
+    echo "ERROR: still missing: $tool"
+    exit 1
+  fi
+done
+
+if command -v Xvfb >/dev/null 2>&1 || command -v xvfb-run >/dev/null 2>&1; then
+  echo "OK: Xvfb stack available"
+else
+  echo "WARN: Xvfb not available — Electron may still run with no-sandbox (or fail on this agent)"
+fi
+
+echo "=== Bootstrap complete ==="

--- a/scripts/jenkins/run-with-display.sh
+++ b/scripts/jenkins/run-with-display.sh
@@ -2,6 +2,13 @@
 # Source .jenkins-display.env and run a command (optionally via xvfb-run).
 set -euo pipefail
 
+if [ -f .jenkins-tools.env ]; then
+  # shellcheck disable=SC1091
+  set -a
+  . ./.jenkins-tools.env
+  set +a
+fi
+
 if [ -f .jenkins-display.env ]; then
   # shellcheck disable=SC1091
   set -a


### PR DESCRIPTION
## Summary

- Adds `scripts/jenkins/bootstrap-agent-tools.sh` to install **gh** (apt or portable tarball) and **xvfb** (apt when root/sudo) before preflight.
- Updates `Jenkinsfile.quality-loop` PATH to include `.jenkins-tools/bin`.

Fixes Jenkins failure: `ERROR: required tool not found: gh`.

## Test plan

- [ ] Merge and re-run `dome-quality-loop` Build Now
- [ ] Agent preflight should show portable gh install or apt install