### PR TITLE
fix(ci): Sonar severity filter + auto-merge en quality-loop PRs

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -170,7 +170,7 @@ pipeline {
             JENKINS_GH_SETUP_GIT=1 bash scripts/jenkins/gh-auth-env.sh
             git push -u origin "$BRANCH"
 
-            node scripts/sonar/create-batch-pr.mjs --batch=.quality-loop/batch.json
+            node scripts/sonar/create-batch-pr.mjs --batch=.quality-loop/batch.json --branch="$BRANCH"
           '''
         }
       }

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -61,8 +61,17 @@ No hace falta instalar `gh` a mano en el agente salvo que `apt` y la descarga fa
 2. Pick batch → `.quality-loop/batch.json`
 3. Fix mecánico (`void` operator) si aplica
 4. **Agent fix** — `pnpm run sonar:run-agent` (MiniMax via Dome harness)
-5. Si hay diff → typecheck, lint, coverage → branch + PR
+5. Si hay diff → typecheck, lint, coverage → branch + PR (**auto-merge squash** cuando pase CI)
 6. Close resolved en Sonar
+
+### Auto-merge de PRs
+
+Tras `gh pr create`, el script `create-batch-pr.mjs` ejecuta `gh pr merge --auto --squash`. El merge ocurre cuando pasen los checks de GitHub Actions (igual que el flujo de [AGENTS.md](../../AGENTS.md)).
+
+Requisitos en el repo **maxprain12/dome**:
+
+- **Settings → General → Allow auto-merge** activado
+- Branch protection en `main` con status checks requeridos (CI)
 
 ## Probar localmente
 

--- a/scripts/sonar/create-batch-pr.mjs
+++ b/scripts/sonar/create-batch-pr.mjs
@@ -3,7 +3,7 @@
  * Create a PR for a mechanical Sonar batch (used by Jenkins quality loop).
  *
  * Usage:
- *   GITHUB_TOKEN=... node scripts/sonar/create-batch-pr.mjs --batch=.quality-loop/batch.json
+ *   GITHUB_TOKEN=... node scripts/sonar/create-batch-pr.mjs --batch=.quality-loop/batch.json [--branch=fix/sonar-batch-...]
  */
 
 import { execFileSync } from 'node:child_process';
@@ -16,6 +16,10 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const args = parseArgs(process.argv.slice(2));
 const batchPath = path.resolve(args.batch || '.quality-loop/batch.json');
 const batch = JSON.parse(fs.readFileSync(batchPath, 'utf8'));
+const branch =
+  args.branch ||
+  process.env.SONAR_LOOP_BRANCH ||
+  `fix/sonar-batch-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}`;
 
 const closes = (batch.batch || [])
   .map((i) => i.githubNumber)
@@ -34,22 +38,32 @@ ${closes.length ? closes.join('\n') : '_No linked GitHub issue numbers in batch.
 - [x] test:coverage
 `;
 
-const branch = `fix/sonar-batch-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}`;
 const bodyFile = path.join(root, '.quality-loop', 'pr-body.md');
 fs.mkdirSync(path.dirname(bodyFile), { recursive: true });
 fs.writeFileSync(bodyFile, body);
 
-execFileSync('gh', [
-  'pr',
-  'create',
-  '--repo',
-  githubRepo(),
-  '--title',
-  'fix(sonar): mechanical quality batch',
-  '--body-file',
-  bodyFile,
-  '--head',
-  branch,
-], { cwd: root, stdio: 'inherit' });
+const repo = githubRepo();
+const prUrl = execFileSync(
+  'gh',
+  [
+    'pr',
+    'create',
+    '--repo',
+    repo,
+    '--title',
+    'fix(sonar): quality loop batch',
+    '--body-file',
+    bodyFile,
+    '--head',
+    branch,
+  ],
+  { cwd: root, encoding: 'utf8' },
+).trim();
 
-console.log(`PR created for branch ${branch}`);
+execFileSync(
+  'gh',
+  ['pr', 'merge', prUrl, '--auto', '--squash', '--repo', repo],
+  { cwd: root, stdio: 'inherit' },
+);
+
+console.log(`PR created with auto-merge (squash): ${prUrl}`);

--- a/scripts/sonar/fetch-issues.mjs
+++ b/scripts/sonar/fetch-issues.mjs
@@ -8,10 +8,10 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { parseArgs, sonarFetch, sonarProjectKey } from './lib.mjs';
+import { parseArgs, sonarFetch, sonarProjectKey, withIssueSeverityFilter } from './lib.mjs';
 
 const args = parseArgs(process.argv.slice(2));
-const severities = (args.severity || 'BLOCKER,CRITICAL,MAJOR,HIGH').split(',').map((s) => s.trim());
+const severityFilter = args.severity || 'BLOCKER,CRITICAL,MAJOR,HIGH';
 const impacts = args.impact ? args.impact.split(',').map((s) => s.trim()) : null;
 const maxIssues = Number(args.max || 500);
 const pageSize = Math.min(500, maxIssues);
@@ -21,13 +21,18 @@ const all = [];
 let page = 1;
 
 while (all.length < maxIssues) {
-  const data = await sonarFetch('/api/issues/search', {
-    componentKeys: sonarProjectKey(),
-    statuses: 'OPEN,CONFIRMED,REOPENED',
-    severities: severities.join(','),
-    ps: pageSize,
-    p: page,
-  });
+  const data = await sonarFetch(
+    '/api/issues/search',
+    withIssueSeverityFilter(
+      {
+        componentKeys: sonarProjectKey(),
+        statuses: 'OPEN,CONFIRMED,REOPENED',
+        ps: pageSize,
+        p: page,
+      },
+      severityFilter,
+    ),
+  );
 
   const issues = data.issues || [];
   if (issues.length === 0) break;

--- a/scripts/sonar/lib.mjs
+++ b/scripts/sonar/lib.mjs
@@ -154,6 +154,58 @@ export function sonarSeverityLabel(severity) {
   return map[severity] || 'sonar-unknown';
 }
 
+const SONAR_LEGACY_SEVERITIES = ['INFO', 'MINOR', 'MAJOR', 'CRITICAL', 'BLOCKER'];
+const SONAR_IMPACT_SEVERITIES = ['HIGH', 'MEDIUM', 'LOW'];
+
+/**
+ * Split CLI severity tokens into Sonar `/api/issues/search` params.
+ * Legacy: INFO…BLOCKER → `severities`. Impact: HIGH/MEDIUM/LOW → `impactSeverities`.
+ * @param {string} csv e.g. "BLOCKER,CRITICAL,MAJOR,HIGH"
+ */
+export function parseIssueSeverityFilter(csv) {
+  /** @type {string[]} */
+  const severities = [];
+  /** @type {string[]} */
+  const impactSeverities = [];
+  /** @type {string[]} */
+  const unknown = [];
+
+  for (const raw of csv.split(',')) {
+    const token = raw.trim().toUpperCase();
+    if (!token) continue;
+    if (SONAR_LEGACY_SEVERITIES.includes(token)) {
+      severities.push(token);
+    } else if (SONAR_IMPACT_SEVERITIES.includes(token)) {
+      impactSeverities.push(token);
+    } else {
+      unknown.push(raw.trim());
+    }
+  }
+
+  if (unknown.length) {
+    throw new Error(
+      `Invalid severity filter: ${unknown.join(', ')}. ` +
+        `Use legacy [${SONAR_LEGACY_SEVERITIES.join(', ')}] ` +
+        `and/or impact [${SONAR_IMPACT_SEVERITIES.join(', ')}].`,
+    );
+  }
+
+  return { severities, impactSeverities };
+}
+
+/**
+ * @param {Record<string, string | number | boolean | undefined>} params
+ * @param {string} severityCsv
+ */
+export function withIssueSeverityFilter(params, severityCsv) {
+  const { severities, impactSeverities } = parseIssueSeverityFilter(severityCsv);
+  /** @type {Record<string, string | number | boolean | undefined>} */
+  const out = { ...params };
+  if (severities.length) out.severities = severities.join(',');
+  if (impactSeverities.length) out.impactSeverities = impactSeverities.join(',');
+  return out;
+}
+
 /** @param {string} impact Software quality impact (SECURITY, RELIABILITY, MAINTAINABILITY) */
 export function sonarImpactLabel(impact) {
   if (!impact) return 'sonar-maintainability';

--- a/scripts/sonar/pick-batch.mjs
+++ b/scripts/sonar/pick-batch.mjs
@@ -17,6 +17,7 @@ import {
   parseArgs,
   sonarFetch,
   sonarProjectKey,
+  withIssueSeverityFilter,
 } from './lib.mjs';
 
 const args = parseArgs(process.argv.slice(2));
@@ -89,13 +90,18 @@ async function loadIssues() {
   }
 
   if (ghIssues.length === 0) {
-    const data = await sonarFetch('/api/issues/search', {
-      componentKeys: sonarProjectKey(),
-      statuses: 'OPEN,CONFIRMED,REOPENED',
-      severities: 'BLOCKER,CRITICAL,MAJOR,HIGH',
-      ps: 100,
-      p: 1,
-    });
+    const data = await sonarFetch(
+      '/api/issues/search',
+      withIssueSeverityFilter(
+        {
+          componentKeys: sonarProjectKey(),
+          statuses: 'OPEN,CONFIRMED,REOPENED',
+          ps: 100,
+          p: 1,
+        },
+        'BLOCKER,CRITICAL,MAJOR,HIGH',
+      ),
+    );
     return data.issues || [];
   }
 

--- a/scripts/sonar/sync-github-issues.mjs
+++ b/scripts/sonar/sync-github-issues.mjs
@@ -18,10 +18,11 @@ import {
   sonarImpactLabel,
   sonarProjectKey,
   sonarSeverityLabel,
+  withIssueSeverityFilter,
 } from './lib.mjs';
 
 const args = parseArgs(process.argv.slice(2));
-const severities = (args.severity || 'BLOCKER,CRITICAL,MAJOR,HIGH').split(',').map((s) => s.trim());
+const severityFilter = args.severity || 'BLOCKER,CRITICAL,MAJOR,HIGH';
 const maxCreate = Number(args.max || 50);
 const dryRun = args['dry-run'] === 'true';
 
@@ -105,15 +106,20 @@ const candidates = [];
 let page = 1;
 
 while (candidates.length < maxCreate) {
-  const data = await sonarFetch('/api/issues/search', {
-    componentKeys: sonarProjectKey(),
-    statuses: 'OPEN,CONFIRMED,REOPENED',
-    severities: severities.join(','),
-    ps: 100,
-    p: page,
-    s: 'SEVERITY',
-    asc: 'false',
-  });
+  const data = await sonarFetch(
+    '/api/issues/search',
+    withIssueSeverityFilter(
+      {
+        componentKeys: sonarProjectKey(),
+        statuses: 'OPEN,CONFIRMED,REOPENED',
+        ps: 100,
+        p: page,
+        s: 'SEVERITY',
+        asc: 'false',
+      },
+      severityFilter,
+    ),
+  );
 
   const issues = data.issues || [];
   if (issues.length === 0) break;


### PR DESCRIPTION
## Summary

- **Sonar 400 fix:** `HIGH` no es severidad legacy — se mapea a `impactSeverities` (API `/api/issues/search`). Filtro `BLOCKER,CRITICAL,MAJOR,HIGH` → `severities` + `impactSeverities`.
- **Auto-merge:** tras crear la PR del loop, `gh pr merge --auto --squash` (merge cuando pase CI).
- **Branch fix:** Jenkins pasa `--branch="$BRANCH"` a `create-batch-pr.mjs` para que el head de la PR coincida con el push.

## Test plan

- [ ] Merge y re-run Jenkins `dome-quality-loop`
- [ ] Sync Sonar → GitHub sin 400
- [ ] PR generada con auto-merge activado (squash al pasar checks)
- [ ] Repo: **Allow auto-merge** + branch protection con CI en `main`