### PR TITLE
fix(sonar): close-resolved 403 permissions guidance

### DIFF
--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -25,8 +25,15 @@ Automated correction loop: SonarQube → GitHub Issues → Dome agent (MiniMax) 
 | **SonarQube server `SonarQube`** | Plugin (Manage Jenkins → SonarQube) | Token para Web API (`SONAR_AUTH_TOKEN`) — **mismo que job `dome-sonar`** |
 | **`github-quality-loop`** | GitHub PAT | `repo` + issues/PRs (`GITHUB_TOKEN`) |
 | **`minimax-api-key`** | Secret text | API MiniMax (`MINIMAX_API_KEY`) |
+| **`sonar-issue-admin`** *(opcional, local)* | User token Sonar (`squ_…`) exportado como `SONAR_ISSUE_ADMIN_TOKEN` | Solo stage *Close resolved* si el token del server no tiene **Administer Issues** |
 
 Los stages Sonar usan `withSonarQubeEnv('SonarQube')`, no la credential suelta `sonar`.
+
+**Stage *Close resolved*:** `POST /api/issues/do_transition` exige permiso **Administer Issues** en el proyecto. Un *Global Analysis Token* (`sqa_…`) devuelve `403 Insufficient privileges`. Opciones:
+
+1. En SonarQube → proyecto → **Permissions** → conceder **Administer Issues** al usuario del token Jenkins.
+2. Exportar `SONAR_ISSUE_ADMIN_TOKEN` con un **User Token** (`squ_…`) de un bot con ese permiso (p. ej. en el shell del stage Jenkins).
+3. Omitir el stage: `SONAR_CLOSE_RESOLVED=0` (las issues se cierran solas en el próximo análisis `dome-sonar` tras merge).
 
 **Local / fallback:** exporta `SONAR_TOKEN` (user token de SonarQube → My Account → Security). La Web API usa **Basic auth** (`token:` como login). Solo SonarQube ≥ 10.6 acepta `Bearer`; opcional `SONAR_AUTH_SCHEME=bearer`.
 

