### PR TITLE
fix(ci): libglib/GTK deps for Electron harness en Jenkins

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -66,6 +66,7 @@ pipeline {
           pnpm install --frozen-lockfile --ignore-scripts
           # Electron binary download (postinstall skipped above) — required for sonar:run-agent harness
           pnpm rebuild electron
+          bash scripts/jenkins/verify-electron-runtime.sh "$PWD"
           pnpm run rebuild:natives
           pnpm run build:packages
         '''
@@ -137,6 +138,7 @@ pipeline {
           sh '''
             set -eux
             export SONAR_LOOP_MODEL="${SONAR_LOOP_MODEL:-MiniMax-M2.7-highspeed}"
+            bash scripts/jenkins/verify-electron-runtime.sh "$PWD"
             bash scripts/jenkins/run-with-display.sh \
               pnpm run sonar:run-agent -- --batch=.quality-loop/batch.json
           '''

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -51,6 +51,7 @@ El pipeline ejecuta **`scripts/jenkins/bootstrap-agent-tools.sh`** + **`agent-pr
 | `git`, `curl` | deben existir en la imagen (Jenkins estándar) |
 | **`gh`** | `apt-get` si hay root/sudo; si no, **descarga portable** a `.jenkins-tools/bin/` |
 | **`xvfb`** | `apt-get` si hay root/sudo; si no, warning (Electron usa `no-sandbox`) |
+| **Electron runtime** | `libglib2.0-0`, GTK, NSS, etc. vía `bootstrap-agent-tools.sh` (requiere apt/root en el agente) |
 | Node/pnpm | bootstrap en stage Setup |
 | **Electron** | `pnpm rebuild electron` tras `install --ignore-scripts` (harness headless) |
 

--- a/scripts/jenkins/bootstrap-agent-tools.sh
+++ b/scripts/jenkins/bootstrap-agent-tools.sh
@@ -28,6 +28,9 @@ run_apt() {
     return 1
   fi
   local pkgs=( "$@" )
+  if [ "${#pkgs[@]}" -eq 0 ]; then
+    return 0
+  fi
   if [ "$(id -u)" = "0" ]; then
     export DEBIAN_FRONTEND=noninteractive
     apt-get update -qq
@@ -43,6 +46,38 @@ run_apt() {
   return 1
 }
 
+# Electron headless harness (sonar:run-agent) on Debian/Ubuntu — libglib, GTK, NSS, etc.
+ELECTRON_RUNTIME_PKGS=(
+  libglib2.0-0
+  libnss3
+  libnspr4
+  libatk1.0-0
+  libatk-bridge2.0-0
+  libatspi2.0-0
+  libgtk-3-0
+  libx11-6
+  libx11-xcb1
+  libxcb1
+  libxcomposite1
+  libxdamage1
+  libxext6
+  libxfixes3
+  libxrandr2
+  libxss1
+  libxtst6
+  libgbm1
+  libdrm2
+  libasound2
+  libpango-1.0-0
+  libcairo2
+  libxkbcommon0
+  libdbus-1-3
+  libexpat1
+  libfontconfig1
+  libfreetype6
+  ca-certificates
+)
+
 # shellcheck source=/dev/null
 set -a
 # shellcheck disable=SC1091
@@ -54,12 +89,17 @@ command -v gh >/dev/null 2>&1 || need_apt+=( gh )
 command -v Xvfb >/dev/null 2>&1 || command -v xvfb-run >/dev/null 2>&1 || need_apt+=( xvfb )
 command -v xdpyinfo >/dev/null 2>&1 || need_apt+=( x11-xserver-utils )
 
+if [ "$(uname -s)" = "Linux" ]; then
+  need_apt+=( "${ELECTRON_RUNTIME_PKGS[@]}" )
+fi
+
 if [ "${#need_apt[@]}" -gt 0 ]; then
+  mapfile -t need_apt < <(printf '%s\n' "${need_apt[@]}" | awk '!seen[$0]++')
   echo "Trying apt-get for: ${need_apt[*]}"
   if run_apt "${need_apt[@]}"; then
-    echo "OK: apt-get installed ${need_apt[*]}"
+    echo "OK: apt-get installed ${#need_apt[@]} package(s)"
   else
-    echo "apt-get skipped (no root/sudo or not Debian/Ubuntu)"
+    echo "WARN: apt-get skipped (no root/sudo or not Debian/Ubuntu) — Electron harness may fail without libglib/GTK"
   fi
 fi
 

--- a/scripts/jenkins/verify-electron-runtime.sh
+++ b/scripts/jenkins/verify-electron-runtime.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Verify Electron binary and Linux shared libraries (after pnpm rebuild electron).
+set -euo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT"
+
+if [ ! -d node_modules/electron ]; then
+  echo "ERROR: node_modules/electron missing — run pnpm rebuild electron first"
+  exit 1
+fi
+
+ELECTRON="$(node -p "require('electron')")"
+echo "Electron binary: ${ELECTRON}"
+
+if [ "$(uname -s)" = "Linux" ] && command -v ldd >/dev/null 2>&1; then
+  missing="$(ldd "$ELECTRON" 2>&1 | grep 'not found' || true)"
+  if [ -n "$missing" ]; then
+    echo "ERROR: Electron missing shared libraries (install via bootstrap-agent-tools.sh / apt):"
+    echo "$missing"
+    exit 1
+  fi
+fi
+
+"$ELECTRON" --version
+echo "OK: Electron runtime ready"


### PR DESCRIPTION
## Summary

Fixes Agent fix failure:

```
electron: error while loading shared libraries: libglib-2.0.so.0: cannot open shared object file
```

- `bootstrap-agent-tools.sh` installs Electron runtime packages via apt (libglib2.0-0, GTK, NSS, …)
- New `verify-electron-runtime.sh` — `ldd` + `electron --version` after Install and before harness
- Fails fast in Install if libs still missing

## Jenkins agent requirement

The agent needs **root or passwordless sudo** for `apt-get`, or bake these packages into the Docker image:

`libglib2.0-0 libnss3 libgtk-3-0 libgbm1 libasound2 xvfb` (+ rest in bootstrap script)

## Test plan

- [ ] Merge and re-run `dome-quality-loop`
- [ ] Install stage: `OK: Electron runtime ready`
- [ ] Agent fix (Dome harness) starts without libglib error