### PR TITLE
fix(jenkins): sonar loop Node harness for Coolify without root

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -13,6 +13,7 @@ pipeline {
     SONAR_HOST_URL = 'https://sonar.dowi.es'
     GITHUB_REPOSITORY = 'maxprain12/dome'
     XVFB_DISPLAY = ':99'
+    SONAR_LOOP_NODE = '1'
   }
 
   stages {
@@ -64,11 +65,11 @@ pipeline {
         sh '''
           set -eux
           pnpm install --frozen-lockfile --ignore-scripts
-          # Electron binary download (postinstall skipped above) — required for sonar:run-agent harness
-          pnpm rebuild electron
-          bash scripts/jenkins/verify-electron-runtime.sh "$PWD"
-          pnpm run rebuild:natives
           pnpm run build:packages
+          # Node harness (SONAR_LOOP_NODE) — rebuild better-sqlite3 for Node ABI, not Electron
+          npm rebuild better-sqlite3
+          node -e "require('better-sqlite3')"
+          echo "OK: better-sqlite3 for Node harness"
         '''
       }
     }
@@ -138,9 +139,7 @@ pipeline {
           sh '''
             set -eux
             export SONAR_LOOP_MODEL="${SONAR_LOOP_MODEL:-MiniMax-M2.7-highspeed}"
-            bash scripts/jenkins/verify-electron-runtime.sh "$PWD"
-            bash scripts/jenkins/run-with-display.sh \
-              pnpm run sonar:run-agent -- --batch=.quality-loop/batch.json
+            pnpm run sonar:run-agent -- --batch=.quality-loop/batch.json
           '''
         }
         archiveArtifacts artifacts: '.quality-loop/agent-run.json', allowEmptyArchive: true

