### PR TITLE
fix(sonar-loop): MiniMax-M3 + lean CI prompt

### DIFF
--- a/.github/workflows/quality-loop.yml
+++ b/.github/workflows/quality-loop.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run Dome Sonar harness
         env:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
-          SONAR_LOOP_MODEL: MiniMax-M2.7-highspeed
+          SONAR_LOOP_MODEL: MiniMax-M3
         run: |
           pnpm run sonar:run-agent -- --batch=${{ inputs.batch_path }}
 

--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -139,7 +139,7 @@ pipeline {
         ]) {
           sh '''
             set -eux
-            export SONAR_LOOP_MODEL="${SONAR_LOOP_MODEL:-MiniMax-M2.7-highspeed}"
+            export SONAR_LOOP_MODEL="${SONAR_LOOP_MODEL:-MiniMax-M3}"
             pnpm run sonar:run-agent -- --batch=.quality-loop/batch.json
           '''
         }

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -45,7 +45,7 @@ Variables de entorno en el job (Environment / pipeline):
 
 | Variable | Default |
 |----------|---------|
-| `SONAR_LOOP_MODEL` | `MiniMax-M2.7-highspeed` |
+| `SONAR_LOOP_MODEL` | `MiniMax-M3` (1M context; evita límite ~2k de M2.7-highspeed) |
 | `SONAR_LOOP_PROVIDER` | `minimax` |
 | `SONAR_LOOP_TIMEOUT_MS` | `900000` (15 min) |
 
@@ -113,7 +113,7 @@ pnpm run sonar:pick-batch -- --size=3 --out=.quality-loop/batch.json
 pnpm run sonar:run-agent -- --dry-run
 
 # Run real
-pnpm run sonar:run-agent -- --batch=.quality-loop/batch.json --model MiniMax-M2.7-highspeed
+pnpm run sonar:run-agent -- --batch=.quality-loop/batch.json --model MiniMax-M3
 ```
 
 Perfil SQLite aislado: `~/.dome-sonar-loop` (no toca `~/.dome`).

--- a/electron/sonar-loop/parse-args.cjs
+++ b/electron/sonar-loop/parse-args.cjs
@@ -5,7 +5,7 @@
 function parseSonarLoopArgs(argv = []) {
   const args = {
     provider: process.env.SONAR_LOOP_PROVIDER || 'minimax',
-    model: process.env.SONAR_LOOP_MODEL || 'MiniMax-M2.7-highspeed',
+    model: process.env.SONAR_LOOP_MODEL || 'MiniMax-M3',
     batch: '.quality-loop/batch.json',
     repoRoot: process.cwd(),
     timeoutMs: Number(process.env.SONAR_LOOP_TIMEOUT_MS) || 900_000,

--- a/electron/sonar-loop/prompt.cjs
+++ b/electron/sonar-loop/prompt.cjs
@@ -3,12 +3,47 @@ const path = require('path');
 
 const SONAR_TOOL_IDS = ['file_read', 'file_write', 'shell_exec'];
 
+/** Lean CI prompt — avoids PR/branch steps Jenkins handles separately. */
+const CI_PROMPT = `# Sonar quality loop (Jenkins CI)
+
+Fix the Sonar issues listed below with **minimal, targeted diffs**. Jenkins will commit, verify again, and open the PR — you only edit source files.
+
+## Workflow (strict)
+1. For each issue: \`file_read\` the reported file — prefer reading only ±40 lines around the reported line when the file is large.
+2. Apply the **smallest** change that satisfies the Sonar rule and message.
+3. Do **not** refactor, rename, or touch unrelated code.
+4. Do **not** create branches, commits, PRs, or run \`git\` except verify commands below.
+5. After all issues: run verify **once** (not per file):
+   \`pnpm run typecheck && pnpm run lint && pnpm run build:packages && pnpm run test:coverage\`
+
+## Tool discipline
+- Allowed: \`file_read\`, \`file_write\`, \`shell_exec\` (pnpm/npm only for verify).
+- Do not list or explore the whole tree — go straight to reported paths.
+- Do not load large generated/vendor files.
+- skipHitl: automated CI — never ask for approval.
+
+## Priority
+SECURITY → RELIABILITY → maintainability (void operator, complexity).
+
+## Finish
+Reply with: files changed | Sonar keys addressed | verify pass/fail.`;
+
 function getSonarLoopToolDefinitions() {
   const { getToolDefinitionsByIds } = require('../tools/tool-dispatcher.cjs');
   return getToolDefinitionsByIds(SONAR_TOOL_IDS);
 }
 
