### PR TITLE
fix(sonar): agent must pass CI verify before opening PR

### DIFF
--- a/.cursor/prompts/sonar-fix-batch-ci.md
+++ b/.cursor/prompts/sonar-fix-batch-ci.md
@@ -8,8 +8,31 @@ Fix the Sonar issues in the attached batch with **minimal, targeted diffs**. Jen
 2. Apply the **smallest** change that satisfies the Sonar rule and message.
 3. Do **not** refactor, rename, or touch unrelated code.
 4. Do **not** create branches, commits, PRs, or run `git`.
-5. After all issues: run verify **once**:
-   `pnpm run typecheck && pnpm run lint && pnpm run build:packages && pnpm run test:coverage`
+5. **Before you finish:** run the full pre-PR verify (mandatory — PR auto-merge waits on GitHub CI):
+
+   ```bash
+   bash scripts/jenkins/verify-batch-pr.sh
+   ```
+
+   If it fails, fix the errors and **re-run until exit 0**. Do not reply "done" or "verify pass" until this script succeeds.
+
+## Verify checklist (what the script runs)
+
+Same gates as GitHub CI on batch PRs:
+
+| Step | Command (inside script) |
+|------|-------------------------|
+| Types | `pnpm run typecheck` |
+| Lint | `pnpm run lint` (0 **errors**; warnings OK) |
+| IPC docs | `pnpm run check:ipc-inventory` (auto-regenerates `docs/architecture/ipc-channels.md` if stale) |
+| Packages | `pnpm run build:packages` |
+| Tests | `pnpm run test:coverage` |
+| Renderer build | `pnpm run build` |
+| Dep structure | `pnpm run depcruise` |
+
+### If you edit `electron/ipc/**`
+
+Line numbers in IPC handlers change → `ipc-channels.md` must stay in sync. The verify script regenerates it when needed. **Stage/commit is Jenkins' job** — just ensure the regenerated file exists on disk after verify passes.
 
 ## Tool discipline
 
@@ -20,8 +43,8 @@ Fix the Sonar issues in the attached batch with **minimal, targeted diffs**. Jen
 
 ## Priority
 
-SECURITY → RELIABILITY → maintainability (void operator, complexity).
+SECURITY → RELIABILITY → maintainability (void operator, complexity, nesting depth).
 
-## Finish
+## Finish (only after verify-batch-pr.sh exits 0)
 
-Reply with: files changed | Sonar keys addressed | verify pass/fail.
+Reply with: files changed | Sonar keys addressed | verify pass/fail (must be **pass**).

--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -163,10 +163,7 @@ pipeline {
         ]) {
           sh '''
             set -eux
-            pnpm run typecheck
-            pnpm run lint
-            pnpm run build:packages
-            pnpm run test:coverage
+            bash scripts/jenkins/verify-batch-pr.sh "$PWD"
 
             BRANCH="fix/sonar-batch-$(date +%Y%m%d-%H%M)"
             git config user.email "jenkins@dowi.es"

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -94,7 +94,7 @@ pnpm run sonar:run-agent -- --dry-run
 2. Pick batch → `.quality-loop/batch.json`
 3. Fix mecánico (`void` operator) si aplica
 4. **Agent fix (OpenCode)** — `pnpm run sonar:run-agent` (MiniMax M3 vía OpenCode CLI)
-5. `verify-loop-diff.sh` → typecheck, lint, coverage → branch + PR (**auto-merge squash** cuando pase CI)
+5. `verify-batch-pr.sh` + `verify-loop-diff.sh` → branch + PR (**auto-merge squash** cuando pase CI)
 6. Close resolved en Sonar
 
 ### Auto-merge de PRs

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "sonar:fetch-issues": "node scripts/sonar/fetch-issues.mjs",
     "sonar:sync-github": "node scripts/sonar/sync-github-issues.mjs",
     "sonar:pick-batch": "node scripts/sonar/pick-batch.mjs",
+    "sonar:verify-batch": "bash scripts/jenkins/verify-batch-pr.sh",
     "sonar:close-resolved": "node scripts/sonar/close-resolved.mjs",
     "sonar:close-github-duplicates": "node scripts/sonar/close-duplicate-github-issues.mjs",
     "sonar:run-agent": "node scripts/sonar/run-opencode-agent.mjs",

--- a/scripts/jenkins/verify-batch-pr.sh
+++ b/scripts/jenkins/verify-batch-pr.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Pre-PR checks for Sonar quality-loop — mirrors GitHub CI required jobs.
+# Used by OpenCode agent (before finish) and Jenkins Verify & PR stage.
+set -euo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT"
+
+echo "=== verify-batch-pr: typecheck ==="
+pnpm run typecheck
+
+echo "=== verify-batch-pr: lint (renderer) ==="
+pnpm run lint
+
+echo "=== verify-batch-pr: IPC inventory ==="
+if ! pnpm run check:ipc-inventory; then
+  echo "ipc-channels.md out of date — regenerating (common after electron/ipc edits)..."
+  node scripts/generate-ipc-inventory.mjs
+  pnpm run check:ipc-inventory
+fi
+
+echo "=== verify-batch-pr: build packages ==="
+pnpm run build:packages
+
+echo "=== verify-batch-pr: test coverage ==="
+pnpm run test:coverage
+
+echo "=== verify-batch-pr: Vite build ==="
+pnpm run build
+
+echo "=== verify-batch-pr: dependency structure ==="
+pnpm run depcruise
+
+echo "verify-batch-pr: OK"

--- a/scripts/sonar/opencode.ci.json
+++ b/scripts/sonar/opencode.ci.json
@@ -16,6 +16,8 @@
         "list": "allow",
         "bash": {
           "*": "deny",
+          "bash scripts/jenkins/verify-batch-pr.sh": "allow",
+          "bash scripts/jenkins/verify-batch-pr.sh *": "allow",
           "pnpm *": "allow",
           "npm *": "allow",
           "node *": "allow"


### PR DESCRIPTION
## Summary

- Adds `scripts/jenkins/verify-batch-pr.sh` — same gates GitHub CI expects on batch PRs.
- OpenCode agent prompt now **requires** this script to exit 0 before finishing (replaces partial `pnpm run lint && …` chain).
- Jenkins Verify & PR stage uses the same script (single source of truth).
- Auto-regenerates `docs/architecture/ipc-channels.md` when `check:ipc-inventory` fails (root cause of #676 Lint failure after `plugins.cjs` edit).

## Test plan

- [ ] Next quality-loop run: agent runs `verify-batch-pr.sh` before done
- [ ] Batch PR includes regenerated `ipc-channels.md` when ipc files touched
- [ ] GitHub CI Lint + Build jobs green on auto-merge PR