### PR TITLE
fix(ci): no commitear .jenkins-node en quality-loop PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ coverage
 .quality-loop/
 .jenkins-display.env
 .jenkins-tools/
+.jenkins-tools.env
+.jenkins-node/
 *.lcov
 
 # logs

--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -29,7 +29,7 @@ pipeline {
         ]) {
           sh '''
             set -eux
-            chmod +x scripts/jenkins/bootstrap-agent-tools.sh scripts/jenkins/agent-preflight.sh scripts/jenkins/gh-auth-env.sh scripts/jenkins/run-with-display.sh
+            chmod +x scripts/jenkins/bootstrap-agent-tools.sh scripts/jenkins/agent-preflight.sh scripts/jenkins/gh-auth-env.sh scripts/jenkins/run-with-display.sh scripts/jenkins/stage-loop-changes.sh
             bash scripts/jenkins/agent-preflight.sh "$PWD"
             cat .jenkins-display.env || true
           '''
@@ -164,7 +164,7 @@ pipeline {
             git config user.email "jenkins@dowi.es"
             git config user.name "Jenkins Quality Loop"
             git checkout -b "$BRANCH"
-            git add -A
+            bash scripts/jenkins/stage-loop-changes.sh "$PWD"
             git commit -m "fix(sonar): quality loop batch $(date -Iseconds)"
 
             JENKINS_GH_SETUP_GIT=1 bash scripts/jenkins/gh-auth-env.sh

--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -29,7 +29,7 @@ pipeline {
         ]) {
           sh '''
             set -eux
-            chmod +x scripts/jenkins/bootstrap-agent-tools.sh scripts/jenkins/agent-preflight.sh scripts/jenkins/gh-auth-env.sh scripts/jenkins/run-with-display.sh scripts/jenkins/stage-loop-changes.sh
+            bash scripts/jenkins/bootstrap-agent-tools.sh scripts/jenkins/agent-preflight.sh scripts/jenkins/gh-auth-env.sh scripts/jenkins/run-with-display.sh scripts/jenkins/stage-loop-changes.sh scripts/jenkins/source-tree-clean.sh
             bash scripts/jenkins/agent-preflight.sh "$PWD"
             cat .jenkins-display.env || true
           '''
@@ -125,7 +125,7 @@ pipeline {
     stage('Agent fix (Dome harness)') {
       when {
         expression {
-          return sh(script: 'git diff --quiet', returnStatus: true) == 0
+          return sh(script: 'bash scripts/jenkins/source-tree-clean.sh', returnStatus: true) == 0
         }
       }
       steps {
@@ -146,7 +146,7 @@ pipeline {
     stage('Verify & PR') {
       when {
         expression {
-          return sh(script: 'git diff --quiet', returnStatus: true) != 0
+          return sh(script: 'bash scripts/jenkins/source-tree-clean.sh', returnStatus: true) != 0
         }
       }
       steps {

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -55,6 +55,8 @@ El pipeline ejecuta **`scripts/jenkins/bootstrap-agent-tools.sh`** + **`agent-pr
 
 No hace falta instalar `gh` a mano en el agente salvo que `apt` y la descarga fallen (sin red).
 
+**Git commit:** el stage Verify & PR usa `stage-loop-changes.sh` — solo `app/`, `electron/`, `packages/`, `shared/`, `scripts/`, `docs/`. Nunca commitea `.jenkins-node/`, `.jenkins-tools/` ni artefactos del loop.
+
 ## Flujo del pipeline
 
 1. Sync Sonar → GitHub issues (`pnpm run sonar:sync-github`)

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -57,6 +57,8 @@ No hace falta instalar `gh` a mano en el agente salvo que `apt` y la descarga fa
 
 **Git commit:** el stage Verify & PR usa `stage-loop-changes.sh` — solo `app/`, `electron/`, `packages/`, `shared/`, `scripts/`, `docs/`. Nunca commitea `.jenkins-node/`, `.jenkins-tools/` ni artefactos del loop.
 
+**Cuándo corre el agente:** stage *Agent fix* solo si `source-tree-clean.sh` (sin diff en código fuente). El `chmod` del preflight u otros artefactos Jenkins **no** deben saltarse el agente. Si el fix mecánico (`void`) ya modificó archivos, el agente se omite a propósito y Verify & PR usa esos cambios.
+
 ## Flujo del pipeline
 
 1. Sync Sonar → GitHub issues (`pnpm run sonar:sync-github`)

--- a/scripts/jenkins/source-tree-clean.sh
+++ b/scripts/jenkins/source-tree-clean.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Exit 0 when no Sonar-fix-worthy changes under source trees; 1 otherwise.
+# Ignores Jenkins bootstrap (.jenkins-node), tool downloads, loop artifacts.
+set -euo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT"
+
+PATHS=(app electron packages shared scripts docs)
+
+if ! git diff --quiet -- "${PATHS[@]}"; then
+  exit 1
+fi
+
+untracked="$(git ls-files --others --exclude-standard -- "${PATHS[@]}" || true)"
+if [ -n "$untracked" ]; then
+  exit 1
+fi
+
+exit 0

--- a/scripts/jenkins/stage-loop-changes.sh
+++ b/scripts/jenkins/stage-loop-changes.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Stage only quality-loop source changes — never Jenkins bootstrap dirs.
+set -euo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT"
+
+PATHS=(app electron packages shared scripts docs)
+
+git add -u -- "${PATHS[@]}"
+
+for path in "${PATHS[@]}"; do
+  if [ -d "$path" ]; then
+    git add -- "$path"
+  fi
+done
+
+for junk in \
+  .jenkins-node \
+  .jenkins-tools \
+  .jenkins-tools.env \
+  .quality-loop \
+  coverage \
+  .jenkins-display.env; do
+  git reset HEAD -- "$junk" 2>/dev/null || true
+done
+
+if git diff --cached --quiet; then
+  echo "ERROR: nothing staged for quality-loop commit (check agent produced file changes)"
+  exit 1
+fi
+
+echo "Staged $(git diff --cached --name-only | wc -l | tr -d ' ') file(s):"
+git diff --cached --name-only


### PR DESCRIPTION
## Summary

Fixes two Jenkins quality-loop bugs:

1. **Push 100MB failure:** `git add -A` staged `.jenkins-node/bin/node`. Now `stage-loop-changes.sh` stages only source trees.
2. **Agent skipped incorrectly:** preflight `chmod +x scripts/jenkins/*` dirtied git → `git diff --quiet` failed → Agent fix skipped but Verify & PR ran with only chmod/jenkins junk. Now `source-tree-clean.sh` checks only `app/`, `electron/`, `packages/`, `shared/`, `scripts/`, `docs/`.

Agent still **skips intentionally** when mechanical void fix already changed source files.

## Test plan

- [ ] Merge and re-run `dome-quality-loop`
- [ ] Agent fix runs when batch needs harness (no void mechanical diff)
- [ ] Verify & PR push contains only Sonar fixes