### PR TITLE
fix(cmdk): palette centrado, focus ring limpio y panel de preview de contenido

### DIFF
--- a/app/components/search/CommandPalette.tsx
+++ b/app/components/search/CommandPalette.tsx
@@ -14,6 +14,7 @@ import { buildNavigationDestinations, buildQuickActions } from './commandPalette
 import { matchesQuery, modKeyLabel, type PaletteRow } from './commandPaletteTypes';
 import { useCommandPaletteSearch } from './useCommandPaletteSearch';
 import { CommandPaletteResultsList } from './CommandPaletteResultsList';
+import CommandPaletteResourcePreview from './CommandPaletteResourcePreview';
 
 export default function CommandPalette() {
   const { t } = useTranslation();
@@ -216,6 +217,7 @@ export default function CommandPalette() {
         kind: 'resource',
         label: r.title,
         type: r.type,
+        resourceId: r.id,
         sublabel: r.updated_at ? formatDistanceToNow(r.updated_at * 1000) : undefined,
         icon: (
           <DomeResourceIcon type={r.type} name={r.title} size={16} className="size-4 shrink-0" strokeWidth={1.5} />
@@ -230,6 +232,7 @@ export default function CommandPalette() {
         kind: 'interaction',
         label: r.title,
         type: r.type,
+        resourceId: r.id,
         sublabel: t('command.notes_annotations'),
         icon: (
           <DomeResourceIcon type={r.type} name={r.title} size={16} className="size-4 shrink-0" strokeWidth={1.5} />
@@ -261,6 +264,14 @@ export default function CommandPalette() {
   const hasResults = flatRows.length > 0;
   const showNoResults = Boolean(trimmedQuery) && !isSearching && !hasResults;
 
+  // Preview pane: stable while arrowing (falls back to the first result when
+  // a nav row is selected) so the dialog width doesn't flicker.
+  const selectedRow = selectedIndex !== undefined ? flatRows[selectedIndex] : undefined;
+  const hasResourceResults = Boolean(trimmedQuery) && (resources.length > 0 || interactions.length > 0);
+  const previewResourceId = hasResourceResults
+    ? (selectedRow?.resourceId ?? resources[0]?.id ?? interactions[0]?.id ?? null)
+    : null;
+
   return (
     <div
       className="fixed inset-0 z-[100] flex items-start justify-center px-4 pt-[12vh]"
@@ -274,7 +285,10 @@ export default function CommandPalette() {
       <dialog
         ref={panelRef}
         open
-        className="w-full max-w-xl overflow-hidden rounded-2xl border shadow-2xl m-0 max-h-none p-0"
+        // `static` neutralizes the <dialog> UA stylesheet (position: absolute
+        // + inset: 0) which would pin the panel to the overlay's left edge
+        // instead of letting flexbox center it.
+        className={`static w-full ${previewResourceId ? 'max-w-3xl' : 'max-w-xl'} overflow-hidden rounded-2xl border shadow-2xl m-0 max-h-none p-0 transition-[max-width] duration-150`}
         style={{
           background: 'var(--dome-bg)',
           borderColor: 'var(--dome-border)',
@@ -294,7 +308,7 @@ export default function CommandPalette() {
             onChange={(e) => setQuery(e.target.value)}
             placeholder={t('command.palette_placeholder')}
             aria-label={t('command.palette_placeholder')}
-            className="flex-1 bg-transparent text-sm outline-none"
+            className="flex-1 border-0 bg-transparent text-sm shadow-none outline-none focus-visible:border-0 focus-visible:shadow-none"
             style={{ color: 'var(--dome-text)' }}
             autoComplete="off"
             spellCheck={false}
@@ -323,20 +337,32 @@ export default function CommandPalette() {
           </kbd>
         </div>
 
-        <CommandPaletteResultsList
-          showEmptyQuery={showEmptyQuery}
-          showNoResults={showNoResults}
-          trimmedQuery={trimmedQuery}
-          quickActions={quickActions}
-          navigationDestinations={navigationDestinations}
-          filteredNav={filteredNav}
-          resources={resources}
-          interactions={interactions}
-          flatRows={flatRows}
-          selectedIndex={selectedIndex}
-          setSelectedIndex={setSelectedIndex}
-          listRef={listRef}
-        />
+        <div className="flex min-h-0">
+          <div className="min-w-0 flex-1">
+            <CommandPaletteResultsList
+              showEmptyQuery={showEmptyQuery}
+              showNoResults={showNoResults}
+              trimmedQuery={trimmedQuery}
+              quickActions={quickActions}
+              navigationDestinations={navigationDestinations}
+              filteredNav={filteredNav}
+              resources={resources}
+              interactions={interactions}
+              flatRows={flatRows}
+              selectedIndex={selectedIndex}
+              setSelectedIndex={setSelectedIndex}
+              listRef={listRef}
+            />
+          </div>
+          {previewResourceId ? (
+            <div
+              className="hidden w-[290px] shrink-0 overflow-hidden border-l sm:block"
+              style={{ borderColor: 'var(--dome-border)', background: 'var(--dome-surface)' }}
+            >
+              <CommandPaletteResourcePreview resourceId={previewResourceId} query={trimmedQuery} />
+            </div>
+          ) : null}
+        </div>
 
         <div
           className="flex items-center justify-between border-t px-4 py-2 text-[11px]"

--- a/app/components/search/CommandPaletteResourcePreview.tsx
+++ b/app/components/search/CommandPaletteResourcePreview.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Folder, Loader2 } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { Resource } from '@/types';
+import DomeResourceIcon from '@/components/ui/DomeResourceIcon';
+import { loadNoteMarkdown } from '@/lib/notes/loadNoteMarkdown';
+import { formatDistanceToNow } from '@/lib/utils';
+
+const CACHE_MAX = 30;
+const MARKDOWN_MAX = 2000;
+const SNIPPET_RADIUS = 260;
+
+interface PreviewData {
+  title: string;
+  type: string;
+  updatedAt: number | null;
+  folderPath: string;
+  /** Note body rendered as Markdown. */
+  markdown: string | null;
+  /** Plain-text body (non-note text resources). */
+  text: string | null;
+  /** Image cover (image/video thumbnails). */
+  imageUrl: string | null;
+  /** First PDF page render. */
+  pdfDataUrl: string | null;
+}
+
+const cache = new Map<string, PreviewData>();
+
+function remember(id: string, data: PreviewData): void {
+  if (cache.has(id)) cache.delete(id);
+  cache.set(id, data);
+  while (cache.size > CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+}
+
+async function fetchFolderPath(folderId: unknown): Promise<string> {
+  const parts: string[] = [];
+  let current = typeof folderId === 'string' ? folderId : null;
+  const seen = new Set<string>();
+  while (current && !seen.has(current) && parts.length < 4) {
+    seen.add(current);
+    const res = await window.electron?.db?.resources?.getById?.(current);
+    if (!res?.success || !res.data) break;
+    const row = res.data as { title?: string; folder_id?: string | null };
+    if (row.title) parts.unshift(row.title);
+    current = typeof row.folder_id === 'string' ? row.folder_id : null;
+  }
+  return parts.join(' / ');
+}
+
+async function fetchPreview(resourceId: string): Promise<PreviewData | null> {
+  const res = await window.electron?.db?.resources?.getById?.(resourceId);
+  if (!res?.success || !res.data) return null;
+  const r = res.data as unknown as Record<string, unknown>;
+  const type = String(r.type ?? 'note');
+
+  const data: PreviewData = {
+    title: String(r.title ?? ''),
+    type,
+    updatedAt: typeof r.updated_at === 'number' ? r.updated_at : null,
+    folderPath: await fetchFolderPath(r.folder_id),
+    markdown: null,
+    text: null,
+    imageUrl: null,
+    pdfDataUrl: null,
+  };
+
+  if (type === 'note') {
+    try {
+      const md = await loadNoteMarkdown(r as unknown as Resource);
+      if (md?.trim()) data.markdown = md.trim().slice(0, MARKDOWN_MAX);
+    } catch { /* fall through to plain text */ }
+  } else if (type === 'pdf') {
+    try {
+      const page = await window.electron?.pdf?.renderPage?.({ resourceId, pageNumber: 1, scale: 1 });
+      if (page && typeof page === 'object' && 'success' in page && page.success) {
+        const url = (page as { dataUrl?: string }).dataUrl;
+        if (typeof url === 'string' && url) data.pdfDataUrl = url;
+      }
+    } catch { /* fall through to plain text */ }
+  } else if ((type === 'image' || type === 'video') && typeof r.thumbnail_data === 'string' && r.thumbnail_data) {
+    data.imageUrl = r.thumbnail_data;
+  }
+
+  if (!data.markdown && !data.pdfDataUrl && !data.imageUrl) {
+    const text =
+      (typeof r.content_text === 'string' && r.content_text.trim()) ||
+      (typeof r.content === 'string' && r.content.trim()) ||
+      '';
+    data.text = text || null;
+  }
+
+  return data;
+}
+
+/** Slice `text` around the first occurrence of `query` so the match is visible. */
+function contextAround(text: string, query: string): string {
+  const idx = query ? text.toLowerCase().indexOf(query.toLowerCase()) : -1;
+  if (idx < 0) return text.slice(0, SNIPPET_RADIUS * 2);
+  const start = Math.max(0, idx - SNIPPET_RADIUS);
+  const end = Math.min(text.length, idx + query.length + SNIPPET_RADIUS);
+  return `${start > 0 ? '…' : ''}${text.slice(start, end)}${end < text.length ? '…' : ''}`;
+}
+
+function highlight(text: string, query: string): ReactNode {
+  const q = query.trim();
+  if (!q) return text;
+  const re = new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
+  const parts: ReactNode[] = [];
+  let last = 0;
+  for (const match of text.matchAll(re)) {
+    const idx = match.index ?? 0;
+    if (idx > last) parts.push(text.slice(last, idx));
+    parts.push(<mark key={idx}>{match[0]}</mark>);
+    last = idx + match[0].length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts.length > 0 ? parts : text;
+}
+
+interface Props {
+  resourceId: string;
+  query: string;
+}
+
+/**
+ * Right-hand preview pane of the command palette: shows where the selected
+ * result lives and enough of its content to verify it's the right document.
+ */
+export default function CommandPaletteResourcePreview({ resourceId, query }: Props) {
+  const { t } = useTranslation();
+  const [preview, setPreview] = useState<PreviewData | null>(() => cache.get(resourceId) ?? null);
+  const [loading, setLoading] = useState(!cache.has(resourceId));
+
+  useEffect(() => {
+    const cached = cache.get(resourceId);
+    if (cached) {
+      setPreview(cached);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    // Small debounce so arrowing through results doesn't fire an IPC per row.
+    const timer = window.setTimeout(async () => {
+      try {
+        const data = await fetchPreview(resourceId);
+        if (cancelled) return;
+        if (data) remember(resourceId, data);
+        setPreview(data);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }, 140);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [resourceId]);
+
+  // Highlighted match context (verification aid), independent of the render mode.
+  const matchContext = useMemo(() => {
+    if (!preview || !query.trim()) return null;
+    const source = preview.markdown ?? preview.text ?? '';
+    if (!source || source.toLowerCase().indexOf(query.trim().toLowerCase()) < 0) return null;
+    return contextAround(source, query.trim());
+  }, [preview, query]);
+
+  if (loading && !preview) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="size-4 animate-spin" style={{ color: 'var(--dome-text-muted)' }} />
+      </div>
+    );
+  }
+
+  if (!preview) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-xs" style={{ color: 'var(--dome-text-muted)' }}>
+        {t('command.preview_empty')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="dome-cmdk-preview flex h-full min-h-0 flex-col">
+      {/* Header: title + location */}
+      <div className="shrink-0 border-b px-3.5 py-2.5" style={{ borderColor: 'var(--dome-border)' }}>
+        <div className="flex items-center gap-2">
+          <span className="shrink-0" style={{ color: 'var(--dome-text-muted)' }}>
+            <DomeResourceIcon type={preview.type} name={preview.title} size={15} strokeWidth={1.5} />
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[13px] font-semibold" style={{ color: 'var(--dome-text)' }}>
+            {preview.title}
+          </span>
+        </div>
+        <div className="mt-1 flex items-center gap-1.5 text-[11px]" style={{ color: 'var(--dome-text-muted)' }}>
+          {preview.folderPath ? (
+            <>
+              <Folder className="size-3 shrink-0" strokeWidth={1.75} />
+              <span className="truncate">{preview.folderPath}</span>
+            </>
+          ) : null}
+          {preview.updatedAt ? (
+            <span className="ml-auto shrink-0">{formatDistanceToNow(preview.updatedAt)}</span>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Match context strip: the exact place the query appears. */}
+      {matchContext ? (
+        <div
+          className="shrink-0 border-b px-3.5 py-2 text-[11px] leading-relaxed"
+          style={{
+            borderColor: 'var(--dome-border)',
+            background: 'color-mix(in srgb, var(--dome-accent) 5%, transparent)',
+            color: 'var(--dome-text-secondary)',
+          }}
+        >
+          <span className="line-clamp-4">{highlight(matchContext, query.trim())}</span>
+        </div>
+      ) : null}
+
+      {/* Body */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {preview.markdown ? (
+          <div className="dome-cmdk-md px-3.5 py-3">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{ a: ({ children }) => <span>{children}</span>, img: () => null }}
+            >
+              {preview.markdown}
+            </ReactMarkdown>
+          </div>
+        ) : preview.pdfDataUrl ? (
+          <img src={preview.pdfDataUrl} alt="" className="block w-full" draggable={false} />
+        ) : preview.imageUrl ? (
+          <img src={preview.imageUrl} alt="" className="block w-full object-contain" draggable={false} />
+        ) : preview.text ? (
+          <p className="whitespace-pre-wrap px-3.5 py-3 text-[11px] leading-relaxed" style={{ color: 'var(--dome-text-secondary)' }}>
+            {highlight(contextAround(preview.text, query.trim()), query.trim())}
+          </p>
+        ) : (
+          <div className="flex h-full items-center justify-center px-4 text-center text-xs" style={{ color: 'var(--dome-text-muted)' }}>
+            {t('command.preview_empty')}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/search/commandPaletteTypes.ts
+++ b/app/components/search/commandPaletteTypes.ts
@@ -10,6 +10,8 @@ export interface PaletteRow {
   type?: string;
   icon: ReactNode;
   run: () => void;
+  /** Backing resource id (resource/interaction rows) for the preview pane. */
+  resourceId?: string;
 }
 
 export interface SearchResourceRow {

--- a/app/globals.css
+++ b/app/globals.css
@@ -5707,3 +5707,86 @@ input[type='range'].dome-media-seekbar::-webkit-slider-thumb {
 input[type='range'].dome-media-seekbar::-webkit-slider-thumb:hover {
   transform: scale(1.2);
 }
+
+/* Command palette preview pane: highlight marks + scaled-down Markdown
+   typography so the selected result's content is verifiable at a glance. */
+.dome-cmdk-preview mark {
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+  color: var(--dome-text);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.dome-cmdk-md {
+  font-size: 11px;
+  line-height: 1.55;
+  color: var(--dome-text-secondary);
+  text-align: left;
+}
+
+.dome-cmdk-md h1,
+.dome-cmdk-md h2,
+.dome-cmdk-md h3,
+.dome-cmdk-md h4 {
+  margin: 0 0 4px;
+  font-weight: 700;
+  line-height: 1.3;
+  color: var(--dome-text);
+}
+
+.dome-cmdk-md h1 { font-size: 14px; }
+.dome-cmdk-md h2 { font-size: 13px; }
+.dome-cmdk-md h3,
+.dome-cmdk-md h4 { font-size: 12px; }
+
+.dome-cmdk-md p { margin: 0 0 6px; }
+
+.dome-cmdk-md ul,
+.dome-cmdk-md ol {
+  margin: 0 0 6px;
+  padding-left: 16px;
+}
+
+.dome-cmdk-md li { margin: 0 0 2px; }
+
+.dome-cmdk-md strong { color: var(--dome-text); }
+
+.dome-cmdk-md code {
+  font-size: 10px;
+  padding: 0 3px;
+  border-radius: 3px;
+  background: var(--dome-bg-tertiary);
+}
+
+.dome-cmdk-md pre {
+  margin: 0 0 6px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  overflow-x: auto;
+  background: var(--dome-bg-tertiary);
+}
+
+.dome-cmdk-md blockquote {
+  margin: 0 0 6px;
+  padding-left: 8px;
+  border-left: 2px solid var(--dome-border);
+  color: var(--dome-text-muted);
+}
+
+.dome-cmdk-md table {
+  margin: 0 0 6px;
+  font-size: 10px;
+  border-collapse: collapse;
+}
+
+.dome-cmdk-md th,
+.dome-cmdk-md td {
+  padding: 1px 5px;
+  border: 1px solid var(--dome-border);
+}
+
+.dome-cmdk-md hr {
+  margin: 6px 0;
+  border: none;
+  border-top: 1px solid var(--dome-border);
+}

--- a/packages/i18n/locales/en/command.json
+++ b/packages/i18n/locales/en/command.json
@@ -19,5 +19,6 @@
   "palette_hint": "↑↓ navigate · ↵ open",
   "palette_esc": "esc close",
   "navigate": "Go to",
-  "quick_actions": "Quick actions"
+  "quick_actions": "Quick actions",
+  "preview_empty": "No preview available"
 }

--- a/packages/i18n/locales/es/command.json
+++ b/packages/i18n/locales/es/command.json
@@ -19,5 +19,6 @@
   "palette_hint": "↑↓ navegar · ↵ abrir",
   "palette_esc": "esc cerrar",
   "navigate": "Ir a",
-  "quick_actions": "Acciones rápidas"
+  "quick_actions": "Acciones rápidas",
+  "preview_empty": "Sin vista previa disponible"
 }

--- a/packages/i18n/locales/fr/command.json
+++ b/packages/i18n/locales/fr/command.json
@@ -19,5 +19,6 @@
   "palette_hint": "↑↓ naviguer · ↵ ouvrir",
   "palette_esc": "esc fermer",
   "navigate": "Aller à",
-  "quick_actions": "Actions rapides"
+  "quick_actions": "Actions rapides",
+  "preview_empty": "Aucun aperçu disponible"
 }

--- a/packages/i18n/locales/pt/command.json
+++ b/packages/i18n/locales/pt/command.json
@@ -19,5 +19,6 @@
   "palette_hint": "↑↓ navegar · ↵ abrir",
   "palette_esc": "esc fechar",
   "navigate": "Ir para",
-  "quick_actions": "Ações rápidas"
+  "quick_actions": "Ações rápidas",
+  "preview_empty": "Sem pré-visualização disponível"
 }


### PR DESCRIPTION
## Qué arregla

**1. Palette anclado al borde izquierdo (bug visual de las capturas).** El `<dialog>` hereda del UA stylesheet `position: absolute; inset: 0`, que ignora el centrado flex del overlay y lo clava arriba a la izquierda. Con `static` el overlay vuelve a centrarlo. (Mismo patrón que el fix del popover de transcripción en v2.8.8.)

**2. Rectángulo alrededor del input.** La regla global `input:focus-visible { box-shadow: 0 0 0 3px …; border-color: accent }` de `globals.css` pintaba un anillo dentro de la cabecera del palette (el input va sin borde por diseño). Suprimido localmente en el input del palette.

## Qué añade

**Panel de preview de contenido (290px, a la derecha) mientras buscas:**
- Título, icono de tipo, **ruta de carpetas** y fecha de modificación — desambigua resultados con el mismo nombre (los dos "POST-CAMPAIGN" de la captura).
- **Franja de contexto del match**: el fragmento exacto donde aparece la query, con las coincidencias resaltadas.
- El contenido en sí: **notas renderizadas como Markdown** (misma fuente que el editor: mirror `.md` del vault vía `loadNoteMarkdown`), **PDFs con su primera página**, imágenes/vídeos con thumbnail, y el resto de tipos con un extracto centrado en la primera coincidencia y resaltado.
- Mientras navegas con ↑↓, si el row seleccionado es de navegación el panel mantiene el primer recurso (el ancho del diálogo no parpadea). Fetch con debounce de 140ms y caché LRU acotada para que recorrer resultados no dispare un IPC por fila.
- El diálogo pasa de `max-w-xl` a `max-w-3xl` solo cuando hay panel; en pantallas estrechas (`< sm`) el panel se oculta.

## Verificación
- `tsc --noEmit` ✅ · eslint 0 errores ✅ · `pnpm run build` ✅ · `check:design-system` ✅
- Clave i18n nueva `command.preview_empty` en en/es/fr/pt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBAidbxybgjh18op1P4aF5