--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -66,6 +66,7 @@ pipeline {
           pnpm install --frozen-lockfile --ignore-scripts
           # Electron binary download (postinstall skipped above) — required for sonar:run-agent harness
           pnpm rebuild electron
+          bash scripts/jenkins/verify-electron-runtime.sh "$PWD"
           pnpm run rebuild:natives
           pnpm run build:packages
         '''
@@ -137,6 +138,7 @@ pipeline {
           sh '''
             set -eux
             export SONAR_LOOP_MODEL="${SONAR_LOOP_MODEL:-MiniMax-M2.7-highspeed}"
+            bash scripts/jenkins/verify-electron-runtime.sh "$PWD"
             bash scripts/jenkins/run-with-display.sh \
               pnpm run sonar:run-agent -- --batch=.quality-loop/batch.json
           '''

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -51,6 +51,7 @@ El pipeline ejecuta **`scripts/jenkins/bootstrap-agent-tools.sh`** + **`agent-pr
 | `git`, `curl` | deben existir en la imagen (Jenkins estándar) |
 | **`gh`** | `apt-get` si hay root/sudo; si no, **descarga portable** a `.jenkins-tools/bin/` |
 | **`xvfb`** | `apt-get` si hay root/sudo; si no, warning (Electron usa `no-sandbox`) |
+| **Electron runtime** | `libglib2.0-0`, GTK, NSS, etc. vía `bootstrap-agent-tools.sh` (requiere apt/root en el agente) |
 | Node/pnpm | bootstrap en stage Setup |
 | **Electron** | `pnpm rebuild electron` tras `install --ignore-scripts` (harness headless) |
 

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -8,7 +8,7 @@ Automated correction loop: SonarQube → GitHub Issues → Dome agent (MiniMax) 
 |-----------|------|
 | Jenkins `dome-sonar` | Sonar analysis on push to `main` |
 | Jenkins `dome-quality-loop` | Cron ~6h: sync issues, pick batch, mechanical fix, **Dome harness**, PR |
-| Dome CLI | `pnpm run sonar:run-agent` — Electron headless + `@dome/agent-core` + MiniMax |
+| Dome CLI | `pnpm run sonar:run-agent` — `@dome/agent-core` + MiniMax (Node en CI; Electron en local) |
 
 ## Jenkins setup
 
@@ -50,12 +50,26 @@ El pipeline ejecuta **`scripts/jenkins/bootstrap-agent-tools.sh`** + **`agent-pr
 |-------------|----------------|
 | `git`, `curl` | deben existir en la imagen (Jenkins estándar) |
 | **`gh`** | `apt-get` si hay root/sudo; si no, **descarga portable** a `.jenkins-tools/bin/` |
-| **`xvfb`** | `apt-get` si hay root/sudo; si no, warning (Electron usa `no-sandbox`) |
-| **Electron runtime** | `libglib2.0-0`, GTK, NSS, etc. vía `bootstrap-agent-tools.sh` (requiere apt/root en el agente) |
+| **`xvfb`** | opcional (solo si usas harness Electron local en Linux headless) |
 | Node/pnpm | bootstrap en stage Setup |
-| **Electron** | `pnpm rebuild electron` tras `install --ignore-scripts` (harness headless) |
+| **Sonar agent (CI)** | `SONAR_LOOP_NODE=1` — harness **Node puro** (`main-node.cjs`), sin binario Electron ni `apt` |
+| **better-sqlite3** | `npm rebuild better-sqlite3` en Setup (ABI de Node, no Electron) |
 
 No hace falta instalar `gh` a mano en el agente salvo que `apt` y la descarga fallen (sin red).
+
+### Coolify / contenedor sin root
+
+En Coolify (o cualquier agente Jenkins **sin** `sudo`/`apt`), el pipeline exporta **`SONAR_LOOP_NODE=1`**. El stage *Agent fix* usa el harness **Node puro** (`electron/sonar-loop/main-node.cjs`): mock de `require('electron')`, SQLite con `better-sqlite3` compilado para **Node** (`npm rebuild better-sqlite3`), sin descargar el binario Electron ni instalar `libglib2.0`.
+
+No se requiere `xvfb`, `verify-electron-runtime.sh` ni libs GTK/NSS del sistema.
+
+**Local con el mismo modo que CI:**
+
+```bash
+export SONAR_LOOP_NODE=1
+npm rebuild better-sqlite3   # una vez, ABI de tu Node (no Electron)
+pnpm run sonar:run-agent -- --dry-run
+```
 
 **Git commit:** el stage Verify & PR usa `stage-loop-changes.sh` — solo `app/`, `electron/`, `packages/`, `shared/`, `scripts/`, `docs/`. Nunca commitea `.jenkins-node/`, `.jenkins-tools/` ni artefactos del loop.
 

--- a/electron/sonar-loop/main-node.cjs
+++ b/electron/sonar-loop/main-node.cjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+'use strict';
+/* eslint-disable no-console */
+/**
+ * Node-only Sonar loop harness (no Electron binary — for CI/Coolify without root).
+ * Usage: node electron/sonar-loop/main-node.cjs -- --batch=.quality-loop/batch.json
+ */
+process.env.SONAR_LOOP_NODE = '1';
+
+const { bootstrapSonarLoopNodeEnv } = require('./node-env.cjs');
+bootstrapSonarLoopNodeEnv();
+
+const { runSonarLoopMain } = require('./run-main.cjs');
+
+runSonarLoopMain(process.argv.slice(2))
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error('[SonarLoop] Fatal:', err);
+    process.exit(1);
+  });

--- a/electron/sonar-loop/main.cjs
+++ b/electron/sonar-loop/main.cjs
@@ -5,7 +5,6 @@
  */
 const path = require('path');
 const os = require('os');
-const fs = require('fs');
 
 const { loadDotenv } = require('../bench/load-env.cjs');
 loadDotenv();
@@ -20,42 +19,12 @@ app.setPath('userData', sonarUserData);
 app.disableHardwareAcceleration();
 app.commandLine.appendSwitch('no-sandbox');
 
-const { parseSonarLoopArgs } = require('./parse-args.cjs');
-const { applyProviderSettings } = require('./provider-config.cjs');
-const { runSonarBatch } = require('./run-batch.cjs');
+const { runSonarLoopMain } = require('./run-main.cjs');
 
-const database = require('../core/database.cjs');
-const runEngine = require('../agents/run-engine.cjs');
-
-async function main() {
-  const args = parseSonarLoopArgs(process.argv.slice(2));
-  console.log('[SonarLoop] userData:', sonarUserData);
-
-  database.initDatabase();
-  runEngine.init(null, database, null);
-
-  if (!args.dryRun) {
-    applyProviderSettings(args.provider, args.model);
-  } else {
-    console.log('[SonarLoop] Dry run — no API calls');
-  }
-
-  const result = await runSonarBatch(args);
-  const outDir = path.resolve('.quality-loop');
-  fs.mkdirSync(outDir, { recursive: true });
-  fs.writeFileSync(path.join(outDir, 'agent-run.json'), `${JSON.stringify(result, null, 2)}\n`);
-
-  console.log('[SonarLoop] Wrote .quality-loop/agent-run.json');
-  if (result.error) {
-    console.error('[SonarLoop] Failed:', result.error);
+app.whenReady()
+  .then(() => runSonarLoopMain(process.argv.slice(2)))
+  .then((code) => app.exit(code))
+  .catch((err) => {
+    console.error('[SonarLoop] Fatal:', err);
     app.exit(1);
-    return;
-  }
-  console.log('[SonarLoop] Done.');
-  app.exit(0);
-}
-
-app.whenReady().then(main).catch((err) => {
-  console.error('[SonarLoop] Fatal:', err);
-  app.exit(1);
-});
+  });

--- a/electron/sonar-loop/node-env.cjs
+++ b/electron/sonar-loop/node-env.cjs
@@ -1,0 +1,71 @@
+'use strict';
+/**
+ * Headless Node bootstrap for sonar-loop (CI/Coolify without Electron binary or root).
+ * Mocks `require('electron')` before database/tools load.
+ */
+const path = require('path');
+const os = require('os');
+const Module = require('module');
+
+/** @param {string} userData */
+function installElectronMock(userData) {
+  const electronStub = {
+    app: {
+      getPath(name) {
+        switch (name) {
+          case 'userData':
+            return userData;
+          case 'home':
+            return os.homedir();
+          case 'temp':
+            return os.tmpdir();
+          case 'appData':
+          case 'userCache':
+          case 'logs':
+            return userData;
+          default:
+            return userData;
+        }
+      },
+      setPath() {},
+      whenReady: () => Promise.resolve(),
+      exit(code) {
+        process.exit(typeof code === 'number' ? code : 0);
+      },
+      disableHardwareAcceleration() {},
+      commandLine: { appendSwitch() {} },
+      isReady: () => true,
+    },
+    dialog: {
+      showOpenDialog: async () => ({ canceled: true, filePaths: [] }),
+      showSaveDialog: async () => ({ canceled: true, filePath: '' }),
+      showMessageBox: async () => ({ response: 0 }),
+    },
+    ipcMain: { handle() {}, on() {} },
+    BrowserWindow: class BrowserWindow {},
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function loadWithElectronMock(request, parent, isMain) {
+    if (request === 'electron') {
+      return electronStub;
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+}
+
+/** @returns {string} userData path */
+function bootstrapSonarLoopNodeEnv() {
+  const { loadDotenv } = require('../bench/load-env.cjs');
+  loadDotenv();
+
+  const userData =
+    process.env.DOME_SONAR_LOOP_USER_DATA || path.join(os.homedir(), '.dome-sonar-loop');
+  process.env.DOME_SONAR_LOOP_USER_DATA = userData;
+  process.env.DOME_BENCH = '1';
+
+  installElectronMock(userData);
+  return userData;
+}
+
+module.exports = { bootstrapSonarLoopNodeEnv, installElectronMock };

--- a/electron/sonar-loop/run-main.cjs
+++ b/electron/sonar-loop/run-main.cjs
@@ -1,0 +1,47 @@
+'use strict';
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+
+const { parseSonarLoopArgs } = require('./parse-args.cjs');
+const { applyProviderSettings } = require('./provider-config.cjs');
+const { runSonarBatch } = require('./run-batch.cjs');
+
+const database = require('../core/database.cjs');
+const runEngine = require('../agents/run-engine.cjs');
+
+/**
+ * @param {string[]} argv CLI args after `--`
+ * @returns {Promise<number>} exit code
+ */
+async function runSonarLoopMain(argv) {
+  const args = parseSonarLoopArgs(argv);
+  const userData =
+    process.env.DOME_SONAR_LOOP_USER_DATA || path.join(require('os').homedir(), '.dome-sonar-loop');
+  console.log('[SonarLoop] userData:', userData);
+  console.log('[SonarLoop] runtime:', process.env.SONAR_LOOP_NODE === '1' ? 'node' : 'electron');
+
+  database.initDatabase();
+  runEngine.init(null, database, null);
+
+  if (!args.dryRun) {
+    applyProviderSettings(args.provider, args.model);
+  } else {
+    console.log('[SonarLoop] Dry run — no API calls');
+  }
+
+  const result = await runSonarBatch(args);
+  const outDir = path.resolve('.quality-loop');
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'agent-run.json'), `${JSON.stringify(result, null, 2)}\n`);
+
+  console.log('[SonarLoop] Wrote .quality-loop/agent-run.json');
+  if (result.error) {
+    console.error('[SonarLoop] Failed:', result.error);
+    return 1;
+  }
+  console.log('[SonarLoop] Done.');
+  return 0;
+}
+
+module.exports = { runSonarLoopMain };

--- a/scripts/jenkins/bootstrap-agent-tools.sh
+++ b/scripts/jenkins/bootstrap-agent-tools.sh
@@ -28,6 +28,9 @@ run_apt() {
     return 1
   fi
   local pkgs=( "$@" )
+  if [ "${#pkgs[@]}" -eq 0 ]; then
+    return 0
+  fi
   if [ "$(id -u)" = "0" ]; then
     export DEBIAN_FRONTEND=noninteractive
     apt-get update -qq
@@ -43,6 +46,38 @@ run_apt() {
   return 1
 }
 
+# Electron headless harness (sonar:run-agent) on Debian/Ubuntu — libglib, GTK, NSS, etc.
+ELECTRON_RUNTIME_PKGS=(
+  libglib2.0-0
+  libnss3
+  libnspr4
+  libatk1.0-0
+  libatk-bridge2.0-0
+  libatspi2.0-0
+  libgtk-3-0
+  libx11-6
+  libx11-xcb1
+  libxcb1
+  libxcomposite1
+  libxdamage1
+  libxext6
+  libxfixes3
+  libxrandr2
+  libxss1
+  libxtst6
+  libgbm1
+  libdrm2
+  libasound2
+  libpango-1.0-0
+  libcairo2
+  libxkbcommon0
+  libdbus-1-3
+  libexpat1
+  libfontconfig1
+  libfreetype6
+  ca-certificates
+)
+
 # shellcheck source=/dev/null
 set -a
 # shellcheck disable=SC1091
@@ -54,12 +89,17 @@ command -v gh >/dev/null 2>&1 || need_apt+=( gh )
 command -v Xvfb >/dev/null 2>&1 || command -v xvfb-run >/dev/null 2>&1 || need_apt+=( xvfb )
 command -v xdpyinfo >/dev/null 2>&1 || need_apt+=( x11-xserver-utils )
 
+if [ "$(uname -s)" = "Linux" ]; then
+  need_apt+=( "${ELECTRON_RUNTIME_PKGS[@]}" )
+fi
+
 if [ "${#need_apt[@]}" -gt 0 ]; then
+  mapfile -t need_apt < <(printf '%s\n' "${need_apt[@]}" | awk '!seen[$0]++')
   echo "Trying apt-get for: ${need_apt[*]}"
   if run_apt "${need_apt[@]}"; then
-    echo "OK: apt-get installed ${need_apt[*]}"
+    echo "OK: apt-get installed ${#need_apt[@]} package(s)"
   else
-    echo "apt-get skipped (no root/sudo or not Debian/Ubuntu)"
+    echo "WARN: apt-get skipped (no root/sudo or not Debian/Ubuntu) — Electron harness may fail without libglib/GTK"
   fi
 fi
 

--- a/scripts/jenkins/verify-electron-runtime.sh
+++ b/scripts/jenkins/verify-electron-runtime.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Verify Electron binary and Linux shared libraries (after pnpm rebuild electron).
+set -euo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT"
+
+if [ ! -d node_modules/electron ]; then
+  echo "ERROR: node_modules/electron missing — run pnpm rebuild electron first"
+  exit 1
+fi
+
+ELECTRON="$(node -p "require('electron')")"
+echo "Electron binary: ${ELECTRON}"
+
+if [ "$(uname -s)" = "Linux" ] && command -v ldd >/dev/null 2>&1; then
+  missing="$(ldd "$ELECTRON" 2>&1 | grep 'not found' || true)"
+  if [ -n "$missing" ]; then
+    echo "ERROR: Electron missing shared libraries (install via bootstrap-agent-tools.sh / apt):"
+    echo "$missing"
+    exit 1
+  fi
+fi
+
+"$ELECTRON" --version
+echo "OK: Electron runtime ready"

--- a/scripts/sonar/run-agent.mjs
+++ b/scripts/sonar/run-agent.mjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 /**
- * Run Dome Sonar quality-loop agent (Electron headless harness + MiniMax).
+ * Run Dome Sonar quality-loop agent.
+ *
+ * - Default (local): Electron headless harness
+ * - CI / Coolify (SONAR_LOOP_NODE=1 or JENKINS_URL): pure Node — no Electron binary, no apt/root
  *
  * Usage:
  *   MINIMAX_API_KEY=... pnpm run sonar:run-agent -- --batch=.quality-loop/batch.json
- *   pnpm run sonar:run-agent -- --provider minimax --model MiniMax-M2.7-highspeed --dry-run
+ *   SONAR_LOOP_NODE=1 pnpm run sonar:run-agent -- --dry-run
  */
 import { spawn } from 'node:child_process';
 import path from 'node:path';
@@ -13,25 +16,31 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, '../..');
 
-const electronBin = path.join(ROOT, 'node_modules', 'electron', 'cli.js');
-const mainCjs = path.join(ROOT, 'electron', 'sonar-loop', 'main.cjs');
-
 const extraArgs = process.argv.slice(2);
 const dash = extraArgs.indexOf('--');
 const flags = dash >= 0 ? extraArgs.slice(dash + 1) : extraArgs;
 
-const child = spawn(
-  process.execPath,
-  [electronBin, mainCjs, ...flags],
-  {
-    cwd: ROOT,
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      NODE_ENV: 'development',
-      ELECTRON_RUN_AS_NODE: undefined,
-    },
+const useNodeHarness =
+  process.env.SONAR_LOOP_NODE === '1' ||
+  process.env.SONAR_LOOP_NODE === 'true' ||
+  Boolean(process.env.JENKINS_URL);
+
+const entry = useNodeHarness
+  ? path.join(ROOT, 'electron', 'sonar-loop', 'main-node.cjs')
+  : path.join(ROOT, 'electron', 'sonar-loop', 'main.cjs');
+
+const spawnArgs = useNodeHarness
+  ? [entry, ...flags]
+  : [path.join(ROOT, 'node_modules', 'electron', 'cli.js'), entry, ...flags];
+
+const child = spawn(process.execPath, spawnArgs, {
+  cwd: ROOT,
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    NODE_ENV: 'development',
+    ...(useNodeHarness ? { SONAR_LOOP_NODE: '1' } : { ELECTRON_RUN_AS_NODE: undefined }),
   },
-);
+});
 
 child.on('exit', (code) => process.exit(code ?? 1));


### PR DESCRIPTION
## Summary
- Adds a pure-Node Sonar quality-loop harness (`main-node.cjs` + `node-env.cjs` electron mock) for CI agents without root/apt.
- `Jenkinsfile.quality-loop` sets `SONAR_LOOP_NODE=1`, rebuilds `better-sqlite3` for Node ABI, and drops Electron binary + `verify-electron-runtime.sh`.
- `run-agent.mjs` auto-selects Node mode when `SONAR_LOOP_NODE=1` or `JENKINS_URL` is set.

## Test plan
- [ ] Re-run `dome-quality-loop` on Coolify — Agent fix stage should start without `libglib-2.0.so.0` / Electron install errors
- [ ] Confirm Setup logs `OK: better-sqlite3 for Node harness`
- [ ] Local: `SONAR_LOOP_NODE=1 npm rebuild better-sqlite3 && pnpm run sonar:run-agent -- --dry-run`