### PR TITLE
fix(ci): use GH_TOKEN for gh in Jenkins quality-loop

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -29,7 +29,7 @@ pipeline {
         ]) {
           sh '''
             set -eux
-            chmod +x scripts/jenkins/bootstrap-agent-tools.sh scripts/jenkins/agent-preflight.sh scripts/jenkins/run-with-display.sh
+            chmod +x scripts/jenkins/bootstrap-agent-tools.sh scripts/jenkins/agent-preflight.sh scripts/jenkins/gh-auth-env.sh scripts/jenkins/run-with-display.sh
             bash scripts/jenkins/agent-preflight.sh "$PWD"
             cat .jenkins-display.env || true
           '''
@@ -78,7 +78,7 @@ pipeline {
         ]) {
           sh '''
             set -eux
-            echo "$GITHUB_TOKEN" | gh auth login --with-token
+            bash scripts/jenkins/gh-auth-env.sh
             pnpm run sonar:sync-github -- --severity=BLOCKER,CRITICAL,MAJOR,HIGH --max=50
           '''
         }
@@ -160,8 +160,7 @@ pipeline {
             git add -A
             git commit -m "fix(sonar): quality loop batch $(date -Iseconds)"
 
-            echo "$GITHUB_TOKEN" | gh auth login --with-token
-            gh auth setup-git
+            JENKINS_GH_SETUP_GIT=1 bash scripts/jenkins/gh-auth-env.sh
             git push -u origin "$BRANCH"
 
             node scripts/sonar/create-batch-pr.mjs --batch=.quality-loop/batch.json

--- a/scripts/jenkins/agent-preflight.sh
+++ b/scripts/jenkins/agent-preflight.sh
@@ -38,11 +38,7 @@ for tool in git curl gh; do
 done
 
 if [ -n "${GITHUB_TOKEN:-}" ]; then
-  if ! echo "$GITHUB_TOKEN" | gh auth login --with-token >/dev/null 2>&1; then
-    echo "WARN: gh auth login failed (check github-quality-loop credential)"
-  else
-    gh auth status -h github.com || true
-  fi
+  bash scripts/jenkins/gh-auth-env.sh
 fi
 
 XVFB_DISPLAY="${XVFB_DISPLAY:-:99}"

--- a/scripts/jenkins/gh-auth-env.sh
+++ b/scripts/jenkins/gh-auth-env.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Configure gh + git for Jenkins when GITHUB_TOKEN is injected via withCredentials.
+# gh reads GH_TOKEN automatically — no need for `gh auth login --with-token`.
+set -euo pipefail
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "WARN: GITHUB_TOKEN not set — gh/git GitHub ops will fail"
+  exit 0
+fi
+
+export GH_TOKEN="$GITHUB_TOKEN"
+
+if gh auth status -h github.com >/dev/null 2>&1; then
+  echo "OK: gh authenticated via GH_TOKEN"
+else
+  echo "ERROR: gh auth check failed — verify github-quality-loop credential (repo + issues scopes)"
+  exit 1
+fi
+
+if [ "${JENKINS_GH_SETUP_GIT:-0}" = "1" ]; then
+  gh auth setup-git
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/jenkins/gh-auth-env.sh` to authenticate `gh` via `GH_TOKEN` when Jenkins injects `GITHUB_TOKEN`.
- Removes redundant `gh auth login --with-token` calls that only printed a confusing warning and could confuse debugging.
- Updates preflight and Verify & PR stages to use the shared helper.

Follow-up to #471 (bootstrap gh/xvfb already merged).

## Test plan

- [ ] Merge and re-run Jenkins job `dome-quality-loop`
- [ ] Preflight should log `OK: gh authenticated via GH_TOKEN`
- [ ] Sync Sonar → GitHub stage should proceed without auth warnings