### PR TITLE
chore(ci): quality-loop batch size 10

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -13,6 +13,7 @@ pipeline {
     SONAR_HOST_URL = 'https://sonar.dowi.es'
     GITHUB_REPOSITORY = 'maxprain12/dome'
     XVFB_DISPLAY = ':99'
+    SONAR_BATCH_SIZE = '10'
   }
 
   stages {
@@ -104,7 +105,7 @@ pipeline {
             sh '''
               set -eux
               mkdir -p .quality-loop
-              pnpm run sonar:pick-batch -- --size=5 --out=.quality-loop/batch.json
+              pnpm run sonar:pick-batch -- --size=${SONAR_BATCH_SIZE} --out=.quality-loop/batch.json
             '''
           }
         }

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -45,6 +45,7 @@ Variables de entorno en el job (Environment / pipeline):
 
 | Variable | Default |
 |----------|---------|
+| `SONAR_BATCH_SIZE` | `10` (issues por batch en pick-batch) |
 | `SONAR_LOOP_MODEL` | `MiniMax-M3` (1M context) |
 | `SONAR_LOOP_TIMEOUT_MS` | `900000` (15 min) |
 | `OPENCODE_CONFIG` | `scripts/sonar/opencode.ci.json` |
@@ -113,7 +114,7 @@ export OPENCODE_CONFIG="$PWD/scripts/sonar/opencode.ci.json"
 export OPENCODE_DISABLE_AUTOUPDATE=1
 
 # Batch de prueba
-pnpm run sonar:pick-batch -- --size=3 --out=.quality-loop/batch.json
+pnpm run sonar:pick-batch -- --size=10 --out=.quality-loop/batch.json
 
 # Dry run (sin API)
 pnpm run sonar:run-agent -- --dry-run
@@ -149,7 +150,7 @@ Mismo prompt que usa el harness interactivo: [`.cursor/prompts/sonar-fix-batch.m
 
 Tras merge a `main`:
 
-1. Build manual de `dome-quality-loop` con batch pequeño (`SONAR_BATCH_SIZE=2` si se expone en pick-batch)
+1. Build manual de `dome-quality-loop` con batch reducido (`SONAR_BATCH_SIZE=3` en el job) para pruebas
 2. Confirmar stage *Agent fix (OpenCode)* verde y `verify-loop-diff.sh` sin falsos positivos
 3. PR auto-merge solo si CI pasa — **no confiar en auto-merge hasta 1 run verde**
 

--- a/scripts/sonar/pick-batch.mjs
+++ b/scripts/sonar/pick-batch.mjs
@@ -4,8 +4,8 @@
  * Prefers same rule + same directory; prioritizes SECURITY/RELIABILITY.
  *
  * Usage:
- *   GITHUB_TOKEN=... node scripts/sonar/pick-batch.mjs [--size=5] [--out=.quality-loop/batch.json]
- *   node scripts/sonar/pick-batch.mjs --from=issues.json --size=5
+ *   GITHUB_TOKEN=... node scripts/sonar/pick-batch.mjs [--size=10] [--out=.quality-loop/batch.json]
+ *   node scripts/sonar/pick-batch.mjs --from=issues.json --size=10
  */
 
 import fs from 'node:fs';
@@ -21,7 +21,7 @@ import {
 } from './lib.mjs';
 
 const args = parseArgs(process.argv.slice(2));
-const batchSize = Number(args.size || 5);
+const batchSize = Number(args.size || process.env.SONAR_BATCH_SIZE || 10);
 const outPath = path.resolve(args.out || '.quality-loop/batch.json');
 
 /** @param {string} component */


### PR DESCRIPTION
## Summary

- Sets `SONAR_BATCH_SIZE=10` in `Jenkinsfile.quality-loop` (was 5).
- `pick-batch.mjs` reads `SONAR_BATCH_SIZE` env; default CLI fallback is now 10.

## Test plan

- [ ] Next hourly Jenkins run picks up to 10 related issues per batch