--- a/scripts/sonar/close-resolved.mjs
+++ b/scripts/sonar/close-resolved.mjs
@@ -2,8 +2,12 @@
 /**
  * Mark Sonar issues as RESOLVED when linked GitHub issues were closed by a merged PR.
  *
+ * Requires a Sonar **User Token** (squ_…) with **Administer Issues** on the project
+ * (not a Global Analysis Token sqa_…). Optional override: SONAR_ISSUE_ADMIN_TOKEN.
+ *
  * Usage:
  *   SONAR_TOKEN=... GITHUB_TOKEN=... node scripts/sonar/close-resolved.mjs [--since-days=7]
+ *   SONAR_CLOSE_RESOLVED=0  — skip entirely
  */
 
 import {
@@ -12,14 +16,50 @@ import {
   githubRepo,
   parseArgs,
   sonarFetch,
+  sonarIssueAdminToken,
+  sonarProjectKey,
 } from './lib.mjs';
 
 const args = parseArgs(process.argv.slice(2));
 const sinceDays = Number(args['since-days'] || 7);
 const since = new Date(Date.now() - sinceDays * 86400000).toISOString();
+const adminToken = sonarIssueAdminToken();
+
+if (process.env.SONAR_CLOSE_RESOLVED === '0' || process.env.SONAR_CLOSE_RESOLVED === 'false') {
+  console.log('SONAR_CLOSE_RESOLVED=0 — skipping close-resolved');
+  process.exit(0);
+}
+
+/** @param {string} message */
+function printPermissionHelp(message) {
+  console.warn('\n[close-resolved] Cannot transition Sonar issues (403 Insufficient privileges).');
+  console.warn(message);
+  console.warn('Fix in SonarQube:');
+  console.warn(`  1. Project → ${sonarProjectKey()} → Project Settings → Permissions`);
+  console.warn('  2. Grant "Administer Issues" to the Jenkins token user (or a dedicated bot user).');
+  console.warn('  3. Token must be a User Token (squ_…), not Global Analysis Token (sqa_…).');
+  console.warn('  4. Optional: set SONAR_ISSUE_ADMIN_TOKEN to a user token with that permission.');
+  console.warn('Note: fixed issues still auto-close on the next dome-sonar analysis on main.\n');
+}
+
+/** @param {string} message */
+function isInsufficientPrivileges(message) {
+  return message.includes('(403)') || message.includes('Insufficient privileges');
+}
+
+/** @param {string} sonarKey */
+async function getOpenSonarIssue(sonarKey) {
+  const data = await sonarFetch('/api/issues/search', { issues: sonarKey }, 'GET', adminToken);
+  const issue = data.issues?.[0];
+  if (!issue) return null;
+  if (issue.status === 'CLOSED' || issue.resolution === 'FIXED') return null;
+  return issue;
+}
 
 let page = 1;
 let transitioned = 0;
+let skippedAlreadyClosed = 0;
+let permissionBlocked = false;
 
 while (true) {
   const data = await githubFetch('GET', `/repos/${githubRepo()}/issues`, {
@@ -39,20 +79,42 @@ while (true) {
     if (!sonarKey) continue;
 
     try {
+      const openIssue = await getOpenSonarIssue(sonarKey);
+      if (!openIssue) {
+        skippedAlreadyClosed++;
+        continue;
+      }
+
       await sonarFetch(
         '/api/issues/do_transition',
         { issue: sonarKey, transition: 'resolve' },
         'POST',
+        adminToken,
       );
       console.log(`Resolved Sonar ${sonarKey} (GitHub #${gh.number})`);
       transitioned++;
     } catch (err) {
-      console.warn(`Skip ${sonarKey}: ${err.message}`);
+      const message = err instanceof Error ? err.message : String(err);
+      if (isInsufficientPrivileges(message)) {
+        printPermissionHelp(message);
+        permissionBlocked = true;
+        break;
+      }
+      console.warn(`Skip ${sonarKey}: ${message}`);
     }
   }
 
+  if (permissionBlocked) break;
   if (data.length < 100) break;
   page++;
+}
+
+if (skippedAlreadyClosed) {
+  console.log(`Skipped ${skippedAlreadyClosed} issue(s) already closed/fixed in Sonar`);
+}
+if (permissionBlocked) {
+  console.log('Done: 0 Sonar issue(s) marked resolved (missing Administer Issues permission)');
+  process.exit(0);
 }
 
 console.log(`Done: ${transitioned} Sonar issue(s) marked resolved`);

--- a/scripts/sonar/lib.mjs
+++ b/scripts/sonar/lib.mjs
@@ -38,6 +38,11 @@ export function sonarToken() {
   return token;
 }
 
+/** Token for issue transitions (do_transition). Prefer dedicated admin user token. */
+export function sonarIssueAdminToken() {
+  return process.env.SONAR_ISSUE_ADMIN_TOKEN || sonarToken();
+}
+
 /** Sonar Web API: token as login, empty password (Basic). Bearer only on SonarQube 10.6+. */
 export function sonarAuthHeader(token) {
   const scheme = (process.env.SONAR_AUTH_SCHEME || 'basic').toLowerCase();
@@ -50,9 +55,11 @@ export function sonarAuthHeader(token) {
 
 /**
  * @param {Record<string, string | number | boolean | undefined>} params
+ * @param {string} [method]
+ * @param {string} [tokenOverride]
  */
-export async function sonarFetch(path, params = {}, method = 'GET') {
-  const token = sonarToken();
+export async function sonarFetch(path, params = {}, method = 'GET', tokenOverride) {
+  const token = tokenOverride || sonarToken();
   const url = new URL(`${sonarHost()}${path}`);
   /** @type {RequestInit} */
   const init = {


### PR DESCRIPTION
## Summary
- `close-resolved` skips issues already CLOSED/FIXED in Sonar before calling `do_transition`
- On first 403, prints actionable setup steps instead of one Skip line per issue
- Supports `SONAR_ISSUE_ADMIN_TOKEN` (dedicated user token) and `SONAR_CLOSE_RESOLVED=0`

## Root cause
Jenkins Sonar token lacks **Administer Issues** on project (or is a Global Analysis Token `sqa_…`).

## Fix in SonarQube (recommended)
1. Sonar → proyecto `maxprain12_dome_…` → **Project Settings → Permissions**
2. Grant **Administer Issues** to the user whose token is configured in Jenkins server `SonarQube`
3. Ensure token is **User Token** (`squ_…`), not analysis token

Issues still auto-close on next `dome-sonar` run after merge even without this step.

## Test plan
- [ ] Re-run quality loop — either transitions succeed or single clear permission message