### PR TITLE
fix(sonar/ci): GitHub dedupe + Electron install en quality-loop

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -64,6 +64,8 @@ pipeline {
         sh '''
           set -eux
           pnpm install --frozen-lockfile --ignore-scripts
+          # Electron binary download (postinstall skipped above) — required for sonar:run-agent harness
+          pnpm rebuild electron
           pnpm run rebuild:natives
           pnpm run build:packages
         '''

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -52,6 +52,7 @@ El pipeline ejecuta **`scripts/jenkins/bootstrap-agent-tools.sh`** + **`agent-pr
 | **`gh`** | `apt-get` si hay root/sudo; si no, **descarga portable** a `.jenkins-tools/bin/` |
 | **`xvfb`** | `apt-get` si hay root/sudo; si no, warning (Electron usa `no-sandbox`) |
 | Node/pnpm | bootstrap en stage Setup |
+| **Electron** | `pnpm rebuild electron` tras `install --ignore-scripts` (harness headless) |
 
 No hace falta instalar `gh` a mano en el agente salvo que `apt` y la descarga fallen (sin red).
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "sonar:sync-github": "node scripts/sonar/sync-github-issues.mjs",
     "sonar:pick-batch": "node scripts/sonar/pick-batch.mjs",
     "sonar:close-resolved": "node scripts/sonar/close-resolved.mjs",
+    "sonar:close-github-duplicates": "node scripts/sonar/close-duplicate-github-issues.mjs",
     "sonar:run-agent": "node scripts/sonar/run-agent.mjs",
     "test": "pnpm run test:security && pnpm --filter @dome/agent-core run test",
     "test:studio": "node scripts/test-studio-validators.mjs",

--- a/scripts/sonar/close-duplicate-github-issues.mjs
+++ b/scripts/sonar/close-duplicate-github-issues.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Close duplicate open GitHub issues that share the same Sonar **Key** in the body.
+ * Keeps the oldest issue number per key; closes newer duplicates.
+ *
+ * Usage:
+ *   GITHUB_TOKEN=... node scripts/sonar/close-duplicate-github-issues.mjs [--dry-run]
+ */
+
+import { execFileSync } from 'node:child_process';
+import { extractSonarKey, githubFetch, githubRepo, parseArgs } from './lib.mjs';
+
+const dryRun = parseArgs(process.argv.slice(2))['dry-run'] === 'true';
+
+/** @type {Map<string, Array<{ number: number; createdAt: string }>>} */
+const byKey = new Map();
+
+let page = 1;
+while (true) {
+  const data = await githubFetch('GET', `/repos/${githubRepo()}/issues`, {
+    state: 'open',
+    labels: 'sonar',
+    per_page: '100',
+    page: String(page),
+    sort: 'created',
+    direction: 'asc',
+  });
+  if (!data || data.length === 0) break;
+  for (const issue of data) {
+    if (issue.pull_request) continue;
+    const key = extractSonarKey(issue.body || '');
+    if (!key) continue;
+    const list = byKey.get(key) || [];
+    list.push({ number: issue.number, createdAt: issue.created_at });
+    byKey.set(key, list);
+  }
+  if (data.length < 100) break;
+  page++;
+}
+
+/** @type {number[]} */
+const toClose = [];
+for (const [, issues] of byKey) {
+  if (issues.length <= 1) continue;
+  issues.sort((a, b) => a.number - b.number);
+  for (const dup of issues.slice(1)) {
+    toClose.push(dup.number);
+  }
+}
+
+toClose.sort((a, b) => a - b);
+console.log(`Found ${toClose.length} duplicate issue(s) to close (keeping oldest per Sonar key)`);
+
+for (const number of toClose) {
+  if (dryRun) {
+    console.log(`[dry-run] would close #${number}`);
+    continue;
+  }
+  execFileSync(
+    'gh',
+    [
+      'issue',
+      'close',
+      String(number),
+      '--repo',
+      githubRepo(),
+      '--comment',
+      'Duplicate Sonar sync issue (same **Key** as an older open issue). Closed by close-duplicate-github-issues.mjs.',
+    ],
+    { stdio: 'inherit' },
+  );
+}
+
+console.log(dryRun ? 'Dry run complete' : `Closed ${toClose.length} duplicate issue(s)`);

--- a/scripts/sonar/lib.mjs
+++ b/scripts/sonar/lib.mjs
@@ -212,7 +212,7 @@ export function sonarImpactLabel(impact) {
   return `sonar-${impact.toLowerCase()}`;
 }
 
-export const SONAR_KEY_RE = /sonarKey:\s*([A-Za-z0-9_-]+)/;
+export const SONAR_KEY_RE = /(?:sonarKey|\*\*Key\*\*):\s*([A-Za-z0-9-]+)/;
 
 /** @param {string} body */
 export function extractSonarKey(body) {


### PR DESCRIPTION
## Summary

### 1. Duplicate GitHub issues (Sync Sonar → GitHub)

- Bodies use `- **Key**: <uuid>` but dedupe regex looked for `sonarKey:` → always `Found 0 existing...` → duplicates every run (~50 pairs).
- Fix: `extractSonarKey` matches `**Key**:` and `sonarKey:`
- Cleanup: `pnpm run sonar:close-github-duplicates`

### 2. Agent fix fails — Electron not installed (build #8)

```
Error: Electron failed to install correctly, please delete node_modules/electron and try installing again
```

- Cause: `pnpm install --ignore-scripts` skips Electron binary download
- Fix: `pnpm rebuild electron` in Install stage before `rebuild:natives`

## After merge

```bash
export GITHUB_TOKEN=...
pnpm run sonar:close-github-duplicates -- --dry-run
pnpm run sonar:close-github-duplicates
```

Re-run `dome-quality-loop` — Sync should create 0 new issues; Agent fix should start Electron harness.

## Test plan

- [ ] Merge and close duplicate Sonar GH issues once
- [ ] Build Now on `dome-quality-loop`
- [ ] Sync logs `Found N existing...`, creates 0
- [ ] Agent fix (Dome harness) passes Electron startup