### PR TITLE
fix(sonar): no crear issues GH si backlog abierto >= max

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -88,6 +88,7 @@ pipeline {
                 const u = await sonarFetch('/api/authentication/validate');
                 console.log('OK: Sonar auth →', u.login || 'valid');
               "
+              pnpm run sonar:close-github-duplicates
               pnpm run sonar:sync-github -- --severity=BLOCKER,CRITICAL,MAJOR,HIGH --max=50
             '''
           }

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -77,7 +77,7 @@ pnpm run sonar:run-agent -- --dry-run
 
 ## Flujo del pipeline
 
-1. Sync Sonar → GitHub issues (`pnpm run sonar:sync-github`)
+1. Sync Sonar → GitHub issues (`pnpm run sonar:sync-github`) — mantiene **máx. 50 issues abiertas** con `sonarKey`; no crea más hasta que se cierren
 2. Pick batch → `.quality-loop/batch.json`
 3. Fix mecánico (`void` operator) si aplica
 4. **Agent fix** — `pnpm run sonar:run-agent` (MiniMax via Dome harness)

--- a/scripts/sonar/sync-github-issues.mjs
+++ b/scripts/sonar/sync-github-issues.mjs
@@ -4,6 +4,7 @@
  *
  * Usage:
  *   SONAR_TOKEN=... GITHUB_TOKEN=... node scripts/sonar/sync-github-issues.mjs [--severity=HIGH,MAJOR] [--max=50]
+ *   --max=N  Max open GitHub issues with sonarKey (default 50). Creates only until backlog < N.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -23,7 +24,8 @@ import {
 
 const args = parseArgs(process.argv.slice(2));
 const severityFilter = args.severity || 'BLOCKER,CRITICAL,MAJOR,HIGH';
-const maxCreate = Number(args.max || 50);
+/** @type {number} Max open tracked issues before we stop creating new ones */
+const maxOpen = Number(args.max || 50);
 const dryRun = args['dry-run'] === 'true';
 
 /** @type {Set<string>} */
@@ -99,13 +101,23 @@ async function createGithubIssue(issue) {
 }
 
 await loadExistingGithubIssues();
-console.log(`Found ${existingKeys.size} existing open GitHub issues with sonarKey`);
+const openTracked = existingKeys.size;
+const createBudget = Math.max(0, maxOpen - openTracked);
+
+console.log(
+  `Found ${openTracked} existing open GitHub issues with sonarKey (cap ${maxOpen}, create budget ${createBudget})`,
+);
+
+if (createBudget === 0) {
+  console.log('Open backlog at cap — skipping create until issues are closed/merged');
+  process.exit(0);
+}
 
 /** @type {Array<Record<string, unknown>>} */
 const candidates = [];
 let page = 1;
 
-while (candidates.length < maxCreate) {
+while (candidates.length < createBudget) {
   const data = await sonarFetch(
     '/api/issues/search',
     withIssueSeverityFilter(
@@ -127,7 +139,7 @@ while (candidates.length < maxCreate) {
   for (const issue of issues) {
     if (existingKeys.has(issue.key)) continue;
     candidates.push(issue);
-    if (candidates.length >= maxCreate) break;
+    if (candidates.length >= createBudget) break;
   }
 
   if (issues.length < 100) break;

--- a/scripts/sonar/sync-github-issues.mjs
+++ b/scripts/sonar/sync-github-issues.mjs
@@ -4,7 +4,9 @@
  *
  * Usage:
  *   SONAR_TOKEN=... GITHUB_TOKEN=... node scripts/sonar/sync-github-issues.mjs [--severity=HIGH,MAJOR] [--max=50]
- *   --max=N  Max open GitHub issues with sonarKey (default 50). Creates only until backlog < N.
+ *
+ * --max caps total open GitHub issues with label `sonar` (default 50). No new issues are
+ * created while at or above the cap.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -24,12 +26,12 @@ import {
 
 const args = parseArgs(process.argv.slice(2));
 const severityFilter = args.severity || 'BLOCKER,CRITICAL,MAJOR,HIGH';
-/** @type {number} Max open tracked issues before we stop creating new ones */
 const maxOpen = Number(args.max || 50);
 const dryRun = args['dry-run'] === 'true';
 
 /** @type {Set<string>} */
 const existingKeys = new Set();
+let openSonarCount = 0;
 
 async function loadExistingGithubIssues() {
   let page = 1;
@@ -42,6 +44,8 @@ async function loadExistingGithubIssues() {
     });
     if (!data || data.length === 0) break;
     for (const issue of data) {
+      if (issue.pull_request) continue;
+      openSonarCount++;
       const key = extractSonarKey(issue.body || '');
       if (key) existingKeys.add(key);
     }
@@ -101,15 +105,14 @@ async function createGithubIssue(issue) {
 }
 
 await loadExistingGithubIssues();
-const openTracked = existingKeys.size;
-const createBudget = Math.max(0, maxOpen - openTracked);
-
+const createBudget = Math.max(0, maxOpen - openSonarCount);
 console.log(
-  `Found ${openTracked} existing open GitHub issues with sonarKey (cap ${maxOpen}, create budget ${createBudget})`,
+  `Found ${existingKeys.size} existing open GitHub issues with sonarKey ` +
+    `(${openSonarCount} total open with label sonar, cap ${maxOpen}, create budget ${createBudget})`,
 );
 
 if (createBudget === 0) {
-  console.log('Open backlog at cap — skipping create until issues are closed/merged');
+  console.log('Sync complete: at cap, created 0 GitHub issue(s)');
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

`--max=50` en sync was interpreted as "create up to 50 per run", not a backlog cap.

Now:
- Counts open GitHub issues with `sonarKey` in body
- `create budget = max(0, max - open)`
- If budget is 0 → log and exit without creating

Example log when full:
```
Found 50 existing open GitHub issues with sonarKey (cap 50, create budget 0)
Open backlog at cap — skipping create until issues are closed/merged
```

## Test plan

- [ ] Merge and re-run Sync Sonar → GitHub with 50 open issues → creates 0
- [ ] Close one issue → next run creates at most 1