### PR TITLE
fix(sonar): parse --key=value CLI args for Jenkins PR creation

### DIFF
--- a/scripts/sonar/create-batch-pr.mjs
+++ b/scripts/sonar/create-batch-pr.mjs
@@ -50,6 +50,8 @@ const prUrl = execFileSync(
     'create',
     '--repo',
     repo,
+    '--base',
+    process.env.SONAR_LOOP_BASE_BRANCH || 'main',
     '--title',
     'fix(sonar): quality loop batch',
     '--body-file',

--- a/scripts/sonar/lib.mjs
+++ b/scripts/sonar/lib.mjs
@@ -130,7 +130,13 @@ export function parseArgs(argv) {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (!arg.startsWith('--')) continue;
-    const key = arg.slice(2);
+    const raw = arg.slice(2);
+    const eq = raw.indexOf('=');
+    if (eq !== -1) {
+      out[raw.slice(0, eq)] = raw.slice(eq + 1);
+      continue;
+    }
+    const key = raw;
     const next = argv[i + 1];
     if (next && !next.startsWith('--')) {
       out[key] = next;


### PR DESCRIPTION
## Summary
- `parseArgs` now supports `--key=value` (used by Jenkins: `--branch=...`, `--max=50`, etc.)
- `create-batch-pr.mjs` passes explicit `--base main` to `gh pr create`

## Context
Quality loop run pushed `fix/sonar-batch-20260704-0136` with valid S2819 fixes but PR creation failed because `create-batch-pr` ignored `--branch=` and tried `fix/sonar-batch-2026-07-04T01-36-23`.

## Test plan
- [ ] Merge and re-run `dome-quality-loop`, or manually: `gh pr create --head fix/sonar-batch-20260704-0136 --base main` for the already-pushed branch