### PR TITLE
fix(sonar): revert destructive batch #669 + diff guard

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -169,6 +169,7 @@ pipeline {
             git config user.name "Jenkins Quality Loop"
             git checkout -b "$BRANCH"
             bash scripts/jenkins/stage-loop-changes.sh "$PWD"
+            bash scripts/jenkins/verify-loop-diff.sh "$PWD"
             git commit -m "fix(sonar): quality loop batch $(date -Iseconds)"
 
             JENKINS_GH_SETUP_GIT=1 bash scripts/jenkins/gh-auth-env.sh

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,16 +1,5691 @@
-/* app/globals.css - minimal viable stub */
-/* Original file was corrupted during automated Sonar fix. This stub preserves
-   the Sonar S4657 fix for the .many-status-shimmer @media block. */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Z-Index utilities using design tokens */
+@layer utilities {
+  .z-dropdown {
+    z-index: var(--z-dropdown);
+  }
+
+  .z-sticky {
+    z-index: var(--z-sticky);
+  }
+
+  .z-fixed {
+    z-index: var(--z-fixed);
+  }
+
+  .z-modal {
+    z-index: var(--z-modal);
+  }
+
+  .z-popover {
+    z-index: var(--z-popover);
+  }
+
+  .z-max {
+    z-index: var(--z-max);
+  }
+
+  /* Performance: skip rendering of off-screen list items */
+  .content-visibility-auto {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 100px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .content-visibility-auto {
+      content-visibility: visible;
+      contain-intrinsic-size: none;
+    }
+  }
+
+  .ai-surface-card {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-2xl);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .ai-composer-frame {
+    background:
+      linear-gradient(180deg, color-mix(in srgb, var(--bg-secondary) 96%, white), var(--bg-secondary));
+    border-radius: 22px;
+  }
+
+  .ai-composer-frame-dragging {
+    background: color-mix(in srgb, var(--accent) 6%, var(--bg-secondary));
+  }
+
+  .ai-composer-frame-welcome {
+    border-radius: 26px;
+  }
+
+  .ai-context-chip {
+    display: inline-flex;
+    max-width: 180px;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 8px 3px 6px;
+    border-radius: var(--radius-md);
+    border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border));
+    background: color-mix(in srgb, var(--accent) 8%, transparent);
+    color: var(--secondary-text);
+    font-size: 11px;
+  }
+
+  .ai-message-item {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 112px;
+  }
+
+  @media (max-width: 980px) {
+    .dome-app-body {
+      position: relative;
+    }
+
+    .dome-main-content {
+      min-width: 0;
+    }
+
+    /* 03/T06: ventanas estrechas — el sidebar cede ancho al contenido */
+    .dome-left-sidebar {
+      width: min(260px, 28vw) !important;
+      min-width: 200px !important;
+    }
+
+    .dome-right-panel {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      z-index: var(--z-fixed);
+      width: min(380px, 86vw) !important;
+      min-width: min(380px, 86vw) !important;
+      border-left: 1px solid var(--dome-border);
+      box-shadow: var(--shadow-xl);
+      background: var(--dome-surface);
+    }
+  }
+}
+
+/* ============================================
+   CSS VARIABLES - Sistema de Diseño Dome
+   Basado en las mejores prácticas de Pile
+   ============================================ */
+
+:root[data-theme="light"] {
+  /* Safe Area Insets (macOS notch, iOS safe areas) */
+  --safe-area-inset-top: env(safe-area-inset-top, 0px);
+  --safe-area-inset-right: env(safe-area-inset-right, 0px);
+  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-inset-left: env(safe-area-inset-left, 0px);
+
+  /* Core Theme Colors - Light Mode (Minimal) */
+  /* Background White: #FFFFFF */
+  /* Background Gray:  #FAFAFA */
+  /* Many Green:       #E0EAB4 */
+  /* Many Outline:     #596037 */
+
+  --text: #1A1A1A;
+  --background: #FAFAFA;
+  --primary: #596037;
+  /* Many Outline */
+  --secondary: #E0EAB4;
+  /* Many Green */
+  --accent: #596037;
+  --accent-hover: #4A502E;
+
+  /* Semantic Colors */
+  --primary-text: #1A1A1A;
+  /* WCAG AA: 4.5:1+ contrast on #FAFAFA */
+  --secondary-text: #5C5C5C;
+  --tertiary-text: #6B6B6B;
+  --quaternary-text: #999999;
+
+  /* Accent surface (Many chips, avatar, clean user bubbles) */
+  --accent-bg: #eef1dc;
+  --bg-elevated: #ffffff;
+  --border-soft: #ececec;
+
+  /* Background Variants */
+  --bg: #FAFAFA;
+  --bg-secondary: #FFFFFF;
+  --bg-tertiary: #F5F5F5;
+  --bg-hover: #E5E5E5;
+  --bg-color-secondary-hover: #F0F0F0;
+
+  /* Borders */
+  --border: #E5E5E5;
+  --border-hover: #D4D4D4;
+
+  /* Interactive Elements */
+  --base: #596037;
+  --base-text: #FFFFFF;
+  --base-hover: #4A502E;
+  --base-active: #3B4025;
+
+  /* Status Colors */
+  --success: #596037;
+  --success-bg: #E0EAB4;
+  --warning: #E6C47A;
+  /* Kept for utility */
+  --warning-bg: #FDF7E8;
+  --warning-text: #8A6D3B;
+  --error: #E88585;
+  /* Kept for utility */
+  --error-bg: #FFEAEA;
+  --info: #7B9DD0;
+  /* Kept for utility */
+  --info-bg: #E8EFF8;
+
+  /* PPT viewer: default slide text (overridden per-presentation via JS) */
+  --ppt-text-default: #1a1a1a;
+
+  /* Highlight / Mark */
+  --primary-light: #FEF9C3;
+
+  /* Translucent */
+  --translucent: rgba(89, 96, 55, 0.12);
+  --bg-translucent: rgba(250, 250, 250, 0.85);
+
+  /* Sidebar & Layout */
+  --sidebar-width: 56px;
+  --sidebar-collapsed-width: 56px;
+  --nav-height: 56px;
+  --header-height: 68px;
+  /* App title bar (Home): h-11 = 44px. Workspace header: 56px. Use max for fullscreen overlays. */
+  --app-header-height: 44px;
+  --app-header-total: calc(var(--app-header-height) + var(--safe-area-inset-top));
+  --workspace-header-height: 56px;
+  --overlay-top-offset: calc(var(--safe-area-inset-top) + var(--workspace-header-height));
+
+  /* Shadows - Minimal */
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.05);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.05);
+  --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.05);
+
+  /* Typography */
+  --font-inter: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-jetbrains-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --font-sans: var(--font-inter), -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-display: var(--font-inter), -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: var(--font-jetbrains-mono), 'Courier New', monospace;
+
+  /* Transitions */
+  --transition-fast: 120ms ease-in-out;
+  --transition-base: 220ms ease-in-out;
+  --transition-slow: 300ms cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-2xl: 16px;
+  --radius-full: 9999px;
+
+  /* Spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+
+  /* Z-Index */
+  --z-local: 10;
+  --z-dropdown: 100;
+  --z-sticky: 200;
+  --z-fixed: 300;
+  --z-modal-backdrop: 400;
+  --z-modal: 500;
+  --z-popover: 600;
+  --z-tooltip: 700;
+  --z-toast: 800;
+  --z-max: 9999;
+
+  /* Focus */
+  --border-focus: var(--accent);
+  --focus-ring: 0 0 0 3px var(--translucent);
+
+  /* Dome Specific Mappings (Legacy/Component Support)
+     Convención: usar --dome-* en componentes de la app (Home, sidebar, modales).
+     Las variables base (--primary-text, --border) se usan en globals.css y utilidades. */
+  --dome-bg: var(--bg);
+  --dome-surface: var(--bg-secondary);
+  --dome-border: var(--border);
+  --dome-text: var(--primary-text);
+  --dome-text-secondary: var(--secondary-text);
+  --dome-text-muted: var(--tertiary-text);
+  --dome-accent: var(--accent);
+  --dome-accent-hover: var(--accent-hover);
+  --dome-accent-bg: var(--translucent);
+  --dome-error: var(--error);
+  --dome-danger: var(--error);
+  --dome-on-accent: #ffffff;
+  --dome-bg-hover: var(--bg-hover);
+  --dome-logo-filter: none;
+  --tertiary: var(--tertiary-text);
+
+  /* Sidebar — DenchClaw-inspired warm stone tone */
+  --dome-sidebar-bg: #f0f0ed;
+}
+
+:root[data-theme="dark"] {
+  /* Safe Area Insets */
+  --safe-area-inset-top: env(safe-area-inset-top, 0px);
+  --safe-area-inset-right: env(safe-area-inset-right, 0px);
+  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-inset-left: env(safe-area-inset-left, 0px);
+
+  --text: #E8E8E8;
+  --background: #121212;
+  --primary: #A4AD7A;
+  --secondary: #3A4020;
+  --accent: #A4AD7A;
+  --accent-hover: #B8C090;
+
+  --primary-text: #E8E8E8;
+  --secondary-text: #A0A0A0;
+  --tertiary-text: #787878;
+  --quaternary-text: #5c5c5c;
+
+  --accent-bg: #2a2f18;
+  --bg-elevated: #1e1e1e;
+  --border-soft: #242424;
+
+  --bg: #121212;
+  --bg-secondary: #1E1E1E;
+  --bg-tertiary: #2A2A2A;
+  --bg-hover: #333333;
+  --bg-color-secondary-hover: #2A2A2A;
+
+  --border: #333333;
+  --border-hover: #444444;
+
+  --base: #A4AD7A;
+  --base-text: #121212;
+  --base-hover: #B8C090;
+  --base-active: #C8D0A8;
+
+  --success: #A4AD7A;
+  --success-bg: #2A2E1A;
+  --warning: #E6C47A;
+  --warning-bg: #2E2A18;
+  --warning-text: #E6C47A;
+  --error: #E88585;
+  --error-bg: #2E1E1E;
+  --info: #7B9DD0;
+  --info-bg: #1A2030;
+
+  /* PPT viewer: default slide text — slides carry their own background, so this
+     does NOT follow the app theme (overridden per-presentation via JS) */
+  --ppt-text-default: #1a1a1a;
+
+  --primary-light: #2A2E1A;
+
+  --translucent: rgba(164, 173, 122, 0.15);
+  --bg-translucent: rgba(18, 18, 18, 0.85);
+
+  /* Sidebar & Layout */
+  --sidebar-width: 56px;
+  --sidebar-collapsed-width: 56px;
+  --nav-height: 56px;
+  --header-height: 68px;
+  --app-header-height: 44px;
+  --app-header-total: calc(var(--app-header-height) + var(--safe-area-inset-top));
+  --workspace-header-height: 56px;
+  --overlay-top-offset: calc(var(--safe-area-inset-top) + var(--workspace-header-height));
+
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.3);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.3);
+  --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.3);
+
+  --font-inter: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-jetbrains-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --font-sans: var(--font-inter), -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-display: var(--font-inter), -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: var(--font-jetbrains-mono), 'Courier New', monospace;
+
+  --transition-fast: 120ms ease-in-out;
+  --transition-base: 220ms ease-in-out;
+  --transition-slow: 300ms cubic-bezier(0.16, 1, 0.3, 1);
+
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-2xl: 16px;
+  --radius-full: 9999px;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+
+  --z-local: 10;
+  --z-dropdown: 100;
+  --z-sticky: 200;
+  --z-fixed: 300;
+  --z-modal-backdrop: 400;
+  --z-modal: 500;
+  --z-popover: 600;
+  --z-tooltip: 700;
+  --z-toast: 800;
+  --z-max: 9999;
+
+  --border-focus: var(--accent);
+  --focus-ring: 0 0 0 3px var(--translucent);
+
+  --dome-bg: var(--bg);
+  --dome-surface: var(--bg-secondary);
+  --dome-border: var(--border);
+  --dome-text: var(--primary-text);
+  --dome-text-secondary: var(--secondary-text);
+  --dome-text-muted: var(--tertiary-text);
+  --dome-accent: var(--accent);
+  --dome-accent-hover: var(--accent-hover);
+  --dome-accent-bg: var(--translucent);
+  --dome-error: var(--error);
+  --dome-danger: var(--error);
+  --dome-on-accent: #ffffff;
+  --dome-bg-hover: var(--bg-hover);
+  --dome-logo-filter: invert(1) brightness(1.2);
+  --tertiary: var(--tertiary-text);
+
+  --dome-sidebar-bg: #181818;
+}
+
+/* ============================================
+   BASE STYLES
+   ============================================ */
+
+* {
+  box-sizing: border-box;
+}
+
+:root[data-theme="light"] { color-scheme: light; }
+:root[data-theme="dark"] { color-scheme: dark; }
+
+html {
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  height: 100%;
+  overflow: clip;
+}
+
+#root,
+#__next {
+  height: 100%;
+  overflow: clip;
+}
+
+body {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding-top: var(--safe-area-inset-top);
+  padding-left: var(--safe-area-inset-left);
+  padding-right: var(--safe-area-inset-right);
+  padding-bottom: var(--safe-area-inset-bottom);
+  overflow: clip;
+  overscroll-behavior: none;
+  font-family: var(--font-sans);
+  color: var(--primary-text);
+  background-color: var(--bg);
+  transition: background-color var(--transition-base), color var(--transition-base);
+}
+
+li {
+  list-style: none;
+}
+
+a {
+  text-decoration: none;
+  height: fit-content;
+  width: fit-content;
+}
+
+a:hover {
+  opacity: 1;
+  text-decoration: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ============================================
+   TAILWIND LAYERS
+   ============================================ */
+
+@layer base {
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-display);
+    @apply font-semibold;
+    color: var(--primary-text);
+    text-wrap: balance;
+    letter-spacing: -0.02em;
+  }
+
+  a {
+    color: var(--primary-text);
+    text-decoration: underline;
+    text-decoration-color: var(--border);
+    transition: all var(--transition-fast);
+  }
+
+  a:hover {
+    color: var(--primary-text);
+    text-decoration-color: var(--accent);
+    opacity: 1;
+  }
+
+  p {
+    color: var(--primary-text);
+    line-height: 1.65;
+  }
+
+  /* Tabular numbers for better alignment in tables and lists */
+  .tabular-nums {
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Ensure buttons have good touch behavior */
+  button {
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  /* Better focus styles for accessibility */
+  *:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  button:focus-visible,
+  input:focus-visible,
+  textarea:focus-visible,
+  select:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--translucent);
+    border-color: var(--accent);
+  }
+
+  a:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    border-radius: 2px;
+  }
+}
+
+@layer components {
+
+  /* Buttons - Pile style */
+  .btn {
+    @apply px-4 py-2 rounded-lg font-medium;
+    transition: all var(--transition-fast);
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .btn-primary {
+    background-color: var(--accent);
+    color: var(--base-text);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  }
+
+  .btn-primary:hover {
+    background-color: var(--base-hover);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+    transform: translateY(-1px);
+  }
+
+  .btn-primary:active {
+    transform: scale(0.98) translateY(0);
+  }
+
+  .btn-primary:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--translucent);
+  }
+
+  .btn-secondary {
+    background-color: var(--bg-secondary);
+    color: var(--primary-text);
+    border: 1px solid var(--border);
+  }
+
+  .btn-secondary:hover {
+    background-color: var(--bg-tertiary);
+    border-color: var(--border-hover);
+  }
+
+  .btn-ghost {
+    background: transparent;
+    color: var(--secondary-text);
+  }
+
+  .btn-ghost:hover {
+    background-color: var(--bg-secondary);
+    color: var(--primary-text);
+  }
+
+  .btn-ghost:active {
+    background-color: var(--bg-tertiary);
+  }
+
+  /* Cards */
+  .card {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+    transition: all var(--transition-base);
+    overflow: hidden;
+  }
+
+  .card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    border-color: var(--accent);
+    transform: translateY(-2px);
+  }
+
+  /* Inputs */
+  .input {
+    @apply w-full px-3 py-2 rounded-lg;
+    background-color: var(--bg);
+    border: 1.5px solid var(--border);
+    color: var(--primary-text);
+    transition: all var(--transition-base);
+    font-size: 14px;
+  }
+
+  .input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--translucent);
+    color: var(--primary-text);
+  }
+
+  .input::placeholder {
+    color: var(--tertiary-text);
+  }
+
+  .input:disabled {
+    @apply opacity-50 cursor-not-allowed;
+    background-color: var(--bg-secondary);
+  }
+
+  /* Range inputs - use theme variables */
+  .range-input {
+    accent-color: var(--accent);
+    background: transparent;
+  }
+
+  .range-input::-webkit-slider-runnable-track {
+    background: var(--bg-tertiary);
+    border-radius: var(--radius-full);
+  }
+
+  .range-input::-moz-range-track {
+    background: var(--bg-tertiary);
+    border-radius: var(--radius-full);
+  }
+
+  /* Icon holders - Pile style */
+  .icon-holder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 32px;
+    min-width: 36px;
+    border-radius: 8px;
+    transition: all var(--transition-fast);
+    background: transparent;
+    cursor: pointer;
+  }
+
+  .icon-holder:hover {
+    background: var(--bg-secondary);
+  }
+
+  .icon-holder:active {
+    background: var(--bg-tertiary);
+  }
+
+  .icon-holder.active {
+    background: var(--bg-secondary);
+  }
+
+  /* Tags - Pile style */
+  .tag {
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    padding: 4px 8px;
+    user-select: none;
+    font-size: 0.875em;
+    transition: all var(--transition-fast);
+  }
+
+  .tag:hover {
+    background: var(--bg-tertiary);
+  }
+
+  /* Dropdown Menu - Reusable component */
+  /* ModelSelector: Portal uses fixed (inline); base for non-portal fallback */
+  .model-selector-dropdown {
+    z-index: var(--z-popover);
+    min-width: 200px;
+    max-width: 480px;
+    background: var(--bg);
+    border: 1.5px solid var(--border);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-lg), 0 0 0 1px rgba(0, 0, 0, 0.04);
+    padding: 8px;
+    animation: dropdown-appear 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .model-selector-dropdown-portal {
+    /* Position set via inline style (fixed + getBoundingClientRect) */
+    content-visibility: auto;
+  }
+
+  .dropdown-menu {
+    position: fixed;
+    z-index: var(--z-popover);
+    min-width: 200px;
+    max-width: 320px;
+    background: var(--bg);
+    border: 1.5px solid var(--border);
+    border-radius: var(--radius-xl);
+    box-shadow: 0 12px 48px rgba(0, 0, 0, 0.12), 0 4px 16px rgba(0, 0, 0, 0.08);
+    padding: 8px;
+    animation: dropdown-appear 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
+
+  .dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    padding: 10px 14px;
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-md);
+    color: var(--primary-text);
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    text-align: left;
+    transition: all var(--transition-base);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .dropdown-item:hover {
+    background: var(--bg-secondary);
+    transform: translateX(2px);
+  }
+
+  .dropdown-item.danger {
+    color: var(--error);
+  }
+
+  .dropdown-item.danger:hover {
+    background: var(--error-bg);
+  }
+
+  .dropdown-divider {
+    height: 1px;
+    background: var(--border);
+    margin: 6px 8px;
+  }
+
+  /* Model Selector Badges */
+  .model-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px;
+    font-size: 10px;
+    font-weight: 600;
+    border-radius: 4px;
+    white-space: nowrap;
+  }
+
+  .model-badge.recommended,
+  .model-badge.free {
+    background: rgba(34, 197, 94, 0.1);
+    color: rgb(34, 197, 94);
+  }
+
+  .model-badge.private {
+    background: rgba(168, 85, 247, 0.1);
+    color: rgb(168, 85, 247);
+  }
+
+  .model-badge.reasoning {
+    background: rgba(249, 115, 22, 0.1);
+    color: rgb(249, 115, 22);
+  }
+
+  .model-badge.vision {
+    background: rgba(59, 130, 246, 0.1);
+    color: rgb(59, 130, 246);
+  }
+
+  /* Modal Overlay */
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: var(--z-modal-backdrop);
+    animation: overlayShow 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+    padding: 24px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .modal-content {
+    width: 100%;
+    max-width: 520px;
+    max-height: min(calc(100dvh - 48px), calc(100vh - 48px));
+    background: var(--bg);
+    border: 1.5px solid var(--border);
+    border-radius: var(--radius-2xl);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.2), 0 8px 24px rgba(0, 0, 0, 0.12);
+    animation: modal-appear 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+    z-index: var(--z-modal);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    margin: auto;
+  }
+
+  .modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px 24px;
+    border-bottom: 1.5px solid var(--border);
+    flex-shrink: 0;
+  }
+
+  .modal-body {
+    padding: 24px;
+    overflow-y: auto;
+    flex: 1 1 auto;
+    min-height: 0;
+    overscroll-behavior: contain;
+  }
+
+  .modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 20px 24px;
+    border-top: 1.5px solid var(--border);
+    flex-shrink: 0;
+    background: var(--bg-secondary);
+  }
+
+  /* Citation Badge */
+  .citation-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    background: var(--dome-accent-bg, rgba(89, 96, 55, 0.1));
+    color: var(--dome-accent, #596037);
+    cursor: pointer;
+    vertical-align: super;
+    line-height: 1;
+    margin: 0 1px;
+    transition: all 0.15s ease;
+    border: 1px solid transparent;
+  }
+
+  .citation-badge:hover {
+    background: var(--dome-accent, #596037);
+    color: #FFFFFF;
+  }
+}
+
+/* ============================================
+   SCROLLBAR - Hidden (content scrollable via trackpad/wheel)
+   ============================================ */
+
+* {
+  scrollbar-width: none;
+}
+
+*::-webkit-scrollbar {
+  display: none;
+}
+
+/* Custom scrollbar class for overlay scroll */
+.scrollbar-overlay {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+/* Reserve space for scrollbar so content is not truncated */
+.scrollbar-gutter-stable {
+  scrollbar-gutter: auto;
+}
+
+/* ============================================
+   ANIMATIONS (from Pile)
+   ============================================ */
+
+@keyframes overlayShow {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 0.9;
+  }
+}
+
+@keyframes contentShow {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(0.8);
+  }
+
+  70% {
+    transform: scale(1);
+    opacity: 0.8;
+  }
+
+  100% {
+    transform: scale(0.8);
+  }
+}
+
+@keyframes pulse-dot {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 0.4;
+    transform: scale(0.7);
+  }
+}
+
+@keyframes dropdown-appear {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(-8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes overlay-appear {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes modal-appear {
+  from {
+    opacity: 0;
+    transform: scale(0.94) translateY(20px);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-in-from-right {
+  from {
+    opacity: 0.9;
+    transform: translateX(100%);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.animate-slide-in-from-right {
+  animation: slide-in-from-right 0.2s ease-out;
+}
+
+.animate-in {
+  animation: fadeIn var(--transition-base);
+}
+
+.animate-overlay {
+  animation: overlayShow 120ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.animate-content {
+  animation: contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.animate-pulse-custom {
+  animation: pulse 2s infinite;
+}
+
+.animate-dropdown {
+  animation: dropdown-appear 0.15s ease-out;
+}
+
+.animate-modal {
+  animation: modal-appear 0.2s ease-out;
+}
+
+.animate-slide-up {
+  animation: slide-up 0.2s ease-out;
+}
+
+/* ============================================
+   DOME TOUR (driver.js) - Popover styling
+   ============================================ */
+
+.dome-tour-popover.driver-popover {
+  background-color: var(--bg) !important;
+  color: var(--primary-text) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: var(--radius-lg) !important;
+}
+
+.dome-tour-popover .driver-popover-title {
+  color: var(--primary-text) !important;
+}
+
+.dome-tour-popover .driver-popover-description {
+  color: var(--secondary-text) !important;
+}
+
+.dome-tour-popover .driver-popover-progress-text {
+  color: var(--secondary-text) !important;
+}
+
+.dome-tour-popover .driver-popover-footer button {
+  background-color: var(--bg-secondary) !important;
+  color: var(--primary-text) !important;
+  border-color: var(--border) !important;
+}
+
+.dome-tour-popover .driver-popover-footer button:hover,
+.dome-tour-popover .driver-popover-footer button:focus {
+  background-color: var(--bg-hover) !important;
+}
+
+.dome-tour-popover .driver-popover-navigation-btns button:last-child {
+  background-color: var(--accent) !important;
+  color: var(--base-text) !important;
+  border-color: var(--accent) !important;
+}
+
+.dome-tour-popover .driver-popover-navigation-btns button:last-child:hover,
+.dome-tour-popover .driver-popover-navigation-btns button:last-child:focus {
+  background-color: var(--accent-hover) !important;
+}
+
+.dome-tour-popover .driver-popover-arrow {
+  border-color: var(--bg) !important;
+}
+
+.dome-tour-popover .driver-popover-arrow-side-left {
+  border-left-color: var(--bg) !important;
+}
+
+.dome-tour-popover .driver-popover-arrow-side-right {
+  border-right-color: var(--bg) !important;
+}
+
+.dome-tour-popover .driver-popover-arrow-side-top {
+  border-top-color: var(--bg) !important;
+}
+
+.dome-tour-popover .driver-popover-arrow-side-bottom {
+  border-bottom-color: var(--bg) !important;
+}
+
+/* ============================================
+   MARTIN FLOATING CHAT - Keyframes & Utilities
+   ============================================ */
+
+@keyframes martinPulse {
+
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 0.6;
+    transform: scale(0.95);
+  }
+}
+
+.animate-martin-pulse,
+.animate-many-pulse {
+  animation: martinPulse 1.5s ease-in-out infinite;
+}
+
+/* Many chat — density + centered messages + clean bubbles + composer/error/history */
+.many-density-scope {
+  --many-msg-gap: 14px;
+  --many-bubble-px: 14px;
+  --many-msg-font: 14px;
+  --many-msg-lh: 1.55;
+}
+
+.many-density-scope[data-density='compact'] {
+  --many-msg-gap: 12px;
+  --many-bubble-px: 12px;
+  --many-msg-font: 13px;
+  --many-msg-lh: 1.55;
+}
+
+.many-panel-messages[data-surface='many'] .many-bubble-clean {
+  font-size: var(--many-msg-font);
+  line-height: var(--many-msg-lh);
+}
+
+.many-msgs-inner {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--many-msg-gap, 14px) + 2px);
+  width: 100%;
+  max-width: 720px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-bottom: 96px;
+  box-sizing: border-box;
+}
+
+.many-msgs-inner--sidebar {
+  max-width: none;
+  padding-bottom: 32px;
+}
+
+.many-panel-messages[data-surface='many'] .many-bubble-clean--user {
+  box-sizing: border-box;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--accent-bg) 94%, white), var(--accent-bg));
+  color: var(--primary-text);
+  border-radius: 20px 20px 6px 20px;
+  padding: 10px calc(var(--many-bubble-px, 12px) + 1px);
+  border: 1px solid color-mix(in srgb, var(--accent) 10%, transparent) !important;
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--accent) 7%, transparent);
+}
+
+.many-panel-messages[data-surface='many'] .many-bubble-clean--assistant {
+  background: transparent;
+  padding: 0;
+  border: none !important;
+}
+
+.many-panel-messages[data-surface='many'] .many-message-group {
+  scroll-margin: 24px;
+}
+
+.many-panel-fullscreen .many-composer-anchor {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border-soft);
+  background: linear-gradient(to top, var(--bg) 72%, color-mix(in srgb, var(--bg) 40%, transparent));
+}
+
+/* Composer attachments (Many prototype) — scoped to frame so styles always apply */
+.ai-composer-frame .many-composer-attach-section {
+  border-bottom: 1px solid var(--border-soft);
+  background: color-mix(in srgb, var(--bg-secondary) 55%, transparent);
+}
+
+.ai-composer-frame .many-composer-attach-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 14px 4px;
+}
+
+.ai-composer-frame .many-composer-attach-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--quaternary-text);
+}
+
+.ai-composer-frame .many-composer-attach-count {
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  color: var(--quaternary-text);
+}
+
+.ai-composer-frame .composer-attachments,
+.ai-composer-frame [data-many-composer-attachments] .composer-attachments {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  padding: 0 14px 8px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  border-bottom: none;
+}
+
+.ai-composer-frame [data-many-composer-attachments]:not(.many-composer-attach-section) .composer-attachments {
+  flex-wrap: wrap;
+  padding: 10px 14px 0;
+}
+
+.ai-composer-frame .attach-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: min(100%, 320px);
+  padding: 4px 6px 4px 4px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg, 12px);
+  font-size: 11.5px;
+  color: var(--secondary-text);
+  box-sizing: border-box;
+}
+
+.ai-composer-frame .attach-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-sm, 4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--tertiary-text);
+}
+
+.ai-composer-frame .attach-icon--thumb {
+  padding: 0;
+  overflow: hidden;
+}
+
+.ai-composer-frame .attach-icon--thumb img {
+  width: 20px;
+  height: 20px;
+  object-fit: cover;
+}
+
+.ai-composer-frame .attach-chip--pdf .attach-icon {
+  background: color-mix(in srgb, var(--error) 15%, transparent);
+  color: #b35858;
+}
+
+.ai-composer-frame .attach-chip--note .attach-icon {
+  background: color-mix(in srgb, var(--info) 15%, transparent);
+  color: var(--info);
+}
+
+.ai-composer-frame .attach-chip--notebook .attach-icon {
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+.ai-composer-frame .attach-chip--sheet .attach-icon {
+  background: color-mix(in srgb, #22c55e 14%, transparent);
+  color: #3d8f52;
+}
+
+.ai-composer-frame .attach-chip--deck .attach-icon {
+  background: color-mix(in srgb, #f97316 14%, transparent);
+  color: #c45c20;
+}
+
+.ai-composer-frame .attach-chip--image .attach-icon {
+  background: color-mix(in srgb, #a855f7 14%, transparent);
+  color: #7c3aed;
+}
+
+.ai-composer-frame .attach-chip--audio .attach-icon {
+  background: color-mix(in srgb, #ec4899 12%, transparent);
+  color: #be185d;
+}
+
+.ai-composer-frame .attach-chip--video .attach-icon {
+  background: color-mix(in srgb, #3b82f6 14%, transparent);
+  color: #2563eb;
+}
+
+.ai-composer-frame .attach-chip--web .attach-icon {
+  background: color-mix(in srgb, var(--info) 12%, transparent);
+  color: var(--info);
+}
+
+.ai-composer-frame .attach-chip--folder .attach-icon {
+  background: color-mix(in srgb, var(--tertiary-text) 12%, transparent);
+  color: var(--secondary-text);
+}
+
+.ai-composer-frame .attach-chip--artifact .attach-icon {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+}
+
+.ai-composer-frame .attach-chip--neutral .attach-icon,
+.ai-composer-frame .attach-chip--resource .attach-icon,
+.ai-composer-frame .attach-chip--other .attach-icon {
+  background: var(--bg-secondary);
+  color: var(--tertiary-text);
+}
+
+.ai-composer-frame .attach-chip__name {
+  min-width: 0;
+  font-weight: 500;
+  color: var(--primary-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ai-composer-frame .attach-chip__meta {
+  flex-shrink: 0;
+  color: var(--quaternary-text);
+}
+
+.ai-composer-frame .attach-chip__spinner {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  animation: attachChipSpin 0.7s linear infinite;
+}
+
+@keyframes attachChipSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ai-composer-frame .attach-chip__spinner {
+    animation: none;
+    border-top-color: var(--border);
+  }
+}
+
+.ai-composer-frame .attach-chip__remove {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--quaternary-text);
+  cursor: pointer;
+  transition: background var(--transition-fast, 120ms ease), color var(--transition-fast, 120ms ease);
+}
+
+.ai-composer-frame .attach-chip__remove:hover {
+  background: var(--bg-hover);
+  color: var(--primary-text);
+}
+
+.ai-composer-frame .attach-chip__remove:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
+.many-composer-meta {
+  max-width: 760px;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+}
+
+.many-composer-hint {
+  max-width: 760px;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+  font-size: 11px;
+  color: var(--quaternary-text);
+  margin-top: 8px;
+}
+
+.many-composer-hint kbd {
+  font-family: var(--font-mono);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm, 4px);
+  padding: 0 4px;
+  font-size: 10px;
+  color: var(--secondary-text);
+}
+
+.many-composer-tools {
+  padding: 3px 12px 11px;
+  min-width: 0;
+}
+
+.many-composer-tools__bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.many-model-pill {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.many-composer-context {
+  margin-left: auto;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
+.many-composer-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 11px;
+  border: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  color: var(--tertiary-text);
+  flex-shrink: 0;
+  transition: background var(--transition-fast, 120ms ease), color var(--transition-fast, 120ms ease), border-color var(--transition-fast, 120ms ease);
+}
+
+.many-composer-icon-btn:hover {
+  background: color-mix(in srgb, var(--bg-hover) 88%, var(--bg));
+  color: var(--primary-text);
+}
+
+.many-composer-icon-btn--active {
+  background: var(--accent-bg);
+  border-color: color-mix(in srgb, var(--accent) 22%, transparent);
+  color: var(--accent);
+}
+
+.many-composer-divider {
+  width: 1px;
+  height: 16px;
+  background: var(--border);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+.many-tool-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: var(--radius-full, 9999px);
+  background: transparent;
+  border: 1px solid transparent;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--tertiary-text);
+  transition: background var(--transition-fast, 120ms ease), color var(--transition-fast, 120ms ease);
+}
+
+.many-tool-toggle:hover {
+  background: var(--bg-tertiary);
+  color: var(--primary-text);
+}
+
+.many-tool-toggle--on {
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+.many-model-pill button {
+  max-width: min(160px, 100%);
+  padding: 5px 9px 5px 10px;
+  font-size: 11.5px;
+  border-color: var(--border-soft);
+  background: color-mix(in srgb, var(--bg) 64%, transparent);
+}
+
+.many-composer-send {
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.many-composer-send:disabled {
+  opacity: 1;
+  border: 1px solid var(--border-soft);
+}
+
+.many-composer-tools--compact {
+  padding: 3px 9px 9px;
+}
+
+.many-composer-tools--compact .many-model-pill button {
+  max-width: 100%;
+}
+
+.many-composer-rich-input {
+  position: relative;
+  min-width: 0;
+}
+
+.many-composer-rich-input__mirror,
+.many-composer-rich-input__field {
+  box-sizing: border-box;
+  margin: 0;
+  border: none;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 400;
+  font-style: normal;
+  letter-spacing: normal;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  tab-size: 8;
+}
+
+.many-composer-rich-input__mirror {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  color: var(--primary-text);
+  scrollbar-width: none;
+}
+
+.many-composer-rich-input__mirror::-webkit-scrollbar {
+  display: none;
+}
+
+.many-composer-rich-input__field {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: 100%;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  caret-color: var(--primary-text);
+  background: transparent;
+  resize: none;
+}
+
+.many-composer-rich-input__field::placeholder {
+  color: var(--tertiary-text);
+  -webkit-text-fill-color: var(--tertiary-text);
+  opacity: 1;
+}
+
+.composer-text-ref {
+  font-weight: inherit;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  text-decoration-skip-ink: none;
+}
+
+.composer-text-ref--mention,
+.composer-text-ref--file {
+  color: var(--info);
+  text-decoration-color: var(--info);
+}
+
+.composer-text-ref--skill {
+  color: var(--warning);
+  text-decoration-color: var(--warning);
+}
+
+.composer-text-ref--mcp {
+  color: var(--success);
+  text-decoration-color: var(--success);
+}
+
+.composer-token-tooltip {
+  position: fixed;
+  z-index: var(--z-popover);
+  max-width: 260px;
+  padding: 8px 10px;
+  border-radius: var(--radius-lg, 10px);
+  border: 1px solid var(--border-soft);
+  background: var(--bg);
+  box-shadow: var(--shadow-md, 0 8px 24px rgba(0, 0, 0, 0.12));
+  pointer-events: none;
+  transform: translate(-50%, calc(-100% - 8px));
+}
+
+.composer-token-tooltip__title {
+  margin: 0 0 2px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.35;
+  color: var(--primary-text);
+}
+
+.composer-token-tooltip__desc {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--secondary-text);
+}
+
+.many-composer-hint--compact {
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.many-composer-meta-row {
+  max-width: 760px;
+  margin: 0 auto 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 2px;
+}
+
+.many-token-budget-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  border-radius: var(--radius-full, 9999px);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-soft);
+  font-size: 10.5px;
+  color: var(--tertiary-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.many-token-budget-pill__bar {
+  width: 40px;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--bg-tertiary);
+  overflow: hidden;
+  position: relative;
+}
+
+.many-token-budget-pill__fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  background: var(--accent);
+  border-radius: 999px;
+  transition: width 200ms ease;
+}
+
+.many-token-budget-meta .many-token-budget-fill {
+  min-width: 2%;
+  transition: width 200ms ease;
+}
+
+/* Context usage indicator (PI-style donut + popup) */
+:root {
+  --ctx-seg-system: #9ca3af;
+  --ctx-seg-tools: #a855f7;
+  --ctx-seg-rules: #22c55e;
+  --ctx-seg-skills: #ca8a04;
+  --ctx-seg-mcp: #ec4899;
+  --ctx-seg-subagents: #3b82f6;
+  --ctx-seg-summarized: #ef4444;
+  --ctx-seg-conversation: #f97316;
+}
+
+.many-context-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: none;
+  background: transparent;
+  color: var(--tertiary-text);
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: var(--radius-md, 8px);
+  font-size: 11px;
+  line-height: 1;
+}
+
+.many-context-trigger:hover {
+  background: var(--bg-hover);
+  color: var(--secondary-text);
+}
+
+.many-context-trigger--header {
+  margin-right: 2px;
+}
+
+.many-context-trigger--inline {
+  padding: 4px 10px;
+  border: 1px solid var(--border-soft);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-full, 9999px);
+}
+
+.many-context-trigger__pct {
+  font-weight: 500;
+  color: var(--secondary-text);
+}
+
+.many-context-popup {
+  border: 1px solid var(--border-soft) !important;
+  background: var(--bg-elevated) !important;
+  overflow: hidden;
+}
+
+.many-context-popup__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 12px 8px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.many-context-popup__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--primary-text);
+}
+
+.many-context-popup__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px 8px;
+  font-size: 12px;
+  color: var(--secondary-text);
+}
+
+.many-context-popup__bar {
+  display: flex;
+  height: 6px;
+  margin: 0 12px 10px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--bg-tertiary);
+  gap: 1px;
+}
+
+.many-context-popup__bar-seg {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  transition: opacity 120ms ease;
+}
+
+.many-context-popup__list {
+  list-style: none;
+  margin: 0;
+  padding: 0 6px 8px;
+}
+
+.many-context-popup__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: var(--radius-md, 8px);
+  font-size: 12px;
+  color: var(--secondary-text);
+}
+
+.many-context-popup__row[data-active] {
+  background: var(--bg-hover);
+}
+
+.many-context-popup__swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.many-context-popup__label {
+  flex: 1;
+  min-width: 0;
+}
+
+.many-context-popup__value {
+  color: var(--primary-text);
+  font-weight: 500;
+}
+
+.many-context-popup__footnote {
+  margin: 0;
+  padding: 8px 12px 12px;
+  border-top: 1px solid var(--border-soft);
+  font-size: 10.5px;
+  line-height: 1.45;
+  color: var(--quaternary-text);
+}
+
+.many-error-card {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 14px 16px;
+  border-radius: var(--radius-lg, 12px);
+  border: 1px solid color-mix(in srgb, var(--error) 24%, transparent);
+  background: color-mix(in srgb, var(--error) 9%, var(--bg));
+  margin-top: 20px;
+  max-width: 560px;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+}
+
+.many-error-card__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.many-error-card__title {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--primary-text);
+}
+
+.many-error-card__msg {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--secondary-text);
+}
+
+.many-error-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.many-error-card__btn {
+  font-size: 12px;
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: 9999px;
+  border: none;
+  cursor: pointer;
+  transition: opacity 120ms ease;
+}
+
+.many-error-card__btn--primary {
+  background: var(--accent);
+  color: var(--base-text, #fff);
+}
+
+.many-error-card__btn--ghost {
+  background: transparent;
+  border: 1px solid var(--border-soft);
+  color: var(--secondary-text);
+}
+
+.many-welcome-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 9999px;
+  border: 1px solid var(--border-soft);
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--secondary-text);
+  background: transparent;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease;
+}
+
+.many-welcome-pill:hover {
+  background: var(--accent-bg);
+  border-color: transparent;
+  color: var(--accent);
+}
+
+
+.many-panel-messages .many-message-group {
+  content-visibility: auto;
+  contain-intrinsic-size: 0 80px;
+}
+
+/* Many minimal chat — subtle status dots + aligned tool/timeline surfaces */
+@keyframes manyMinimalDotPulse {
+
+  0%,
+  100% {
+    opacity: 0.38;
+    transform: scale(0.9);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.many-panel-messages[data-surface="many"] .many-minimal-status-dots {
+  color: var(--secondary-text);
+}
+
+.many-panel-messages[data-surface="many"] .many-minimal-status-dot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 9999px;
+  background: currentColor;
+  animation: manyMinimalDotPulse 1.05s ease-in-out infinite both;
+}
+
+.many-panel-messages[data-surface="many"] .many-minimal-status-dot:nth-child(1) {
+  animation-delay: 0ms;
+}
+
+.many-panel-messages[data-surface="many"] .many-minimal-status-dot:nth-child(2) {
+  animation-delay: 140ms;
+}
+
+.many-panel-messages[data-surface="many"] .many-minimal-status-dot:nth-child(3) {
+  animation-delay: 280ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .many-panel-messages[data-surface="many"] .many-minimal-status-dot {
+    animation: none;
+    opacity: 0.55;
+  }
+}
+
+.many-panel-messages[data-surface="many"] .many-chat-tool-root {
+  box-shadow: none;
+}
+
+.many-panel-messages[data-surface="many"] .many-chat-timeline-root {
+  background: color-mix(in srgb, var(--bg-secondary) 72%, transparent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: none;
+}
+
+
+/* ============================================
+   MANY CHAT REDESIGN — Avatar, Header, Tool Cards, Status
+   ============================================ */
+
+/* Avatar state animations */
+.many-avatar-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: visible;
+  flex-shrink: 0;
+}
+
+.many-avatar { position: relative; overflow: visible; }
+
+.many-avatar--thinking::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  border: 1.5px solid var(--accent);
+  border-right-color: transparent;
+  border-bottom-color: transparent;
+  animation: manyAvatarSpin 1.4s linear infinite;
+  pointer-events: none;
+}
+
+.many-avatar--speaking::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 40%, transparent);
+  animation: manyAvatarPulse 1.6s ease-out infinite;
+  pointer-events: none;
+}
+
+.many-avatar-dot {
+  position: absolute;
+  bottom: -2px;
+  right: -2px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid var(--bg);
+  background: var(--tertiary-text);
+}
+
+.many-avatar-dot--thinking {
+  background: var(--warning);
+}
+
+.many-avatar-dot--speaking {
+  background: var(--accent);
+}
+
+@keyframes manyAvatarSpin { to { transform: rotate(360deg); } }
+
+@keyframes manyAvatarPulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 40%, transparent); }
+  70% { box-shadow: 0 0 0 8px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .many-avatar--thinking::after,
+  .many-avatar--speaking::after { animation: none; }
+}
+
+/* Header chips */
+.many-chat-header {
+  container-type: inline-size;
+  container-name: many-chat-header;
+  min-height: 54px;
+  padding: 9px 14px;
+  border-color: color-mix(in srgb, var(--border) 72%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--bg) 96%, white), color-mix(in srgb, var(--bg) 92%, transparent));
+  backdrop-filter: blur(16px) saturate(1.08);
+  -webkit-backdrop-filter: blur(16px) saturate(1.08);
+  box-shadow: 0 1px 0 color-mix(in srgb, white 36%, transparent) inset;
+  z-index: 5;
+}
+
+.many-chat-header--docked {
+  position: relative;
+}
+
+.many-chat-header[data-status='thinking'] {
+  background:
+    radial-gradient(circle at 34px 50%, color-mix(in srgb, var(--accent) 10%, transparent), transparent 28px),
+    linear-gradient(180deg, color-mix(in srgb, var(--bg) 97%, white), color-mix(in srgb, var(--bg) 92%, transparent));
+}
+
+.many-hd-avatar--compact {
+  display: none;
+}
+
+.many-hd-actions--compact {
+  display: none;
+}
+
+.many-hd-model--compact {
+  display: none;
+}
+
+.many-hd-title {
+  max-width: min(260px, 48cqw);
+  letter-spacing: -0.01em;
+}
+
+.many-hd-subtitle {
+  font-size: 12px;
+  color: var(--tertiary-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: min(200px, 40cqw);
+}
+
+.many-hd-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 21px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  background: color-mix(in srgb, var(--bg-secondary) 82%, transparent);
+  color: var(--secondary-text);
+  font-size: 11px;
+  font-weight: 560;
+  white-space: nowrap;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.many-hd-chip--accent {
+  border-color: color-mix(in srgb, var(--accent) 16%, transparent);
+  background: color-mix(in srgb, var(--accent-bg) 84%, transparent);
+  color: var(--accent);
+}
+
+.many-hd-status-badge {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+/* Header icon button */
+.many-icon-btn {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--bg-secondary) 32%, transparent);
+  border-radius: 11px;
+  color: var(--tertiary-text);
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease, transform 120ms ease;
+  flex-shrink: 0;
+}
+.many-icon-btn:hover {
+  background: var(--bg-hover);
+  border-color: color-mix(in srgb, var(--border) 70%, transparent);
+  color: var(--primary-text);
+  transform: translateY(-1px);
+}
+
+@container many-chat-header (max-width: 440px) {
+  .many-hd-actions--wide {
+    display: none;
+  }
+
+  .many-hd-actions--compact {
+    display: flex;
+  }
+
+  .many-hd-model--wide {
+    display: none;
+  }
+
+  .many-hd-model--compact {
+    display: inline-flex;
+    min-width: 0;
+  }
+
+  .many-hd-meta--extra {
+    display: none;
+  }
+
+  .many-hd-title {
+    max-width: min(140px, 38cqw);
+  }
+}
+
+@container many-chat-header (max-width: 360px) {
+  .many-hd-avatar--wide {
+    display: none;
+  }
+
+  .many-hd-avatar--compact {
+    display: flex;
+  }
+
+  .many-hd-title {
+    max-width: min(96px, 34cqw);
+  }
+}
+
+/* ── Many fullscreen welcome (tab + popout) ── */
+.many-welcome-title {
+  font-family: 'Source Serif 4', Georgia, 'Times New Roman', serif;
+  font-size: clamp(28px, 4vw, 42px);
+  font-weight: 600;
+  color: var(--primary-text);
+  text-align: center;
+  line-height: 1.2;
+  margin: 0 0 28px;
+  letter-spacing: -0.02em;
+}
+
+.many-welcome-subtitle {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--secondary-text);
+}
+
+/* ── Many standalone popout window ── */
+.many-popout-root {
+  background: var(--dome-bg);
+  color: var(--dome-text);
+}
+
+.many-panel--popout {
+  border-left: none !important;
+  background:
+    radial-gradient(
+      ellipse 130% 70% at 50% -18%,
+      color-mix(in srgb, var(--dome-accent) 10%, transparent) 0%,
+      transparent 58%
+    ),
+    var(--dome-bg);
+}
+
+.many-panel--popout .many-chat-header--popout {
+  min-height: 54px;
+  padding: calc(9px + var(--safe-area-inset-top, 0px)) 16px 9px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--dome-surface) 84%, var(--dome-bg)), color-mix(in srgb, var(--dome-surface) 68%, var(--dome-bg)));
+  border-bottom: 1px solid color-mix(in srgb, var(--dome-border) 82%, transparent);
+}
+
+.many-panel--popout .many-chat-header--popout.nav-mac {
+  padding-left: 92px !important;
+}
+
+.many-panel--popout .many-chat-header--popout.win-titlebar-padding {
+  padding-right: 140px !important;
+}
+
+.many-panel--popout .many-hd-chip {
+  background: color-mix(in srgb, var(--dome-surface) 88%, var(--dome-bg));
+  color: var(--dome-text-secondary);
+}
+
+.many-panel--popout .many-hd-chip--accent {
+  background: color-mix(in srgb, var(--dome-accent) 14%, var(--dome-bg));
+  color: var(--dome-accent);
+}
+
+.many-panel--popout .many-icon-btn {
+  color: var(--dome-text-muted);
+}
+
+.many-panel--popout .many-icon-btn:hover {
+  background: var(--dome-bg-hover);
+  color: var(--dome-text);
+}
+
+.many-panel--popout .many-popout-welcome--window {
+  padding-top: 8px;
+  padding-bottom: 28px;
+}
+
+.many-panel--popout .many-welcome-title {
+  color: var(--dome-text);
+  margin-bottom: 24px;
+}
+
+.many-panel--popout .many-welcome-subtitle {
+  color: var(--dome-text-secondary);
+}
+
+.many-panel--popout .many-welcome-composer {
+  padding: 0 4px;
+}
+
+.many-panel--popout .many-welcome-pill {
+  background: color-mix(in srgb, var(--dome-surface) 72%, transparent);
+  border-color: color-mix(in srgb, var(--dome-border) 75%, transparent);
+  color: var(--dome-text-secondary);
+}
+
+.many-panel--popout .many-welcome-pill:hover {
+  background: color-mix(in srgb, var(--dome-accent) 12%, var(--dome-bg));
+  border-color: color-mix(in srgb, var(--dome-accent) 28%, transparent);
+  color: var(--dome-accent);
+}
+
+.many-panel--popout .many-panel-messages {
+  background: transparent;
+}
+
+.many-panel--popout .many-popout-messages {
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.many-panel--popout .many-composer-anchor {
+  border-top: 1px solid color-mix(in srgb, var(--dome-border) 72%, transparent);
+  background: linear-gradient(
+    to top,
+    var(--dome-bg) 78%,
+    color-mix(in srgb, var(--dome-bg) 42%, transparent)
+  );
+  padding-bottom: max(4px, env(safe-area-inset-bottom, 0px));
+}
+
+.many-panel--popout .many-popout-composer-inner {
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.dome-ui-cursor-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99999;
+}
+
+.dome-ui-cursor-ring {
+  position: absolute;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--dome-accent) 55%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--dome-accent) 14%, transparent),
+    0 10px 28px color-mix(in srgb, var(--dome-bg) 88%, transparent);
+  transition: all 260ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.dome-ui-cursor-arrow {
+  position: absolute;
+  overflow: visible;
+  filter: drop-shadow(0 1px 3px color-mix(in srgb, var(--dome-text) 18%, transparent));
+  transition: left 240ms cubic-bezier(0.4, 0, 0.2, 1), top 240ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.dome-ui-cursor-tooltip {
+  position: absolute;
+  max-width: 280px;
+  background: var(--dome-surface);
+  color: var(--dome-text-muted);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--dome-border);
+  padding: 5px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.35;
+  letter-spacing: 0.01em;
+  white-space: normal;
+  box-shadow:
+    0 4px 16px color-mix(in srgb, var(--dome-text) 8%, transparent),
+    0 0 1px color-mix(in srgb, var(--dome-border) 40%, transparent);
+  transition: left 240ms cubic-bezier(0.4, 0, 0.2, 1), top 240ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Subagent delegation section (nested tools under research/library/…) */
+.many-subagent-section {
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--border));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--accent-bg) 35%, var(--bg-secondary));
+  overflow: hidden;
+}
+.many-subagent-section-trigger {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+.many-subagent-section-trigger:hover {
+  background: color-mix(in srgb, var(--bg-hover) 50%, transparent);
+}
+.many-subagent-section-icon {
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.many-subagent-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--secondary-text);
+}
+.many-subagent-section-body {
+  padding: 4px 8px 8px 12px;
+  border-top: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border));
+}
+
+/* New card-based tool card (many surface) */
+.many-tool-card-v2 {
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  overflow: hidden;
+  min-width: 0;
+  max-width: 100%;
+  transition: border-color 120ms ease;
+}
+.many-tool-card-v2:hover { border-color: var(--border-hover, color-mix(in srgb, var(--border) 150%, transparent)); }
+.many-tool-card-v2.state-running {
+  border-color: color-mix(in srgb, var(--accent) 28%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent-bg) 60%, transparent) 0%, var(--bg-secondary) 60%);
+}
+.many-tool-card-v2.state-error {
+  border-color: color-mix(in srgb, var(--error) 28%, transparent);
+}
+
+.many-tool-card-v2-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--bg-tertiary);
+  color: var(--secondary-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  overflow: visible;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.many-tool-card-v2-icon .many-tool-spinner {
+  flex-shrink: 0;
+}
+.many-tool-card-v2-icon.state-success { background: var(--accent-bg); color: var(--accent); }
+.many-tool-card-v2-icon.state-running { background: color-mix(in srgb, var(--accent-bg) 80%, transparent); color: var(--accent); }
+.many-tool-card-v2-icon.state-error   { background: color-mix(in srgb, var(--error) 12%, transparent); color: var(--error); }
+
+.many-tool-card-v2-trigger {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  width: 100%;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+}
+.many-tool-card-v2-trigger:hover { background: color-mix(in srgb, var(--bg-hover) 40%, transparent); }
+
+.many-tool-card-v2-copy {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow: hidden;
+}
+
+.many-tool-card-v2-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--primary-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.many-tool-card-v2-summary {
+  font-size: 11.5px;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--tertiary-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.many-tool-card-v2-trail {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  margin-left: 2px;
+}
+
+.many-tool-card-v2-status-icon {
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.many-tool-card-v2-status-icon.is-error {
+  color: var(--error);
+}
+
+.many-tool-card-v2-body {
+  padding: 10px 12px 12px;
+  font-size: 12.5px;
+  color: var(--secondary-text);
+  border-top: 1px solid var(--border);
+  border-radius: 0 0 12px 12px;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.many-tool-card-v2-body.is-detail {
+  padding: 10px 12px 12px 52px;
+}
+
+.many-tool-card-v2-body.is-nested {
+  padding: 8px 8px 10px;
+}
+
+.many-tool-card-v2-body.is-nested .many-tool-card-v2-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.many-tool-card-v2-body.is-nested .many-tool-card-v2 {
+  max-width: 100%;
+}
+
+/* HITL inline (prototype) */
+.hitl,
+.many-hitl-inline {
+  margin: 8px auto 4px;
+  border: 1px solid var(--warning);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--warning) 14%, transparent) 0%, var(--bg-secondary) 48%);
+  border-radius: var(--radius-xl, 16px);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  max-width: 560px;
+  box-sizing: border-box;
+}
+
+.hitl-hd {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hitl-badge {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-md, 8px);
+  background: color-mix(in srgb, var(--warning) 28%, transparent);
+  color: color-mix(in srgb, var(--warning) 70%, #8a6818);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.hitl-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--primary-text);
+}
+
+.hitl-sub {
+  font-size: 11.5px;
+  color: var(--tertiary-text);
+  margin-top: 2px;
+}
+
+.hitl-sub__mono {
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.hitl-preview {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md, 8px);
+  padding: 10px 12px;
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 12px;
+  color: var(--secondary-text);
+  line-height: 1.5;
+}
+
+.hitl-preview__command {
+  font-weight: 600;
+  color: var(--primary-text);
+  word-break: break-all;
+}
+
+.hitl-preview .diff-line {
+  display: block;
+}
+
+.hitl-preview .diff-add {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
+  padding: 0 4px;
+  border-radius: 2px;
+}
+
+.hitl-preview .diff-rem {
+  background: color-mix(in srgb, var(--error) 14%, transparent);
+  color: #b35858;
+  padding: 0 4px;
+  border-radius: 2px;
+  text-decoration: line-through;
+}
+
+.hitl-preview .diff-ctx {
+  color: var(--quaternary-text);
+}
+
+.hitl-context-line {
+  margin: 0;
+  font-size: 12px;
+  color: var(--tertiary-text);
+}
+
+.hitl-context-line--after {
+  margin-top: -4px;
+}
+
+.hitl-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.hitl-actions .btn {
+  padding: 7px 14px;
+  border-radius: var(--radius-md, 8px);
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--primary-text);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: background var(--transition-fast, 120ms ease);
+}
+
+.hitl-actions .btn:hover {
+  background: var(--bg-hover);
+}
+
+.hitl-actions .btn-primary {
+  background: var(--accent);
+  color: #ffffff;
+  border-color: var(--accent);
+  font-weight: 600;
+}
+
+.hitl-actions .btn-primary:hover {
+  background: var(--accent-hover);
+  color: #ffffff;
+  filter: none;
+}
+
+.hitl-actions .btn-primary svg {
+  color: #ffffff;
+}
+
+.hitl-actions .btn-danger {
+  color: #b35858;
+  border-color: color-mix(in srgb, var(--error) 40%, transparent);
+  background: var(--bg-secondary);
+}
+
+.hitl-actions .btn-ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--secondary-text);
+}
+
+.hitl-actions__spacer {
+  flex: 1;
+  min-width: 8px;
+}
+
+.hitl-paused,
+.hitl-expires {
+  font-size: 11px;
+  color: var(--tertiary-text);
+  align-self: center;
+}
+
+.many-hitl-stream-block {
+  margin-top: 12px;
+  margin-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.many-hitl-stream-status {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+  width: 100%;
+  max-width: 560px;
+  text-align: center;
+}
+
+.many-hitl-stream-status__hint {
+  margin: 0;
+  font-size: 11px;
+  color: var(--quaternary-text);
+  padding-left: 2px;
+}
+
+.many-tool-card-v2-kv {
+  display: grid;
+  grid-template-columns: minmax(80px, 120px) 1fr;
+  gap: 3px 10px;
+  font-size: 12px;
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+.many-tool-card-v2-kv dt { color: var(--tertiary-text); font-size: 11.5px; }
+.many-tool-card-v2-kv dd { margin: 0; word-break: break-all; color: var(--primary-text); }
+.many-tool-card-v2-section-label {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--quaternary-text, var(--tertiary-text));
+  font-weight: 600;
+  margin-bottom: 5px;
+}
+
+.many-tool-card-v2-chevron {
+  color: var(--tertiary-text);
+  transition: transform 120ms ease;
+  flex-shrink: 0;
+}
+.many-tool-card-v2-chevron.expanded { transform: rotate(90deg); }
+
+/* Status shimmer (streaming) */
+.many-status-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--tertiary-text) 0%,
+    var(--primary-text) 50%,
+    var(--tertiary-text) 100%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: manyShimmer 2.4s ease-in-out infinite;
+  font-weight: 500;
+}
+
+@keyframes manyShimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
 
 @media (prefers-reduced-motion: reduce) {
   .many-status-shimmer {
     animation: none;
     background: none;
     color: var(--secondary-text);
-    /* background-clip longhand placed AFTER the background shorthand to avoid
-       the S4657 "Overridden property 'background-clip' by shorthand 'background'"
-       violation. */
-    -webkit-background-clip: text;
-    background-clip: text;
+    -webkit-background-clip: unset;
+    background-clip: unset;
   }
+}
+
+/* Chat history — compact 280px column (fullscreen + overlay) */
+.chat-history-panel {
+  display: flex;
+  flex-direction: column;
+  width: 280px;
+  min-width: 280px;
+  max-width: 280px;
+  flex-shrink: 0;
+  overflow: hidden;
+  border-left: 1px solid var(--border-soft);
+  background: var(--dome-sidebar-bg, var(--bg-secondary));
+}
+
+.chat-history-panel--inline-right {
+  height: 100%;
+  border-left: 1px solid var(--border-soft);
+  border-right: none;
+}
+
+.many-panel-body {
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.many-panel-main {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.chat-history-hd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  padding: 11px 12px 10px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.chat-history-hd__title {
+  flex: 1;
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--primary-text);
+  letter-spacing: -0.01em;
+}
+
+.chat-history-search {
+  flex-shrink: 0;
+  padding: 8px 10px 10px;
+}
+
+.chat-history-search-box {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border-soft);
+  background: var(--bg-secondary);
+  color: var(--tertiary-text);
+}
+
+.chat-history-search-box input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: 12px;
+  color: var(--primary-text);
+}
+
+.chat-history-search-box input::placeholder {
+  color: var(--quaternary-text);
+}
+
+.chat-history-scroll {
+  padding: 2px 8px 14px;
+  overscroll-behavior: contain;
+}
+
+.chat-history-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.chat-history-scroll::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tertiary-text) 28%, transparent);
+}
+
+.chat-history-section-block {
+  margin-bottom: 2px;
+}
+
+.chat-history-section-label {
+  margin: 0;
+  padding: 10px 6px 4px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--quaternary-text);
+}
+
+.chat-history-row-wrap {
+  position: relative;
+  margin-bottom: 2px;
+}
+
+.chat-history-row {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  border-radius: 10px;
+  text-align: left;
+  cursor: pointer;
+  background: transparent;
+  transition: background 120ms ease;
+}
+
+.chat-history-row-live,
+.chat-history-row-live-spacer {
+  flex: 0 0 14px;
+  width: 14px;
+  height: 14px;
+  margin-top: 3px;
+}
+
+.chat-history-row-live {
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  background: transparent;
+  animation: attachChipSpin 0.7s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-history-row-live {
+    animation: none;
+    border-top-color: var(--border);
+  }
+}
+
+.chat-history-row-live-spacer {
+  visibility: hidden;
+}
+
+.chat-history-row-body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+  flex: 1;
+}
+
+.chat-history-row:hover {
+  background: color-mix(in srgb, var(--primary-text) 5%, transparent);
+}
+
+.chat-history-row--active {
+  background: var(--accent-bg);
+}
+
+.chat-history-row--active .chat-history-row-title {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.chat-history-row-title {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  font-size: 12.5px;
+  font-weight: 500;
+  line-height: 1.35;
+  color: var(--primary-text);
+}
+
+.chat-history-row-pin {
+  flex-shrink: 0;
+  color: var(--accent);
+}
+
+.chat-history-row-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+}
+
+.chat-history-row-preview {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--tertiary-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-history-row-preview--empty {
+  min-height: 1px;
+}
+
+.chat-history-row-time {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  color: var(--quaternary-text);
+}
+
+.chat-history-row-wrap:hover .chat-history-row-time--idle {
+  opacity: 0;
+}
+
+.chat-history-row-actions {
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  z-index: 1;
+  display: none;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg) 92%, transparent);
+  border: 1px solid var(--border-soft);
+  box-shadow: 0 1px 4px color-mix(in srgb, var(--primary-text) 8%, transparent);
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.chat-history-row-wrap:hover .chat-history-row-actions,
+.chat-history-row-wrap:focus-within .chat-history-row-actions {
+  display: flex;
+  pointer-events: auto;
+}
+
+.chat-history-action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--tertiary-text);
+  cursor: pointer;
+  transition:
+    background 100ms ease,
+    color 100ms ease;
+}
+
+.chat-history-action-btn:hover {
+  background: var(--bg-hover);
+  color: var(--primary-text);
+}
+
+.chat-history-action-btn--danger:hover {
+  color: var(--error);
+}
+
+.chat-history-row-wrap:hover .chat-history-row,
+.chat-history-row-wrap:focus-within .chat-history-row {
+  padding-right: 72px;
+}
+
+/* History panel slide-in (Many sidebar overlay) */
+.many-history-panel {
+  animation: manyHistorySlideIn 160ms ease-out;
+  width: 280px;
+}
+
+@keyframes manyHistorySlideIn {
+  from { opacity: 0; transform: translateX(24px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .many-history-panel { animation: none; }
+}
+
+/* ============================================
+   FLASHCARD ANIMATIONS
+   ============================================ */
+
+.flashcard-container {
+  perspective: 1000px;
+}
+
+.flashcard-flip {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.5s ease;
+  transform-style: preserve-3d;
+}
+
+.flashcard-flip.flipped {
+  transform: rotateY(180deg);
+}
+
+.flashcard-face {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border-radius: var(--radius-xl, 12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.flashcard-front {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+}
+
+.flashcard-back {
+  background: var(--bg-secondary);
+  border: 1px solid var(--accent);
+  transform: rotateY(180deg);
+}
+
+.flashcard-swipe {
+  touch-action: pan-y;
+  user-select: none;
+  cursor: grab;
+}
+
+.flashcard-swipe:active {
+  cursor: grabbing;
+}
+
+@keyframes flashcard-fly-left {
+  to {
+    transform: translateX(-150%) rotate(-20deg);
+    opacity: 0;
+  }
+}
+
+@keyframes flashcard-fly-right {
+  to {
+    transform: translateX(150%) rotate(20deg);
+    opacity: 0;
+  }
+}
+
+.flashcard-exit-left {
+  animation: flashcard-fly-left 0.3s ease-out forwards;
+}
+
+.flashcard-exit-right {
+  animation: flashcard-fly-right 0.3s ease-out forwards;
+}
+
+/* ============================================
+   DIALOG / MODAL STYLES (from Pile)
+   ============================================ */
+
+.dialog-overlay {
+  background-color: var(--bg-secondary);
+  position: fixed;
+  inset: 0;
+  animation: overlayShow 120ms cubic-bezier(0.16, 1, 0.3, 1);
+  opacity: 0.9;
+  z-index: 40;
+  overflow-y: overlay;
+}
+
+.dialog-content {
+  z-index: 50;
+  position: fixed;
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, 0);
+  animation: contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+  overflow-y: overlay;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.dialog-content:focus {
+  outline: none;
+}
+
+/* ============================================
+   GLASS EFFECTS
+   ============================================ */
+
+.glass {
+  background: var(--bg-translucent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid var(--border);
+}
+
+.glass-strong {
+  background: var(--translucent);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+/* ============================================
+   TIPTAP / PROSEMIRROR EDITOR STYLES
+   ============================================ */
+
+/* Notion-style Editor */
+.notion-editor-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.notion-editor-content {
+  width: 100%;
+}
+
+/* Vertical guides for note content area (Docmost-style) */
+.note-editor-with-guides {
+  position: relative;
+  max-width: 72ch;
+  margin: 0 auto;
+}
+
+.note-editor-with-guides::before,
+.note-editor-with-guides::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.note-editor-with-guides::before {
+  left: 0;
+}
+
+.note-editor-with-guides::after {
+  right: 0;
+}
+
+/* Docmost-style editor layout */
+.ProseMirror {
+  outline: none;
+  min-height: 200px;
+  padding: 1.5rem 3rem 20vh 3rem;
+  color: var(--primary-text);
+  max-width: 900px;
+  margin: 0 auto;
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: -0.01em;
+}
+
+@media (max-width: 640px) {
+  .ProseMirror {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}
+
+.ProseMirror>*+* {
+  margin-top: 3px;
+}
+
+.ProseMirror p {
+  margin: 0;
+  padding: 3px 2px;
+  min-height: 1.5em;
+  line-height: 1.6;
+}
+
+.ProseMirror p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  float: left;
+  color: var(--tertiary-text);
+  pointer-events: none;
+  height: 0;
+}
+
+.ProseMirror h1 {
+  font-size: 2em;
+  font-weight: 700;
+  margin-top: 2em;
+  margin-bottom: 4px;
+  padding: 3px 2px;
+  line-height: 1.2;
+}
+
+.ProseMirror h2 {
+  font-size: 1.5em;
+  font-weight: 600;
+  margin-top: 1.4em;
+  margin-bottom: 1px;
+  padding: 3px 2px;
+  line-height: 1.3;
+}
+
+.ProseMirror h3 {
+  font-size: 1.25em;
+  font-weight: 600;
+  margin-top: 1em;
+  margin-bottom: 1px;
+  padding: 3px 2px;
+  line-height: 1.4;
+}
+
+.ProseMirror ul,
+.ProseMirror ol {
+  padding-left: 1.625em;
+  margin: 0;
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
+
+.ProseMirror li {
+  margin: 0;
+  padding: 0;
+  padding-left: 0.3em;
+}
+
+.ProseMirror li>p {
+  margin: 0;
+}
+
+.ProseMirror code {
+  background-color: var(--bg-tertiary);
+  color: var(--accent);
+  padding: 0.2em 0.5em;
+  border-radius: 4px;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-size: 85%;
+  border: 1px solid var(--border);
+}
+
+.ProseMirror pre {
+  background-color: var(--bg-secondary);
+  color: var(--primary-text);
+  padding: 1.25em;
+  border-radius: var(--radius-lg);
+  overflow-x: auto;
+  margin: 8px 0;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-size: 85%;
+  line-height: 1.5;
+  border: 1.5px solid var(--border);
+}
+
+.ProseMirror pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-size: 100%;
+}
+
+.ProseMirror blockquote {
+  border-left: 3px solid var(--accent);
+  padding-left: 1em;
+  padding-right: 1em;
+  margin: 8px 0;
+  color: var(--secondary-text);
+  font-style: italic;
+  background: var(--bg-secondary);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+}
+
+.ProseMirror mark {
+  background-color: var(--primary-light);
+  color: var(--primary-text);
+  padding: 0.15em 0.25em;
+  border-radius: 3px;
+}
+
+.ProseMirror a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-color: var(--secondary);
+  text-underline-offset: 3px;
+  transition: all var(--transition-fast);
+}
+
+.ProseMirror a:hover {
+  background-color: var(--translucent);
+  text-decoration-color: var(--accent);
+}
+
+.ProseMirror img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 3px;
+  margin: 4px 0;
+}
+
+/* Task Lists */
+.ProseMirror ul[data-type='taskList'] {
+  list-style: none;
+  padding: 0;
+  padding-left: 0;
+}
+
+.ProseMirror ul[data-type='taskList'] li {
+  display: flex;
+  align-items: flex-start;
+  padding-left: 0;
+}
+
+.ProseMirror ul[data-type='taskList'] li>label {
+  flex: 0 0 auto;
+  margin-right: 0.5rem;
+  user-select: none;
+  padding-top: 3px;
+}
+
+.ProseMirror ul[data-type='taskList'] li>div {
+  flex: 1 1 auto;
+}
+
+/* Bubble Menu */
+.bubble-menu {
+  z-index: 1000;
+}
+
+.ai-bubble-menu {
+  z-index: 999;
+}
+
+.bubble-menu-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--primary-text);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background-color 0.2s;
+}
+
+.bubble-menu-button:hover {
+  background-color: var(--bg-hover);
+}
+
+.bubble-menu-button.is-active {
+  background-color: var(--bg-hover);
+  color: var(--accent);
+}
+
+/* Slash Command Menu */
+.slash-command-menu {
+  z-index: 10001;
+  animation: slash-menu-in 0.15s ease-out;
+}
+
+@keyframes slash-menu-in {
+  from {
+    opacity: 0.9;
+    transform: scale(0.97);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Custom Blocks */
+.callout-block {
+  margin: 4px 0;
+}
+
+.toggle-block {
+  margin: 4px 0;
+}
+
+.divider-block {
+  margin: 4px 0;
+}
+
+.pdf-embed-block {
+  margin: 16px 0;
+}
+
+/* Mention (Docmost parity) */
+.resource-mention,
+.node-mention {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  background-color: rgba(55, 53, 47, 0.08);
+  border-radius: 3px;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.resource-mention:hover,
+.node-mention:hover {
+  background-color: rgba(55, 53, 47, 0.12);
+}
+
+.node-mention.ProseMirror-selectednode {
+  outline: none;
+}
+
+/* Status badge (Docmost parity) */
+.node-status {
+  margin-right: 2px;
+}
+
+.node-status.ProseMirror-selectednode {
+  outline: none;
+}
+
+.node-status.ProseMirror-selectednode .status-badge {
+  box-shadow: 0 0 0 2px var(--accent);
+  border-radius: 3px;
+}
+
+.file-block {
+  margin: 4px 0;
+}
+
+/* ============================================
+   UTILITY CLASSES
+   ============================================ */
+
+.text-balance {
+  text-wrap: balance;
+}
+
+.text-nowrap {
+  white-space: nowrap;
+}
+
+.user-select-none {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* Prevent Overlapping - Stacking Context Utilities */
+.stack-layer-1 {
+  position: relative;
+  z-index: 1;
+}
+
+.stack-layer-2 {
+  position: relative;
+  z-index: 2;
+}
+
+.stack-layer-3 {
+  position: relative;
+  z-index: 3;
+}
+
+/* Spacing Utilities for Better Layout */
+.spacing-section {
+  margin-bottom: var(--space-8);
+}
+
+.spacing-component {
+  margin-bottom: var(--space-4);
+}
+
+.spacing-tight {
+  gap: var(--space-2);
+}
+
+.spacing-normal {
+  gap: var(--space-4);
+}
+
+.spacing-loose {
+  gap: var(--space-6);
+}
+
+/* Container Constraints to Prevent Overflow */
+.container-constrain {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.container-scroll {
+  max-width: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+/* Refined Focus States */
+.focus-ring:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--translucent);
+  border-color: var(--accent);
+}
+
+/* Smooth Hover Interactions */
+.hover-lift {
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.hover-lift:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.hover-scale {
+  transition: transform var(--transition-fast);
+}
+
+.hover-scale:hover {
+  transform: scale(1.02);
+}
+
+.hover-brightness {
+  transition: filter var(--transition-fast);
+}
+
+.hover-brightness:hover {
+  filter: brightness(1.05);
+}
+
+/* Content Width Constraints */
+.content-prose {
+  max-width: 72ch;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.content-wide {
+  max-width: 90rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.content-narrow {
+  max-width: 48rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Improved Scrolling */
+.scroll-smooth {
+  scroll-behavior: smooth;
+}
+
+.scroll-snap-y {
+  scroll-snap-type: y mandatory;
+}
+
+.scroll-snap-start {
+  scroll-snap-align: start;
+}
+
+/* Better Text Rendering */
+.text-crisp {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+/* Gradient Text */
+.text-gradient {
+  background: linear-gradient(135deg, var(--accent), var(--secondary));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* ============================================
+   ELECTRON - Drag Regions & App Region
+   ============================================ */
+
+.drag-region,
+.-webkit-app-region-drag {
+  -webkit-app-region: drag;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.no-drag,
+.-webkit-app-region-no-drag {
+  -webkit-app-region: no-drag;
+}
+
+/* All interactive elements inside drag region should be no-drag */
+.drag-region button,
+.drag-region input,
+.drag-region textarea,
+.drag-region a,
+.drag-region select,
+.drag-region [role="button"],
+.drag-region [tabindex] {
+  -webkit-app-region: no-drag;
+}
+
+/* Window controls (Obsidian-style title bar) */
+.window-control-btn:hover {
+  background: var(--dome-bg);
+}
+
+.window-control-close:hover {
+  background: var(--error);
+  color: white;
+}
+
+/* ============================================
+   RESPONSIVE BREAKPOINTS (from Pile)
+   ============================================ */
+
+@media only screen and (max-width: 909px) {
+  :root {
+    --sidebar-width: 0px;
+  }
+
+  .sidebar-responsive {
+    display: none;
+    width: 0px;
+    opacity: 0;
+  }
+
+  .content-responsive {
+    margin-left: 0;
+  }
+
+  .nav-mac-responsive {
+    padding-left: 70px;
+  }
+}
+
+/* Windows nav adjustment */
+.nav-win {
+  padding-right: 130px;
+}
+
+/* Windows: reserve space for native title bar overlay controls */
+.win-titlebar-padding {
+  padding-right: 140px;
+}
+
+/* Mac nav adjustment for traffic lights */
+.nav-mac {
+  padding-left: 70px;
+}
+
+/* ============================================
+   LAYOUT UTILITIES
+   ============================================ */
+
+.layout-sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: var(--sidebar-width);
+  border-right: 1.5px solid var(--border);
+  background: var(--bg);
+  z-index: var(--z-sticky);
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.layout-content {
+  flex: 1 0 calc(100vw - var(--sidebar-width));
+  margin-left: var(--sidebar-width);
+  background: var(--bg);
+  min-height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  position: relative;
+}
+
+.layout-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: var(--z-fixed);
+  height: var(--nav-height);
+  font-size: 0.85em;
+  background: var(--bg-translucent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  -webkit-app-region: drag;
+  transition: all var(--transition-base);
+  border-bottom: 1px solid var(--border);
+}
+
+/* ============================================
+   FILTERBAR COMPONENT
+   ============================================ */
+
+.filter-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 0;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.filter-bar-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.filter-bar-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sort-select {
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--primary-text);
+  font-size: 13px;
+  cursor: pointer;
+  outline: none;
+}
+
+.sort-select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--translucent);
+}
+
+.filter-dropdown-container {
+  position: relative;
+}
+
+.filter-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--secondary-text);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.filter-btn:hover,
+.filter-btn.active {
+  border-color: var(--accent);
+  color: var(--primary-text);
+}
+
+.filter-count {
+  background: var(--accent);
+  color: var(--base-text);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 10px;
+}
+
+.filter-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  width: 200px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  z-index: 100;
+  padding: 8px;
+  animation: dropdown-appear 0.15s ease-out;
+}
+
+.filter-dropdown-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--secondary-text);
+}
+
+.clear-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.filter-options {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.filter-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--primary-text);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: all var(--transition-fast);
+}
+
+.filter-option:hover {
+  background: var(--bg-hover);
+}
+
+.filter-option.selected {
+  background: var(--translucent);
+  color: var(--accent);
+}
+
+.remove-icon {
+  margin-left: auto;
+}
+
+.active-filters {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.filter-chip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: var(--translucent);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-full);
+  color: var(--accent);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.filter-chip:hover {
+  opacity: 0.8;
+}
+
+.create-folder-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--base-text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.create-folder-btn:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.view-mode-toggle {
+  display: flex;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.view-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 10px;
+  background: transparent;
+  border: none;
+  color: var(--secondary-text);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.view-btn:hover {
+  color: var(--primary-text);
+}
+
+.view-btn.active {
+  background: var(--bg-hover);
+  color: var(--accent);
+}
+
+.view-btn+.view-btn {
+  border-left: 1px solid var(--border);
+}
+
+/* ============================================
+   RESOURCE CARD COMPONENT
+   ============================================ */
+
+/* GRID VIEW */
+.resource-card-grid {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 200px;
+  position: relative;
+  isolation: isolate;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: all var(--transition-fast);
+  aspect-ratio: 4/3;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 200px;
+}
+
+/* Mismo tamaño para todos los recursos */
+.resource-card-grid:hover {
+  border-color: var(--accent);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  z-index: 1;
+}
+
+.resource-card-grid.resource-card-selected,
+.resource-card-list.resource-card-selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent);
+  z-index: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .resource-card-grid:hover {
+    transform: translateY(-1px);
+  }
+}
+
+.card-preview {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: var(--bg-tertiary);
+}
+
+.preview-image {
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+  position: relative;
+}
+
+.video-play-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 44px;
+  height: 44px;
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 16px;
+  backdrop-filter: blur(4px);
+}
+
+.content-preview {
+  padding: 20px 16px 16px;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+.content-preview p {
+  font-size: 13px;
+  color: var(--secondary-text);
+  line-height: 1.6;
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin: 0;
+}
+
+/* Note Markdown preview - renderizado de markdown en cards */
+.content-preview-note.markdown-preview {
+  font-size: 13px;
+  color: var(--secondary-text);
+  line-height: 1.5;
+}
+
+.content-preview-note.markdown-preview h1,
+.content-preview-note.markdown-preview h2,
+.content-preview-note.markdown-preview h3 {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--primary-text);
+  margin: 0 0 4px 0;
+}
+
+.content-preview-note.markdown-preview p,
+.content-preview-note.markdown-preview span {
+  margin: 0 0 4px 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.content-preview-note.markdown-preview ul,
+.content-preview-note.markdown-preview ol {
+  margin: 0 0 4px 0;
+  padding-left: 1em;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.content-preview-note.markdown-preview code {
+  font-size: 12px;
+  background: var(--bg-tertiary);
+  padding: 1px 4px;
+  border-radius: 4px;
+}
+
+.content-preview-note.markdown-preview strong {
+  font-weight: 600;
+  color: var(--primary-text);
+}
+
+.content-preview::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 48px;
+  background: linear-gradient(transparent, var(--bg-tertiary));
+  pointer-events: none;
+}
+
+.document-preview {
+  position: relative;
+}
+
+/* URL rich preview (no image) */
+.content-preview-url .url-preview-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--primary-text);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-bottom: 4px;
+}
+
+.content-preview-url .url-preview-meta {
+  font-size: 11px;
+  color: var(--tertiary-text);
+  margin-bottom: 6px;
+}
+
+.content-preview-url .url-preview-excerpt {
+  font-size: 12px;
+  color: var(--secondary-text);
+  -webkit-line-clamp: 3;
+  margin: 0;
+}
+
+.doc-type-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+  letter-spacing: 0.5px;
+}
+
+.time-badge {
+  display: none;
+}
+
+.icon-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  height: 100%;
+  padding: 16px;
+}
+
+.icon-preview .resource-icon {
+  width: 40px;
+  height: 40px;
+  opacity: 0.4;
+}
+
+.icon-preview-empty .resource-icon {
+  opacity: 0.5;
+}
+
+.icon-preview-hint {
+  font-size: 11px;
+  color: var(--tertiary-text);
+  text-align: center;
+  max-width: 100%;
+}
+
+/* Overlay Elements */
+.overlay-time-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: rgba(0, 0, 0, 0.55);
+  color: white;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 6px;
+  backdrop-filter: blur(8px);
+  z-index: 3;
+  pointer-events: none;
+}
+
+.overlay-menu {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.resource-card-grid:hover .overlay-menu {
+  opacity: 1;
+}
+
+.resource-card-grid:not(.has-image-preview) .overlay-menu-btn {
+  background: var(--bg-secondary);
+  color: var(--secondary-text);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+}
+
+.resource-card-grid:not(.has-image-preview) .overlay-menu-btn:hover {
+  background: var(--bg-hover);
+  color: var(--primary-text);
+  border-color: var(--border-hover);
+}
+
+.resource-card-grid:not(.has-image-preview) .overlay-delete-btn:hover {
+  background: var(--error-bg) !important;
+  color: var(--error) !important;
+  border-color: var(--error) !important;
+}
+
+.overlay-delete-btn:hover {
+  background: rgba(220, 38, 38, 0.9) !important;
+  color: white !important;
+}
+
+.overlay-menu-btn {
+  padding: 6px;
+  min-width: 36px;
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  border: none;
+  border-radius: 8px;
+  color: white;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  backdrop-filter: blur(8px);
+}
+
+.resource-card-grid.has-image-preview .overlay-menu-btn {
+  min-width: 36px;
+  min-height: 36px;
+}
+
+.overlay-menu-btn:hover {
+  background: rgba(0, 0, 0, 0.75);
+}
+
+.card-footer-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  z-index: 2;
+}
+
+.card-footer-overlay.on-image {
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.65));
+  color: white;
+  padding-top: 28px;
+}
+
+.card-footer-overlay.on-content {
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border);
+  color: var(--primary-text);
+}
+
+.footer-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.footer-icon .resource-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.footer-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.footer-title {
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card-footer-overlay.on-image .footer-title {
+  color: white;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.footer-snippet {
+  font-size: 10px;
+  opacity: 0.7;
+  margin-top: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.footer-title-input {
+  width: 100%;
+  padding: 2px 4px;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--primary-text);
+  font-size: 12px;
+  font-weight: 600;
+  outline: none;
+}
+
+/* LIST VIEW */
+.resource-card-list {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 72px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  transition: all var(--transition-fast);
+  content-visibility: auto;
+}
+
+.resource-card-list:hover {
+  border-color: var(--accent);
+  background: var(--bg-hover);
+}
+
+.list-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.list-icon .resource-icon {
+  width: 20px;
+  height: 20px;
+}
+
+.list-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.list-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--primary-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.list-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--tertiary-text);
+}
+
+.list-type {
+  text-transform: capitalize;
+}
+
+.list-origin {
+  max-width: 120px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.list-snippet {
+  font-size: 11px;
+  color: var(--secondary-text);
+  margin-top: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.list-actions {
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.resource-card-list:hover .list-actions {
+  opacity: 1;
+}
+
+.action-btn {
+  padding: 6px;
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--secondary-text);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.action-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
+}
+
+.action-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--primary-text);
+}
+
+.action-btn.delete:hover {
+  background: var(--error-bg);
+  color: var(--error);
+}
+
+/* SHARED MENU STYLES */
+.dropdown-menu {
+  position: fixed;
+  z-index: 9999;
+  min-width: 180px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15), 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 6px;
+  animation: dropdown-appear 0.15s ease-out;
+}
+
+.dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--primary-text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: all var(--transition-fast);
+}
+
+.dropdown-item:hover {
+  background: var(--bg-secondary);
+}
+
+.dropdown-item.delete {
+  color: var(--error);
+}
+
+.dropdown-item.delete:hover {
+  background: var(--error-bg);
+}
+
+.dropdown-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+/* Context menu con scroll cuando hay muchas opciones */
+.context-menu-scrollable .context-menu-items {
+  max-height: min(60vh, 320px);
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+
+.skeleton {
+  background: linear-gradient(90deg,
+      var(--bg-tertiary) 25%,
+      var(--bg-hover) 50%,
+      var(--bg-tertiary) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: var(--radius-md);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+    background: var(--bg-tertiary);
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* ============================================
+   HOME DASHBOARD
+   ============================================ */
+.dashboard-empty-state {
+  text-align: center;
+  padding: 5rem 0;
+}
+
+.dashboard-icon-wrapper {
+  width: 5rem;
+  height: 5rem;
+  border-radius: 9999px;
+  margin: 0 auto 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--translucent);
+}
+
+.dashboard-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  color: var(--accent);
+}
+
+.dashboard-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--primary-text);
+}
+
+.dashboard-description {
+  font-size: 0.875rem;
+  color: var(--secondary-text);
+}
+
+/* Breadcrumbs */
+.breadcrumb-nav {
+  margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--secondary-text);
+  overflow-x: auto;
+  max-width: 100%;
+  white-space: nowrap;
+  scrollbar-width: thin;
+}
+
+.breadcrumb-home {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: var(--radius-lg);
+  transition: all var(--transition-fast);
+  color: var(--secondary-text);
+}
+
+.breadcrumb-home:hover {
+  background-color: var(--bg-hover);
+  color: var(--primary-text);
+}
+
+.breadcrumb-segment {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.breadcrumb-separator {
+  width: 1rem;
+  height: 1rem;
+  opacity: 0.7;
+}
+
+.breadcrumb-item {
+  padding: 0.375rem 0.75rem;
+  border-radius: var(--radius-lg);
+  transition: all var(--transition-fast);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--secondary-text);
+}
+
+.breadcrumb-item:hover {
+  background-color: var(--bg-hover);
+  color: var(--primary-text);
+}
+
+.breadcrumb-current {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--primary-text);
+}
+
+/* Folder Grid — horizontal scroll, minimalista */
+.folder-grid {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 4px;
+  -webkit-overflow-scrolling: touch;
+}
+
+.folder-item-wrapper {
+  position: relative;
+  flex-shrink: 0;
+  border-radius: var(--radius-md);
+  transition: box-shadow var(--transition-fast), background-color var(--transition-fast);
+}
+
+.folder-item-wrapper.drag-over {
+  box-shadow: 0 0 0 3px var(--accent);
+  background-color: var(--translucent);
+}
+
+.breadcrumb-home-dropzone {
+  display: inline-flex;
+  border-radius: var(--radius-md);
+  transition: background-color var(--transition-fast);
+}
+
+.breadcrumb-home-dropzone.drag-over {
+  background-color: var(--translucent);
+}
+
+.folder-item-menu-btn {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  padding: 0.25rem;
+  border-radius: var(--radius-md);
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+  color: var(--secondary-text);
+}
+
+.folder-item-wrapper:hover .folder-item-menu-btn,
+.folder-item-menu-btn[aria-expanded="true"] {
+  opacity: 1;
+}
+
+.folder-item-menu-btn:hover {
+  background-color: var(--bg-hover);
+  color: var(--primary-text);
+}
+
+.folder-rename-input {
+  width: 100%;
+  max-width: 8rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: center;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--primary-text);
+  outline: none;
+}
+
+.folder-rename-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--translucent);
+}
+
+.folder-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 10px;
+  width: 88px;
+  min-width: 88px;
+  flex-shrink: 0;
+  border-radius: var(--radius-md);
+  transition: all var(--transition-fast);
+  cursor: pointer;
+}
+
+.folder-item:hover {
+  background-color: var(--bg-hover);
+}
+
+.folder-item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.folder-icon-wrapper {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--transition-fast);
+}
+
+.folder-item:hover .folder-icon-wrapper {
+  transform: scale(1.02);
+}
+
+.folder-title {
+  font-size: 12px;
+  font-weight: 400;
+  text-align: center;
+  width: 100%;
+  max-width: 88px;
+  line-height: 1.25;
+  color: var(--primary-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Folder Color Picker (react-colorful) */
+.folder-color-picker .react-colorful-wrapper {
+  width: 100%;
+}
+
+.folder-color-picker .react-colorful-wrapper .react-colorful {
+  height: 120px;
+  width: 100%;
+  border-radius: var(--radius-md);
+}
+
+.folder-color-picker .react-colorful__saturation {
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+
+.folder-color-picker .react-colorful__hue {
+  height: 12px;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+}
+
+/* Document Toolbar */
+.document-toolbar-path-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--dome-text-secondary);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.document-toolbar-path-btn:hover {
+  background: var(--bg-hover);
+  color: var(--dome-text);
+}
+
+.document-toolbar-path-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.document-toolbar-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--dome-text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  min-height: 44px;
+}
+
+.document-toolbar-btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-hover);
+}
+
+.document-toolbar-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Selection Action Bar */
+.selection-action-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--translucent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  margin-bottom: 16px;
+  box-shadow: var(--shadow-sm);
+  animation: selection-bar-in 0.2s ease-out;
+}
+
+.selection-action-bar-count {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--dome-text);
+}
+
+.selection-action-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.selection-action-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--dome-text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  min-height: 40px;
+}
+
+.selection-action-btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-hover);
+}
+
+.selection-action-btn-danger:hover {
+  background: var(--error-bg);
+  border-color: var(--error);
+  color: var(--error);
+}
+
+.selection-action-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@keyframes selection-bar-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Compact (icon-only) variant — narrow containers like the workspace sidebar */
+.selection-action-bar--compact {
+  gap: 6px;
+  padding: 4px 6px;
+  margin-bottom: 4px;
+  border-radius: var(--radius-md);
+  min-width: 0;
+}
+
+.selection-action-bar--compact .selection-action-bar-count {
+  font-size: 11px;
+  flex-shrink: 0;
+  min-width: 16px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--dome-text);
+}
+
+.selection-action-bar--compact .selection-action-bar-actions {
+  gap: 4px;
+  flex-wrap: nowrap;
+  min-width: 0;
+}
+
+.selection-action-bar--compact .selection-action-btn {
+  padding: 0;
+  width: 26px;
+  min-width: 26px;
+  min-height: 26px;
+  height: 26px;
+  justify-content: center;
+  gap: 0;
+}
+
+.toast-container {
+  position: fixed;
+  top: 56px;
+  right: 16px;
+  z-index: var(--z-toast);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.toast-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 16px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--toast-accent, var(--accent));
+  border-radius: 8px;
+  box-shadow: var(--shadow-md);
+  min-width: 280px;
+  max-width: 420px;
+  animation: toast-enter 0.25s ease-out;
+  pointer-events: auto;
+}
+
+.toast-item--exit {
+  animation: toast-exit 0.2s ease-in forwards;
+}
+
+.toast-item__icon {
+  color: var(--toast-accent, var(--accent));
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1px;
+}
+
+.toast-item__message {
+  flex: 1;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--primary-text);
+  word-break: break-word;
+}
+
+.toast-item__dismiss {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--tertiary-text);
+  font-size: 14px;
+  padding: 10px;
+  flex-shrink: 0;
+  line-height: 1;
+  margin-top: -1px;
+}
+
+/* Folder Tree Pane — minimal */
+.folder-tree-pane {
+  position: relative;
+}
+
+.folder-tree-pane.collapsed {
+  position: relative;
+}
+
+.folder-tree-pane-toggle {
+  padding: 6px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--tertiary-text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--transition-fast);
+}
+
+.folder-tree-pane-toggle:hover {
+  color: var(--primary-text);
+}
+
+.folder-tree-pane-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
+.folder-tree-item-wrapper {
+  min-height: 44px;
+}
+
+.folder-tree-item-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+
+.folder-tree-item {
+  display: flex;
+  align-items: stretch;
+  min-height: 44px;
+  margin: 0 2px;
+  border-radius: var(--radius-sm);
+  border-left: 2px solid transparent;
+  transition: border-color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.folder-tree-item.drag-over {
+  background-color: var(--bg-hover);
+  border-left-color: var(--accent);
+}
+
+.folder-tree-item.active {
+  border-left-color: var(--accent);
+}
+
+.folder-tree-item-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 6px;
+  border: none;
+  background: transparent;
+  color: var(--primary-text);
+  font-size: 13px;
+  font-weight: 400;
+  cursor: pointer;
+  text-align: left;
+  border-radius: var(--radius-sm);
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.folder-tree-item-btn:hover {
+  background: var(--bg-hover);
+}
+
+.folder-tree-item.active .folder-tree-item-btn {
+  color: var(--accent);
+}
+
+.folder-tree-item-btn:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.folder-tree-expand {
+  flex-shrink: 0;
+  min-width: 36px;
+  min-height: 44px;
+  width: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--tertiary-text);
+  cursor: pointer;
+  padding: 0;
+  border-radius: var(--radius-sm);
+}
+
+.folder-tree-expand:hover {
+  color: var(--primary-text);
+}
+
+.folder-tree-expand:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.folder-tree-expand-placeholder {
+  display: inline-block;
+  width: 36px;
+  min-width: 36px;
+  flex-shrink: 0;
+}
+
+.folder-tree-icon {
+  flex-shrink: 0;
+  color: var(--tertiary-text);
+  transition: color var(--transition-fast);
+}
+
+.folder-tree-item.active .folder-tree-icon {
+  color: var(--accent);
+}
+
+.folder-tree-root-icon {
+  flex-shrink: 0;
+  color: var(--tertiary-text);
+  transition: color var(--transition-fast);
+}
+
+.folder-tree-root-btn.active .folder-tree-root-icon {
+  color: var(--accent);
+}
+
+.folder-tree-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.folder-tree-root {
+  padding: 2px 4px;
+  margin-bottom: 2px;
+  border-radius: var(--radius-sm);
+  border-left: 2px solid transparent;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.folder-tree-root.active {
+  border-left-color: var(--accent);
+}
+
+.folder-tree-root.drag-over {
+  background-color: var(--bg-hover);
+  border-left-color: var(--accent);
+}
+
+.folder-tree-root-btn {
+  width: 100%;
+  min-height: 44px;
+}
+
+/* Inline Folder Breadcrumb — ruta integrada en panel de carpetas */
+.inline-folder-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 12px;
+  font-size: 12px;
+  min-height: 44px;
+  border-bottom: 1px solid var(--dome-border);
+}
+
+.inline-folder-breadcrumb-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  margin: -4px -2px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--dome-text-secondary);
+  font-size: 12px;
+  font-weight: 400;
+  cursor: pointer;
+  text-align: left;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.inline-folder-breadcrumb-btn:hover {
+  color: var(--dome-text);
+  background: var(--bg-hover);
+}
+
+.inline-folder-breadcrumb-btn:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+/* Inline Folder Nav — al lado de recursos */
+.inline-folder-nav {
+  font-size: 12px;
+  color: var(--primary-text);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.inline-folder-list {
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+  flex: 1;
+}
+
+.inline-folder-item-wrapper {
+  min-height: 44px;
+}
+
+.inline-folder-item-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+
+.inline-folder-item {
+  display: flex;
+  align-items: stretch;
+  min-height: 44px;
+  margin: 0 1px;
+  border-radius: var(--radius-sm);
+  border-left: 2px solid transparent;
+  transition: border-color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.inline-folder-item.drag-over {
+  background-color: var(--bg-hover);
+  border-left-color: var(--accent);
+}
+
+.inline-folder-item.active {
+  border-left-color: var(--accent);
+}
+
+.inline-folder-item-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border: none;
+  background: transparent;
+  color: var(--primary-text);
+  font-size: 12px;
+  font-weight: 400;
+  cursor: pointer;
+  text-align: left;
+  border-radius: var(--radius-sm);
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.inline-folder-item-btn:hover {
+  background: var(--bg-hover);
+}
+
+.inline-folder-item.active .inline-folder-item-btn {
+  color: var(--accent);
+}
+
+.inline-folder-item-btn:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.inline-folder-expand {
+  flex-shrink: 0;
+  min-width: 28px;
+  min-height: 44px;
+  width: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--tertiary-text);
+  cursor: pointer;
+  padding: 0;
+  border-radius: var(--radius-sm);
+}
+
+.inline-folder-expand:hover {
+  color: var(--primary-text);
+}
+
+.inline-folder-expand:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.inline-folder-expand-placeholder {
+  display: inline-block;
+  width: 28px;
+  min-width: 28px;
+  flex-shrink: 0;
+}
+
+.inline-folder-icon {
+  flex-shrink: 0;
+  color: var(--tertiary-text);
+  transition: color var(--transition-fast);
+}
+
+.inline-folder-item.active .inline-folder-icon {
+  color: var(--accent);
+}
+
+.inline-folder-root-btn.active .inline-folder-icon {
+  color: var(--accent);
+}
+
+.inline-folder-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.inline-folder-root {
+  padding: 2px 4px;
+  margin-bottom: 2px;
+  border-radius: var(--radius-sm);
+  border-left: 2px solid transparent;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.inline-folder-root.active {
+  border-left-color: var(--accent);
+}
+
+.inline-folder-root.drag-over {
+  background-color: var(--bg-hover);
+  border-left-color: var(--accent);
+}
+
+.inline-folder-root-btn {
+  width: 100%;
+  min-height: 44px;
+}
+
+/* Page Header */
+.page-header {
+  margin-bottom: 2rem;
+}
+
+.page-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--primary-text);
+  margin-bottom: 8px;
+  letter-spacing: -0.02em;
+}
+
+.page-subtitle {
+  font-size: 14px;
+  color: var(--secondary-text);
+}
+
+/* Import Progress */
+.import-progress-card {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  padding: 1rem;
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  z-index: 50;
+  min-width: 300px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+}
+
+/* Section Headers */
+.section-header {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1rem;
+  color: var(--secondary-text);
+}
+
+/* Resources Grid/List */
+.resources-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.25rem;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 240px;
+}
+
+.resources-list-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.resources-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 80px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .resources-grid,
+  .resources-list {
+    content-visibility: visible;
+    contain-intrinsic-size: none;
+  }
+}
+
+.list-header-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--secondary-text);
+  cursor: pointer;
+  text-align: left;
+  transition: color var(--transition-fast);
+}
+
+.list-header-btn:hover {
+  color: var(--primary-text);
+}
+
+.list-header-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
+}
+
+/* Loaders & Errors */
+.loading-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5rem 0;
+}
+
+.spinner-icon {
+  width: 2rem;
+  height: 2rem;
+  color: var(--accent);
+  animation: spin 1s linear infinite;
+}
+
+.resource-card-skeleton {
+  min-height: 220px;
+  background: linear-gradient(90deg,
+      var(--bg-tertiary) 25%,
+      var(--bg-hover) 50%,
+      var(--bg-tertiary) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 2s infinite;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+}
+
+.resource-card-list-skeleton {
+  height: 72px;
+  background: linear-gradient(90deg,
+      var(--bg-tertiary) 25%,
+      var(--bg-hover) 50%,
+      var(--bg-tertiary) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 2s infinite;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .resource-card-skeleton,
+  .resource-card-list-skeleton {
+    animation: none;
+    background: var(--bg-tertiary);
+  }
+}
+
+.error-container {
+  text-align: center;
+  padding: 5rem 0;
+}
+
+.error-message {
+  margin-bottom: 0.5rem;
+  color: var(--error);
+}
+
+.try-again-btn {
+  color: var(--primary-text);
+}
+
+.no-matches-container {
+  text-align: center;
+  padding: 5rem 0;
+}
+
+.no-matches-text {
+  font-size: 0.875rem;
+  color: var(--secondary-text);
+}
+
+/* Empty Folder State */
+.empty-folder-state {
+  text-align: center;
+  padding: 5rem 0;
+}
+
+.empty-folder-icon {
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto 1rem;
+  color: var(--tertiary-text);
+}
+
+.empty-folder-title {
+  font-size: 1.125rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+  color: var(--primary-text);
+}
+
+.empty-folder-description {
+  font-size: 0.875rem;
+  color: var(--secondary-text);
+}
+
+/* ============================================
+   SLIDES PRESENTATION MODE (Fullscreen)
+   ============================================ */
+.slides-presentation-container:fullscreen,
+.slides-presentation-container:-webkit-full-screen {
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.slides-presentation-container:fullscreen>*,
+.slides-presentation-container:-webkit-full-screen>* {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+/* PptViewer: slide rendering container (pptx-preview renders here, one slide shown at a time) */
+.pptx-slide-stage {
+  position: relative;
+  overflow: hidden;
+}
+
+/* Hide pptx-preview's built-in navigation arrows and pagination counter.
+   Dome provides its own navigation UI. */
+.pptx-preview-wrapper-next,
+.pptx-preview-wrapper-pagination {
+  display: none !important;
+}
+
+/* Default text color for slide content that has no explicit color in the
+   PPTX XML (theme-inherited). Updated per-presentation from the PPTX
+   theme's lt1 (Light 1) value. Falls back to white for the common
+   dark-background design. pptx-preview's inline style="color:…" (higher
+   specificity) still overrides this for explicitly colored text. */
+.pptx-preview-slide-wrapper {
+  color: var(--ppt-text-default, #ffffff);
+}
+
+/* Hide scrollbar in PPT thumbnail strip — scroll still works via wheel/trackpad */
+.ppt-thumb-scroll::-webkit-scrollbar {
+  display: none;
 }

--- a/app/lib/marketplace/api.ts
+++ b/app/lib/marketplace/api.ts
@@ -37,7 +37,7 @@ export interface InstalledMarketplaceWorkflowRecord {
 
 async function getInstalledIds(): Promise<string[]> {
   const records = await getAgentRecords();
-  return Object.keys(records).sort();
+  return Object.keys(records).sort((a, b) => a.localeCompare(b));
 }
 
 async function getAgentRecords(): Promise<Record<string, InstalledMarketplaceAgentRecord>> {
@@ -249,7 +249,7 @@ export async function uninstallMarketplaceAgent(
 
 async function getInstalledWorkflowIds(): Promise<string[]> {
   const records = await getWorkflowRecords();
-  return Object.keys(records).sort();
+  return Object.keys(records).sort((a, b) => a.localeCompare(b));
 }
 
 async function getWorkflowRecords(): Promise<Record<string, InstalledMarketplaceWorkflowRecord>> {

--- a/electron/agents/workflow-executor.cjs
+++ b/electron/agents/workflow-executor.cjs
@@ -36,7 +36,7 @@ const {
 
 let _database = null;
 /** @type {(projectId?: string) => any[]} */
-let _loadManyAgents = () => [];
+let _loadManyAgents = (_projectId) => [];
 
 /** Wired by run-engine.init(). */
 function init({ database, loadManyAgents }) {

--- a/electron/mcp/mcp-client.cjs
+++ b/electron/mcp/mcp-client.cjs
@@ -1,7 +1,524 @@
+/* eslint-disable no-console */
+/**
+ * MCP Client - Main Process
+ *
+ * Connects to configured MCP servers and provides tools for the agent runtime.
+ * Config is stored in dedicated SQLite tables.
+ *
+ * Format: [{ name, type: "stdio"|"http"|"sse", command?, args?, url?, headers? }]
+ * - stdio: command (required), args (optional array)
+ * - http: url (required), Streamable HTTP transport
+ * - sse: url (required), SSE legacy transport
+ */
+
+const { capToolResultString, getCapForTool, safeStringify } = require('../tools/tool-result-cap.cjs');
+const {
+  isMcpToolDisabledByDefault,
+  normalizeMcpId,
+} = require('./mcp-tool-policy.cjs');
+
+const DEFAULT_MCP_SERVERS = [];
+
+function normalizeServerId(name) {
+  return String(name || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '');
+}
+
+function normalizeToolId(name) {
+  return normalizeServerId(name);
+}
+
+/**
+ * Sanitize args: strip quotes/spaces, filter empty.
+ * @param {string[]|unknown} args
+ * @returns {string[]}
+ */
+function sanitizeArgs(args) {
+  if (!Array.isArray(args)) return [];
+  return args
+    .map((a) => String(a).trim().replace(/^["'\s,]+|["'\s,]+$/g, ''))
+    .filter(Boolean);
+}
+
+/**
+ * Drop orphan Node/MCP flags (e.g. `--localstorage-file` without a path) that spawn warnings.
+ * @param {string[]} args
+ * @returns {string[]}
+ */
+function sanitizeMcpStdioArgs(args) {
+  const cleaned = sanitizeArgs(args);
+  const out = [];
+  for (let i = 0; i < cleaned.length; i += 1) {
+    const a = cleaned[i];
+    if (a === '--localstorage-file' || a === '--local-storage-file') {
+      const next = cleaned[i + 1];
+      if (next && !next.startsWith('-')) {
+        out.push(a, next);
+        i += 1;
+      }
+      continue;
+    }
+    out.push(a);
+  }
+  return out;
+}
+
+/**
+ * Normalize headers to Record<string, string>.
+ * @param {unknown} h
+ * @returns {Record<string, string>|undefined}
+ */
+function sanitizeHeaders(h) {
+  if (!h || typeof h !== 'object' || Array.isArray(h)) return undefined;
+  const out = {};
+  for (const [k, v] of Object.entries(h)) {
+    if (typeof k === 'string' && typeof v === 'string') out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Normalize a single server entry to our format.
+ * @param {string} name - Server name (key)
+ * @param {object} s - Server config (from mcpServers or our array)
+ * @returns {{ name: string; type: string; command?: string; args?: string[]; url?: string; headers?: Record<string, string>; env?: Record<string, string> }|null}
+ */
+function normalizeServerEntry(name, s) {
+  if (!s || typeof s !== 'object') return null;
+  const n = String(name || '').trim();
+  if (!n) return null;
+  if (s.enabled === false) return null;
+  const env = s.env && typeof s.env === 'object' && !Array.isArray(s.env)
+    ? s.env
+    : undefined;
+  const headers = sanitizeHeaders(s.headers);
+  const tools = Array.isArray(s.tools)
+    ? s.tools
+        .map((tool) => normalizeToolEntry(tool))
+        .filter(Boolean)
+    : undefined;
+  const enabledToolIds = Array.isArray(s.enabledToolIds)
+    ? s.enabledToolIds
+        .map((toolId) => (typeof toolId === 'string' ? normalizeToolId(toolId) : ''))
+        .filter(Boolean)
+    : undefined;
+  if ((s.type === 'sse' || s.transport === 'sse') && typeof s.url === 'string') {
+    return {
+      name: n,
+      type: 'sse',
+      url: s.url,
+      headers,
+      tools,
+      enabledToolIds,
+      lastDiscoveryAt: typeof s.lastDiscoveryAt === 'number' ? s.lastDiscoveryAt : undefined,
+      lastDiscoveryError: typeof s.lastDiscoveryError === 'string' ? s.lastDiscoveryError : null,
+    };
+  }
+  if ((s.type === 'http' || s.url) && typeof s.url === 'string') {
+    return {
+      name: n,
+      type: 'http',
+      url: s.url,
+      headers,
+      tools,
+      enabledToolIds,
+      lastDiscoveryAt: typeof s.lastDiscoveryAt === 'number' ? s.lastDiscoveryAt : undefined,
+      lastDiscoveryError: typeof s.lastDiscoveryError === 'string' ? s.lastDiscoveryError : null,
+    };
+  }
+  if ((s.type === 'stdio' || s.command) && typeof s.command === 'string') {
+    return {
+      name: n,
+      type: 'stdio',
+      command: s.command,
+      args: sanitizeArgs(s.args),
+      env,
+      tools,
+      enabledToolIds,
+      lastDiscoveryAt: typeof s.lastDiscoveryAt === 'number' ? s.lastDiscoveryAt : undefined,
+      lastDiscoveryError: typeof s.lastDiscoveryError === 'string' ? s.lastDiscoveryError : null,
+    };
+  }
+  return null;
+}
+
+function normalizeToolEntry(tool) {
+  if (!tool || typeof tool !== 'object') return null;
+  const name = typeof tool.name === 'string'
+    ? tool.name.trim()
+    : typeof tool.id === 'string'
+      ? tool.id.trim()
+      : '';
+  if (!name) return null;
+  return {
+    id: typeof tool.id === 'string' && tool.id.trim()
+      ? normalizeToolId(tool.id)
+      : normalizeToolId(name),
+    name,
+    description: typeof tool.description === 'string' && tool.description.trim()
+      ? tool.description
+      : '',
+    inputSchema: tool.inputSchema && typeof tool.inputSchema === 'object' && !Array.isArray(tool.inputSchema)
+      ? tool.inputSchema
+      : undefined,
+    enabled: tool.enabled !== false,
+  };
+}
+
+function safeParseJson(raw, fallback) {
+  if (typeof raw !== 'string' || !raw.trim()) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function deserializeMcpServerRow(row) {
+  if (!row) return null;
+  return normalizeServerEntry(row.name, {
+    type: row.type,
+    command: row.command,
+    args: safeParseJson(row.args_json, []),
+    url: row.url,
+    headers: safeParseJson(row.headers_json, undefined),
+    env: safeParseJson(row.env_json, undefined),
+    tools: safeParseJson(row.tools_json, undefined),
+    enabledToolIds: safeParseJson(row.enabled_tool_ids_json, undefined),
+    lastDiscoveryAt: row.last_discovery_at,
+    lastDiscoveryError: row.last_discovery_error,
+    enabled: row.enabled !== 0,
+  });
+}
+
+/**
+ * Parse MCP servers config from settings value.
+ * Accepts both:
+ * - Array: [{ name, type, command?, args?, url?, env? }]
+ * - Object: { mcpServers: { "server-name": { command, args, env?, url? } } }
+ * @param {string|undefined} raw - JSON string from db
+ * @returns {Array<{ name: string; type: string; command?: string; args?: string[]; url?: string; env?: Record<string, string> }>}
+ */
+function parseMcpServersConfig(raw) {
+  if (!raw || typeof raw !== 'string') return DEFAULT_MCP_SERVERS;
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .map((s) => s && typeof s.name === 'string' ? normalizeServerEntry(s.name, s) : null)
+        .filter(Boolean)
+        .filter(
+          (s) =>
+            (s.type === 'stdio' && s.command) ||
+            (s.type === 'http' && s.url) ||
+            (s.type === 'sse' && s.url),
+        );
+    }
+    if (parsed && typeof parsed.mcpServers === 'object') {
+      return Object.entries(parsed.mcpServers)
+        .map(([k, v]) => normalizeServerEntry(k, v))
+        .filter(Boolean)
+        .filter(
+          (s) =>
+            (s.type === 'stdio' && s.command) ||
+            (s.type === 'http' && s.url) ||
+            (s.type === 'sse' && s.url),
+        );
+    }
+    return DEFAULT_MCP_SERVERS;
+  } catch (e) {
+    console.warn('[MCP] Failed to parse mcp_servers config:', e?.message);
+    return DEFAULT_MCP_SERVERS;
+  }
+}
+
+/**
+ * Build mcpServers object for MultiServerMCPClient from parsed config.
+ * @param {Array} servers
+ * @returns {Record<string, { transport?: string; command?: string; args?: string[]; url?: string; headers?: Record<string, string>; env?: Record<string, string> }>}
+ */
+function buildMcpServersObject(servers) {
+  const out = {};
+  for (const s of servers) {
+    const key = String(s.name).trim().toLowerCase().replace(/[^a-z0-9_]/g, '_') || `server_${Date.now()}`;
+    if (s.type === 'stdio') {
+      // Always merge process.env so the spawned MCP process inherits the full environment
+      // (including the PATH enriched by fix-path on macOS GUI apps). Custom env vars override.
+      const entry = {
+        transport: 'stdio',
+        command: s.command,
+        args: sanitizeMcpStdioArgs(s.args),
+        env: { ...process.env, ...(s.env || {}) },
+      };
+      out[key] = entry;
+    } else if (s.type === 'http' && s.url) {
+      const entry = { transport: 'http', url: s.url };
+      if (s.headers && typeof s.headers === 'object' && Object.keys(s.headers).length > 0) {
+        entry.headers = s.headers;
+      }
+      out[key] = entry;
+    } else if (s.type === 'sse' && s.url) {
+      const entry = { transport: 'sse', url: s.url };
+      if (s.headers && typeof s.headers === 'object' && Object.keys(s.headers).length > 0) {
+        entry.headers = s.headers;
+      }
+      out[key] = entry;
+    }
+  }
+  return out;
+}
+
+function getEnabledToolIdsForServer(server) {
+  if (Array.isArray(server?.enabledToolIds) && server.enabledToolIds.length > 0) {
+    return server.enabledToolIds
+      .map((toolId) => normalizeToolId(toolId))
+      .filter(Boolean);
+  }
+  if (Array.isArray(server?.tools) && server.tools.length > 0) {
+    return server.tools
+      .filter((tool) => tool?.enabled !== false)
+      .map((tool) => normalizeToolId(tool.id || tool.name))
+      .filter(Boolean);
+  }
+  return null;
+}
+
+function serializeTool(tool) {
+  if (!tool || typeof tool !== 'object') return null;
+  const name = typeof tool.name === 'string' ? tool.name.trim() : '';
+  if (!name) return null;
+
+  let inputSchema;
+  try {
+    if (tool.schema && typeof tool.schema === 'object' && typeof tool.schema.toJSON === 'function') {
+      inputSchema = tool.schema.toJSON();
+    } else if (tool.schema && typeof tool.schema === 'object') {
+      inputSchema = tool.schema;
+    }
+  } catch {
+    inputSchema = undefined;
+  }
+
+  return {
+    id: normalizeToolId(name),
+    name,
+    description: typeof tool.description === 'string' ? tool.description : '',
+    inputSchema,
+  };
+}
+
+async function createClientForServers(servers) {
+  const mcpServers = buildMcpServersObject(servers);
+  if (Object.keys(mcpServers).length === 0) {
+    return null;
+  }
+  const { MultiServerMCPClient } = await import('@langchain/mcp-adapters');
+  return new MultiServerMCPClient({
+    mcpServers,
+    throwOnLoadError: false,
+    onConnectionError: 'ignore',
+  });
+}
+
+/**
+ * Wrap LangChain MCP tools so large payloads are capped before entering agent state.
+ * @param {import('@langchain/core/tools').StructuredToolInterface} tool
+ * @returns {import('@langchain/core/tools').StructuredToolInterface}
+ */
+function wrapMcpToolWithCap(tool) {
+  if (!tool || typeof tool.invoke !== 'function') return tool;
+  const originalInvoke = tool.invoke.bind(tool);
+  const toolName = typeof tool.name === 'string' ? tool.name : 'mcp_tool';
+  tool.invoke = async (input, config) => {
+    const out = await originalInvoke(input, config);
+    // safeStringify (not raw JSON.stringify): bounds serialization so a huge MCP
+    // payload can't OOM the main process before the char cap runs (ELECTRON-7).
+    const text = safeStringify(out ?? '');
+    return capToolResultString(toolName, text, { maxChars: getCapForTool(toolName) });
+  };
+  return tool;
+}
+
+/**
+ * @param {import('@langchain/core/tools').StructuredToolInterface[]} tools
+ * @param {{ name?: string; command?: string; args?: string[]; enabledToolIds?: string[] }} server
+ * @returns {import('@langchain/core/tools').StructuredToolInterface[]}
+ */
+function filterToolsForServerPolicy(tools, server) {
+  if (!Array.isArray(tools)) return [];
+  const enabledSet = Array.isArray(server?.enabledToolIds) && server.enabledToolIds.length > 0
+    ? new Set(server.enabledToolIds.map((id) => normalizeMcpId(id)))
+    : null;
+
+  return tools.filter((tool) => {
+    const id = normalizeMcpId(tool?.name);
+    if (isMcpToolDisabledByDefault(id, server)) {
+      return enabledSet?.has(id) ?? false;
+    }
+    if (enabledSet) return enabledSet.has(id);
+    return true;
+  });
+}
+
+const MCP_SERVER_LOAD_TIMEOUT_MS = 25_000;
+const MCP_TOOLS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** @type {{ key: string; tools: import('@langchain/core/tools').StructuredToolInterface[]; at: number } | null} */
+let mcpToolsCache = null;
+
 function mcpCacheKey(serverIds) {
   if (!serverIds || serverIds.length === 0) return '__all__';
-  return [...serverIds]
-    .map((id) => String(id).trim().toLowerCase())
-    .sort((a, b) => a.localeCompare(b))
-    .join('|');
+  return [...serverIds].map((id) => String(id).trim().toLowerCase()).sort((a, b) => a.localeCompare(b)).join('|');
 }
+
+function invalidateMcpToolsCache() {
+  mcpToolsCache = null;
+}
+
+/** Best-effort: drop cached tool handles (stdio clients are closed per discovery load). */
+function closeAllMcpClients() {
+  invalidateMcpToolsCache();
+}
+
+async function loadToolsForServer(server) {
+  let client = null;
+  const loadPromise = (async () => {
+    client = await createClientForServers([server]);
+    if (!client) {
+      return { tools: [], manifest: [] };
+    }
+
+    const tools = await client.getTools();
+    const safeTools = (Array.isArray(tools) ? tools : [])
+      .map((tool) => wrapMcpToolWithCap(tool));
+    const manifest = safeTools
+      .map((tool) => serializeTool(tool))
+      .filter(Boolean);
+
+    return { tools: safeTools, manifest };
+  })();
+
+  let timeoutId;
+  const timeoutPromise = new Promise((resolve) => {
+    timeoutId = setTimeout(() => {
+      console.warn(`[MCP] ${server?.name || 'server'} tool load timed out after ${MCP_SERVER_LOAD_TIMEOUT_MS}ms`);
+      resolve({ tools: [], manifest: [] });
+    }, MCP_SERVER_LOAD_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([loadPromise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutId);
+    if (client && typeof client.close === 'function') {
+      try {
+        await client.close();
+      } catch (err) {
+        console.warn(`[MCP] Failed to close client for ${server?.name || 'server'}:`, err?.message || err);
+      }
+    }
+  }
+}
+
+/**
+ * Get MCP tools from configured servers.
+ * @param {object} database - Dome database module (with getQueries())
+ * @param {string[]} [serverIds] - Optional. If provided, only include tools from servers whose name matches (case-insensitive).
+ * @returns {Promise<import('@langchain/core/tools').StructuredToolInterface[]>}
+ */
+async function getMCPTools(database, serverIds) {
+  const queries = database?.getQueries?.();
+  if (!queries) return [];
+
+  const mcpEnabledRow = queries.getMcpGlobalSettings?.get?.();
+  if (mcpEnabledRow && mcpEnabledRow.enabled === 0) return [];
+
+  const rows = queries.listMcpServers?.all?.() ?? [];
+  let servers = rows.map((row) => deserializeMcpServerRow(row)).filter(Boolean);
+  if (servers.length === 0) {
+    const row = queries.getSetting?.get?.('mcp_servers');
+    const raw = row?.value;
+    servers = parseMcpServersConfig(raw);
+  }
+  if (servers.length === 0) return [];
+
+  if (serverIds && serverIds.length > 0) {
+    const idSet = new Set(serverIds.map((id) => String(id).trim().toLowerCase()));
+    servers = servers.filter((s) => idSet.has(String(s.name || '').trim().toLowerCase()));
+    if (servers.length === 0) return [];
+  }
+
+  const cacheKey = mcpCacheKey(serverIds);
+  if (
+    mcpToolsCache
+    && mcpToolsCache.key === cacheKey
+    && Date.now() - mcpToolsCache.at < MCP_TOOLS_CACHE_TTL_MS
+  ) {
+    return mcpToolsCache.tools;
+  }
+
+  try {
+    const allTools = [];
+    for (const server of servers) {
+      const { tools } = await loadToolsForServer(server);
+      const policyFiltered = filterToolsForServerPolicy(tools, server);
+      const enabledToolIds = getEnabledToolIdsForServer(server);
+      if (!enabledToolIds || enabledToolIds.length === 0) {
+        allTools.push(...policyFiltered);
+        continue;
+      }
+
+      const enabledSet = new Set(enabledToolIds);
+      const filteredTools = policyFiltered.filter((tool) => enabledSet.has(normalizeToolId(tool?.name)));
+      allTools.push(...filteredTools);
+    }
+    mcpToolsCache = { key: cacheKey, tools: allTools, at: Date.now() };
+    return allTools;
+  } catch (err) {
+    console.warn('[MCP] Failed to load MCP tools:', err?.message);
+    return [];
+  }
+}
+
+/**
+ * Test a single MCP server.
+ * @param {object} server - { name, type, command?, args?, url?, env? }
+ * @returns {Promise<{ success: boolean; toolCount: number; error?: string }>}
+ */
+async function testSingleMcpServer(server) {
+  if (!server || !server.name) {
+    return { success: false, toolCount: 0, tools: [], error: 'Config inválida' };
+  }
+  const normalized = normalizeServerEntry(server.name, server);
+  if (!normalized) {
+    return { success: false, toolCount: 0, tools: [], error: 'Servidor no configurado correctamente' };
+  }
+  try {
+    const { manifest } = await loadToolsForServer(normalized);
+    return {
+      success: true,
+      toolCount: manifest.length,
+      tools: manifest,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      toolCount: 0,
+      tools: [],
+      error: err?.message || String(err),
+    };
+  }
+}
+
+module.exports = {
+  getMCPTools,
+  invalidateMcpToolsCache,
+  closeAllMcpClients,
+  parseMcpServersConfig,
+  buildMcpServersObject,
+  testSingleMcpServer,
+};

--- a/electron/sonar-loop/prompt.cjs
+++ b/electron/sonar-loop/prompt.cjs
@@ -20,6 +20,8 @@ Fix the Sonar issues listed below with **minimal, targeted diffs**. Jenkins will
 - Allowed: \`file_read\`, \`file_write\`, \`shell_exec\` (pnpm/npm only for verify).
 - Do not list or explore the whole tree — go straight to reported paths.
 - Do not load large generated/vendor files.
+- **Never replace an entire file** with a snippet — use minimal edits at the reported line only.
+- \`app/globals.css\` and \`electron/mcp/mcp-client.cjs\` are large: patch in place; deleting thousands of lines is a failure.
 - skipHitl: automated CI — never ask for approval.
 
 ## Priority

--- a/scripts/jenkins/verify-loop-diff.sh
+++ b/scripts/jenkins/verify-loop-diff.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Reject agent commits that truncate large files (file_write gone wrong).
+set -euo pipefail
+
+ROOT="${1:-.}"
+MAX_FILE_DELETIONS="${SONAR_LOOP_MAX_FILE_DELETIONS:-200}"
+MIN_MCP_CLIENT_LINES="${SONAR_LOOP_MIN_MCP_CLIENT_LINES:-400}"
+MIN_GLOBALS_CSS_LINES="${SONAR_LOOP_MIN_GLOBALS_CSS_LINES:-5000}"
+
+cd "$ROOT"
+
+if ! git diff --cached --quiet; then
+  DIFF_SCOPE='--cached'
+elif ! git diff --quiet; then
+  DIFF_SCOPE=''
+else
+  echo "verify-loop-diff: no staged or unstaged diff — OK"
+  exit 0
+fi
+
+fail=0
+
+while IFS=$'\t' read -r adds dels path; do
+  dels="${dels:-0}"
+  adds="${adds:-0}"
+  case "$path" in
+    app/globals.css)
+      if [ "$dels" -gt "$MAX_FILE_DELETIONS" ]; then
+        echo "ERROR: $path would delete $dels lines (cap $MAX_FILE_DELETIONS) — likely truncated by agent"
+        fail=1
+      fi
+      ;;
+    electron/mcp/mcp-client.cjs)
+      if [ "$dels" -gt "$MAX_FILE_DELETIONS" ]; then
+        echo "ERROR: $path would delete $dels lines (cap $MAX_FILE_DELETIONS) — likely truncated by agent"
+        fail=1
+      fi
+      ;;
+  esac
+done < <(git diff $DIFF_SCOPE --numstat -- app/globals.css electron/mcp/mcp-client.cjs 2>/dev/null || true)
+
+if [ -f electron/mcp/mcp-client.cjs ]; then
+  lines=$(wc -l < electron/mcp/mcp-client.cjs | tr -d ' ')
+  if [ "$lines" -lt "$MIN_MCP_CLIENT_LINES" ]; then
+    echo "ERROR: electron/mcp/mcp-client.cjs has $lines lines (min $MIN_MCP_CLIENT_LINES)"
+    fail=1
+  fi
+fi
+
+if [ -f app/globals.css ]; then
+  lines=$(wc -l < app/globals.css | tr -d ' ')
+  if [ "$lines" -lt "$MIN_GLOBALS_CSS_LINES" ]; then
+    echo "ERROR: app/globals.css has $lines lines (min $MIN_GLOBALS_CSS_LINES)"
+    fail=1
+  fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "verify-loop-diff: refusing destructive quality-loop diff"
+  exit 1
+fi
+
+echo "verify-loop-diff: OK"


### PR DESCRIPTION
## Summary
- **Revert** catastrophic PR #669 (agent replaced whole files with snippets)
- Restore `app/globals.css` + `electron/mcp/mcp-client.cjs` and apply **minimal** fixes for the 5-issue batch
- Add `scripts/jenkins/verify-loop-diff.sh` — blocks commits that delete >200 lines from guarded files
- Strengthen CI prompt: never replace entire large files

## PR #669 problems (already merged — urgent)
| File | Before | After #669 | Valid fix |
|------|--------|------------|-----------|
| `app/globals.css` | 5691 lines | 16-line stub | reorder `background` before `background-clip` (S4657) |
| `electron/mcp/mcp-client.cjs` | 525 lines | 6-line snippet | `.sort((a,b) => a.localeCompare(b))` only |
| `workflow-executor.cjs` | untouched | — | `_projectId` stub param (S930) |
| `marketplace/api.ts` | untouched | — | `localeCompare` sort ×2 (S2871) |

## Test plan
- [ ] Merge ASAP — restores app styling
- [ ] `pnpm run typecheck`
- [ ] Next quality-loop run blocked if agent truncates large files