### PR TITLE
chore(ci): quality-loop cron every hour

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -2,7 +2,7 @@ pipeline {
   agent any
 
   triggers {
-    cron('H */6 * * *')
+    cron('H * * * *')
   }
 
   environment {

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -16,7 +16,7 @@ Automated correction loop: SonarQube → GitHub Issues → OpenCode CLI (MiniMax
 
 - Pipeline from SCM → **`Jenkinsfile.quality-loop`**
 - Branch `*/main`
-- Cron incluido en el pipeline (`H */6 * * *`)
+- Cron incluido en el pipeline (`H * * * *` — cada hora, minuto aleatorio)
 
 ### Credentials (Manage Jenkins → Credentials)
 


### PR DESCRIPTION
## Summary

- Changes `dome-quality-loop` cron from `H */6 * * *` to `H * * * *` (hourly, hashed minute).
- Docs updated to match.

## Context

Manual Jenkins run on `main` (post-#672) completed successfully:
- OpenCode agent fixed 3× S2871 with minimal diffs
- `verify-loop-diff` OK
- PR #673 opened with auto-merge

## Test plan

- [ ] After merge, confirm Jenkins job shows updated cron trigger (Build Triggers → "Build periodically")