### PR TITLE
fix(ci): preflight bootstrap-agent-tools args

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -29,7 +29,7 @@ pipeline {
         ]) {
           sh '''
             set -eux
-            bash scripts/jenkins/bootstrap-agent-tools.sh scripts/jenkins/agent-preflight.sh scripts/jenkins/gh-auth-env.sh scripts/jenkins/run-with-display.sh scripts/jenkins/stage-loop-changes.sh scripts/jenkins/source-tree-clean.sh
+            bash scripts/jenkins/bootstrap-agent-tools.sh "$PWD"
             bash scripts/jenkins/agent-preflight.sh "$PWD"
             cat .jenkins-display.env || true
           '''


### PR DESCRIPTION
## Summary

Fixes Jenkins preflight failure:

```
bootstrap-agent-tools.sh: line 7: cd: scripts/jenkins/agent-preflight.sh: Not a directory
```

Restore `bootstrap-agent-tools.sh "$PWD"` (only the workspace path, not other script paths).

## Test plan

- [ ] Merge and Build Now on `dome-quality-loop`
- [ ] Agent preflight completes