+function isCiHarness() {
+  return (
+    process.env.SONAR_LOOP_NODE === '1' ||
+    process.env.SONAR_LOOP_NODE === 'true' ||
+    Boolean(process.env.JENKINS_URL)
+  );
+}
+
 function loadPromptTemplate(repoRoot) {
+  if (isCiHarness()) return CI_PROMPT;
+
   const promptPath = path.join(repoRoot, '.cursor/prompts/sonar-fix-batch.md');
   if (fs.existsSync(promptPath)) {
     return fs.readFileSync(promptPath, 'utf8');
@@ -25,12 +60,13 @@ function formatIssue(issue) {
   const component = String(issue.component || '');
   const file = component.includes(':') ? component.split(':').slice(1).join(':') : component;
   const line = issue.line ? `:${issue.line}` : '';
+  const impact = issue.impacts?.[0]?.softwareQuality || '';
   return [
-    `- **Sonar key**: ${issue.key || issue.sonarKey || 'unknown'}`,
-    `  **Rule**: ${issue.rule || 'unknown'}`,
-    `  **File**: ${file}${line}`,
-    `  **Message**: ${issue.message || issue.title || ''}`,
-    issue.githubNumber ? `  **GitHub issue**: #${issue.githubNumber}` : null,
+    `### ${issue.key || issue.sonarKey || 'unknown'}`,
+    `- Rule: \`${issue.rule || 'unknown'}\`${impact ? ` (${impact})` : ''}`,
+    `- File: \`${file}${line}\``,
+    `- Message: ${issue.message || issue.title || ''}`,
+    issue.githubNumber ? `- GitHub: #${issue.githubNumber}` : null,
   ]
     .filter(Boolean)
     .join('\n');
@@ -42,26 +78,18 @@ function buildSonarLoopMessages(batchPayload, repoRoot) {
   const issueBlock =
     issues.length > 0
       ? issues.map(formatIssue).join('\n\n')
-      : '_No issues in batch — pick batch failed or batch is empty._';
+      : '_No issues in batch._';
 
+  const repoAbs = path.resolve(repoRoot);
   const system = `${template}
 
-## Runtime constraints
-- Repository root (absolute): ${path.resolve(repoRoot)}
-- Only modify files under this root.
-- Allowed tools: file_read, file_write, shell_exec (pnpm/npm/git commands for verify only).
-- skipHitl: automated CI — do not ask for approval.
-- When done, reply with a short summary: files changed, Sonar keys addressed, tests run.`;
+## Runtime
+- Repo root: \`${repoAbs}\`
+- Modify files only under this root.`;
 
-  const user = `Process this Sonar batch (max ${issues.length} issues):
+  const user = `Fix these ${issues.length} Sonar issue(s):
 
-${issueBlock}
-
-Steps:
-1. Read each reported file at the indicated line.
-2. Apply the smallest fix per Sonar rule.
-3. Run: pnpm run typecheck && pnpm run lint && pnpm run build:packages && pnpm run test:coverage
-4. Summarize what you changed.`;
+${issueBlock}`;
 
   return [
     { role: 'system', content: system },
@@ -73,4 +101,5 @@ module.exports = {
   SONAR_TOOL_IDS,
   getSonarLoopToolDefinitions,
   buildSonarLoopMessages,
+  CI_PROMPT,
 };

--- a/electron/sonar-loop/provider-config.cjs
+++ b/electron/sonar-loop/provider-config.cjs
@@ -4,7 +4,7 @@ const { readSettingSecret, writeSettingSecret } = require('../core/settings-secr
 
 const PROVIDER_DEFAULTS = {
   minimax: {
-    model: 'MiniMax-M2.7-highspeed',
+    model: 'MiniMax-M3',
     envKeys: ['MINIMAX_API_KEY', 'MINIMAX_BENCH_API_KEY', 'AI_API_KEY'],
   },
 };


### PR DESCRIPTION
## Summary
- Default `SONAR_LOOP_MODEL` → `MiniMax-M3` (1M context) in Jenkins, harness, docs, GHA workflow
- CI-specific prompt in `prompt.cjs`: no branch/PR steps, read only reported files/lines, verify once at end

## Context
Jenkins agent failed with `context window exceeds limit (2013)` on M2.7-highspeed with batch size 5.

## Test plan
- [ ] Re-run `dome-quality-loop` — log shows `model: MiniMax-M3` and agent completes