### PR TITLE
fix(sonar): OpenCode prompt on stdin (post-#671)

### DIFF
--- a/scripts/sonar/run-opencode-agent.mjs
+++ b/scripts/sonar/run-opencode-agent.mjs
@@ -76,27 +76,27 @@ const env = {
   OPENCODE_CLIENT: 'dome-sonar-loop',
 };
 
-const result = spawnSync(
-  'opencode',
-  [
-    'run',
-    '--auto',
-    '--agent',
-    'sonar-fix',
-    '--model',
-    `minimax/${model}`,
-    '--file',
-    batchPath,
-    prompt,
-  ],
-  {
-    cwd: ROOT,
-    env,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-    timeout: timeoutMs,
-  },
-);
+// OpenCode `--file` is a greedy yargs array: a trailing positional prompt is treated
+// as another attachment path ("File not found: Fix these…"). Deliver prompt on stdin.
+const opencodeArgs = [
+  'run',
+  '--auto',
+  '--agent',
+  'sonar-fix',
+  '--model',
+  `minimax/${model}`,
+  '--file',
+  batchPath,
+];
+
+const result = spawnSync('opencode', opencodeArgs, {
+  cwd: ROOT,
+  env,
+  input: prompt,
+  encoding: 'utf8',
+  maxBuffer: 64 * 1024 * 1024,
+  timeout: timeoutMs,
+});
 
 const stdout = result.stdout || '';
 const stderr = result.stderr || '';


### PR DESCRIPTION
## Summary

Follow-up to #671 — Jenkins *Agent fix (OpenCode)* failed with:

```
Error: File not found: Fix these 3 Sonar issue(s) from the attached batch JSON: …
```

OpenCode `--file` is a greedy yargs array and treated the trailing positional prompt as a second attachment path. The runner now pipes the Sonar prompt on **stdin** and only attaches `.quality-loop/batch.json` via `--file`.

## Test plan

- [x] `pnpm run sonar:run-agent -- --dry-run`
- [ ] Re-run `dome-quality-loop` Jenkins build — stage *Agent fix (OpenCode)* should pass argument parsing