### PR TITLE
fix(ci): Sonar 401 — Basic auth + withSonarQubeEnv

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -72,30 +72,37 @@ pipeline {
 
     stage('Sync Sonar → GitHub') {
       steps {
-        withCredentials([
-          string(credentialsId: 'sonar', variable: 'SONAR_TOKEN'),
-          string(credentialsId: 'github-quality-loop', variable: 'GITHUB_TOKEN'),
-        ]) {
-          sh '''
-            set -eux
-            bash scripts/jenkins/gh-auth-env.sh
-            pnpm run sonar:sync-github -- --severity=BLOCKER,CRITICAL,MAJOR,HIGH --max=50
-          '''
+        withSonarQubeEnv('SonarQube') {
+          withCredentials([
+            string(credentialsId: 'github-quality-loop', variable: 'GITHUB_TOKEN'),
+          ]) {
+            sh '''
+              set -eux
+              bash scripts/jenkins/gh-auth-env.sh
+              node --input-type=module -e "
+                import { sonarFetch } from './scripts/sonar/lib.mjs';
+                const u = await sonarFetch('/api/authentication/validate');
+                console.log('OK: Sonar auth →', u.login || 'valid');
+              "
+              pnpm run sonar:sync-github -- --severity=BLOCKER,CRITICAL,MAJOR,HIGH --max=50
+            '''
+          }
         }
       }
     }
 
     stage('Pick batch') {
       steps {
-        withCredentials([
-          string(credentialsId: 'sonar', variable: 'SONAR_TOKEN'),
-          string(credentialsId: 'github-quality-loop', variable: 'GITHUB_TOKEN'),
-        ]) {
-          sh '''
-            set -eux
-            mkdir -p .quality-loop
-            pnpm run sonar:pick-batch -- --size=5 --out=.quality-loop/batch.json
-          '''
+        withSonarQubeEnv('SonarQube') {
+          withCredentials([
+            string(credentialsId: 'github-quality-loop', variable: 'GITHUB_TOKEN'),
+          ]) {
+            sh '''
+              set -eux
+              mkdir -p .quality-loop
+              pnpm run sonar:pick-batch -- --size=5 --out=.quality-loop/batch.json
+            '''
+          }
         }
         archiveArtifacts artifacts: '.quality-loop/batch.json', allowEmptyArchive: true
       }
@@ -171,11 +178,12 @@ pipeline {
 
     stage('Close resolved in Sonar') {
       steps {
-        withCredentials([
-          string(credentialsId: 'sonar', variable: 'SONAR_TOKEN'),
-          string(credentialsId: 'github-quality-loop', variable: 'GITHUB_TOKEN'),
-        ]) {
-          sh 'pnpm run sonar:close-resolved -- --since-days=14 || true'
+        withSonarQubeEnv('SonarQube') {
+          withCredentials([
+            string(credentialsId: 'github-quality-loop', variable: 'GITHUB_TOKEN'),
+          ]) {
+            sh 'pnpm run sonar:close-resolved -- --since-days=14 || true'
+          }
         }
       }
     }

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -22,9 +22,13 @@ Automated correction loop: SonarQube → GitHub Issues → Dome agent (MiniMax) 
 
 | ID Jenkins | Tipo | Uso |
 |------------|------|-----|
-| **`sonar`** | Secret text | Token SonarQube (`SONAR_TOKEN`) |
+| **SonarQube server `SonarQube`** | Plugin (Manage Jenkins → SonarQube) | Token para Web API (`SONAR_AUTH_TOKEN`) — **mismo que job `dome-sonar`** |
 | **`github-quality-loop`** | GitHub PAT | `repo` + issues/PRs (`GITHUB_TOKEN`) |
 | **`minimax-api-key`** | Secret text | API MiniMax (`MINIMAX_API_KEY`) |
+
+Los stages Sonar usan `withSonarQubeEnv('SonarQube')`, no la credential suelta `sonar`.
+
+**Local / fallback:** exporta `SONAR_TOKEN` (user token de SonarQube → My Account → Security). La Web API usa **Basic auth** (`token:` como login). Solo SonarQube ≥ 10.6 acepta `Bearer`; opcional `SONAR_AUTH_SCHEME=bearer`.
 
 El pipeline mapea `minimax-api-key` → env `MINIMAX_API_KEY`.
 

--- a/scripts/sonar/lib.mjs
+++ b/scripts/sonar/lib.mjs
@@ -27,16 +27,37 @@ export function requireEnv(name) {
   return value;
 }
 
+/** User token from env or Jenkins SonarQube plugin (`SONAR_AUTH_TOKEN`). */
+export function sonarToken() {
+  const token = process.env.SONAR_TOKEN || process.env.SONAR_AUTH_TOKEN;
+  if (!token) {
+    throw new Error(
+      'Missing Sonar token: set SONAR_TOKEN or use Jenkins withSonarQubeEnv (SONAR_AUTH_TOKEN)',
+    );
+  }
+  return token;
+}
+
+/** Sonar Web API: token as login, empty password (Basic). Bearer only on SonarQube 10.6+. */
+export function sonarAuthHeader(token) {
+  const scheme = (process.env.SONAR_AUTH_SCHEME || 'basic').toLowerCase();
+  if (scheme === 'bearer') {
+    return { Authorization: `Bearer ${token}` };
+  }
+  const encoded = Buffer.from(`${token}:`, 'utf8').toString('base64');
+  return { Authorization: `Basic ${encoded}` };
+}
+
 /**
  * @param {Record<string, string | number | boolean | undefined>} params
  */
 export async function sonarFetch(path, params = {}, method = 'GET') {
-  const token = requireEnv('SONAR_TOKEN');
+  const token = sonarToken();
   const url = new URL(`${sonarHost()}${path}`);
   /** @type {RequestInit} */
   const init = {
     method,
-    headers: { Authorization: `Bearer ${token}` },
+    headers: sonarAuthHeader(token),
   };
 
   if (method === 'GET') {


### PR DESCRIPTION
## Summary

Fixes Jenkins `dome-quality-loop` failure on **Sync Sonar → GitHub**:

```
Sonar API /api/issues/search failed (401)
```

**Root cause:** `scripts/sonar/lib.mjs` used `Authorization: Bearer`, but SonarQube user tokens expect **HTTP Basic** (token as login, empty password) unless SonarQube ≥ 10.6.

**Changes:**
- `lib.mjs`: Basic auth by default; reads `SONAR_AUTH_TOKEN` from Jenkins SonarQube plugin
- `Jenkinsfile.quality-loop`: `withSonarQubeEnv('SonarQube')` on Sonar stages (same as `dome-sonar` job)
- Validates token via `/api/authentication/validate` before sync

## Jenkins checklist

- [ ] **Manage Jenkins → SonarQube** server named **`SonarQube`** with valid token (same as `dome-sonar`)
- [ ] Credential `github-quality-loop` still required for GitHub
- [ ] Re-run `dome-quality-loop` — expect `OK: Sonar auth → <user>`

## Test plan

- [ ] Merge and Build Now on `dome-quality-loop`
- [ ] Sync stage passes (no 401)