### PR TITLE
v2.8.9 hotfix — Home boot crash (React #130), vault-native imports (.md → notes), Finder drag & drop

### DIFF
--- a/app/components/ErrorBoundary.tsx
+++ b/app/components/ErrorBoundary.tsx
@@ -6,6 +6,10 @@ interface Props {
   children: ReactNode;
   fallback?: ReactNode;
   onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+  /** Extra data attached to the Sentry report (e.g. which tab crashed). */
+  context?: Record<string, unknown>;
+  /** Optional escape hatch rendered under the retry button of the default fallback. */
+  action?: ReactNode;
 }
 
 interface State {
@@ -25,7 +29,10 @@ export default class ErrorBoundary extends Component<Props, State> {
 
   override componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     console.error('[ErrorBoundary] Caught error:', error, errorInfo);
-    captureExceptionSentry(error, { componentStack: errorInfo.componentStack });
+    captureExceptionSentry(error, {
+      componentStack: errorInfo.componentStack,
+      ...this.props.context,
+    });
     this.props.onError?.(error, errorInfo);
   }
 
@@ -38,6 +45,7 @@ export default class ErrorBoundary extends Component<Props, State> {
         <ErrorState
           error={this.state.error.message || 'An unexpected error occurred'}
           onRetry={() => this.setState({ hasError: false, error: null })}
+          action={this.props.action}
         />
       );
     }

--- a/app/components/chat/ArtifactCard.tsx
+++ b/app/components/chat/ArtifactCard.tsx
@@ -274,8 +274,13 @@ function ArtifactHeader({
   copied: boolean;
 }) {
   const { t } = useTranslation();
-  const styles = ARTIFACT_STYLES[artifact.type];
-  const Icon = ARTIFACT_ICONS[artifact.type];
+  // Fallbacks: chat history can contain artifact types from other app
+  // versions; an unknown type must degrade, not crash the tab (React error 130).
+  const styles = ARTIFACT_STYLES[artifact.type] ?? {
+    borderColor: 'var(--border)',
+    iconColor: 'var(--secondary-text)',
+  };
+  const Icon = ARTIFACT_ICONS[artifact.type] ?? FileText;
 
   const handleOpenTab = () => {
     const title = artifact.title || getArtifactTitle(artifact);

--- a/app/components/home/dashboard/editorial/ContinueActivityList.tsx
+++ b/app/components/home/dashboard/editorial/ContinueActivityList.tsx
@@ -2,13 +2,15 @@ import { useTranslation } from 'react-i18next';
 import type { ActivityItem } from '@/lib/hooks/useDashboardData';
 import { formatShortDistance, getResourceTypeLabel } from '@/lib/utils';
 import { DomeResourceIconBox } from '@/components/ui/DomeResourceIcon';
-import type { ResourceVisualKind } from '@/lib/resources/resourceVisual';
+import { inferResourceVisualKind, type ResourceVisualKind } from '@/lib/resources/resourceVisual';
 import { HomeSectionHeader } from '@/components/home/dashboard/editorial/HomeSectionHeader';
 
 function activityIconKind(item: ActivityItem): ResourceVisualKind {
   if (item.kind === 'chat') return 'chat';
-  if (item.resourceType === 'folder') return 'folder';
-  return (item.resourceType as ResourceVisualKind | undefined) ?? 'file';
+  // resourceType is a DB string ('document', 'transcription', …) — it must go
+  // through the type→kind mapping; a raw cast crashed Home when the recent
+  // activity contained a 'document' (Sentry 132319823, React error 130).
+  return inferResourceVisualKind(item.resourceType, item.title);
 }
 
 export function ContinueActivityList({

--- a/app/components/shell/ContentRouter.tsx
+++ b/app/components/shell/ContentRouter.tsx
@@ -101,6 +101,45 @@ function SuspenseWithTimeout({ children }: { children: ReactNode }) {
   );
 }
 
+function TabErrorHomeAction({ tabId }: { tabId: string }) {
+  const { t } = useTranslation();
+  return (
+    <DomeButton
+      type="button"
+      variant="secondary"
+      size="sm"
+      onClick={() => {
+        const store = useTabStore.getState();
+        store.activateTab(HOME_TAB_ID);
+        if (tabId !== HOME_TAB_ID) store.closeTab(tabId);
+      }}
+    >
+      {t('common.go_home')}
+    </DomeButton>
+  );
+}
+
+/**
+ * Per-tab error boundary: tags the Sentry report with the crashing tab
+ * (type/id/title/resource) and offers a "go home" escape hatch so a broken
+ * tab never leaves the user stuck on a retry loop (Sentry issue 132319823).
+ */
+function TabBoundary({ tab, children }: { tab: DomeTab; children: ReactNode }) {
+  return (
+    <ErrorBoundary
+      context={{
+        tabType: tab.type,
+        tabId: tab.id,
+        tabTitle: tab.title,
+        tabResourceId: tab.resourceId,
+      }}
+      action={<TabErrorHomeAction tabId={tab.id} />}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
 function NoResource() {
   const { t } = useTranslation();
   return (
@@ -160,320 +199,320 @@ function TabContent({ tab, referenceMode = false }: { tab: DomeTab; referenceMod
   switch (tab.type) {
     case 'home':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <HomePage />
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'projects':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full min-h-0 overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <ProjectsPage />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'note':
       if (!tab.resourceId) return <NoResource />;
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full overflow-hidden">
               <NoteWorkspaceClient resourceId={tab.resourceId} readOnly={referenceMode} compact={referenceMode} />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'notebook':
       if (!tab.resourceId) return <NoResource />;
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full overflow-hidden">
               <NotebookWorkspaceClient key={tab.resourceId} resourceId={tab.resourceId} />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'resource':
       if (!tab.resourceId) return <NoResource />;
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full overflow-hidden">
               <WorkspaceClient key={tab.resourceId} resourceId={tab.resourceId} />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'url':
       if (!tab.resourceId) return <NoResource />;
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full overflow-hidden">
               <URLWorkspaceClient key={tab.resourceId} resourceId={tab.resourceId} />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'youtube':
       if (!tab.resourceId) return <NoResource />;
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full overflow-hidden">
               <YouTubeWorkspaceClient key={tab.resourceId} resourceId={tab.resourceId} />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'ppt':
       if (!tab.resourceId) return <NoResource />;
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full overflow-hidden">
               <PptWorkspaceClient key={tab.resourceId} resourceId={tab.resourceId} />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'settings':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full min-w-0 w-full overflow-auto" style={{ background: 'var(--dome-bg)' }}>
               <SettingsPage />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'calendar':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full overflow-auto" style={{ background: 'var(--dome-bg)' }}>
               <CalendarPage />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'github':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <GitHubView />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'email':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <SuspenseWithTimeout>
             <div className="flex flex-col h-full overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <EmailView />
             </div>
           </SuspenseWithTimeout>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'social':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <SuspenseWithTimeout>
             <div className="flex flex-col h-full overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <SocialHubView />
             </div>
           </SuspenseWithTimeout>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'chat':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <ChatTabView sessionId={tab.resourceId ?? ''} onClose={() => closeTab(tab.id)} />
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'learn':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full overflow-auto" style={{ background: 'var(--dome-bg)' }}>
               <LearnPage />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'studio':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full overflow-auto" style={{ background: 'var(--dome-bg)' }}>
               <LearnTabShell initialSection="all" />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'flashcards':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full overflow-auto" style={{ background: 'var(--dome-bg)' }}>
               <LearnTabShell initialSection="decks" />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'tags':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full min-h-0 overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <LegacyTagsWorkspace />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'marketplace':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full overflow-auto" style={{ background: 'var(--dome-bg)' }}>
               <MarketplacePage />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'pipelines':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full min-h-0 overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <PipelinesBoard />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'agents':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full min-h-0 overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <AgentsStudioView />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'workflows':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full min-h-0 overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <WorkflowsStudioView />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'automations':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full min-h-0 overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <AutomationsStudioView />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'runs':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex flex-col h-full min-h-0 overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <RunsStudioView />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'folder':
       if (!tab.resourceId) return <NoResource />;
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <FolderTabView folderId={tab.resourceId} folderTitle={tab.title} />
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'transcriptions':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex h-full min-h-0 flex-col overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <TranscriptionsListPage />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'transcription-detail':
       if (!tab.resourceId) return <NoResource />;
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex h-full min-h-0 flex-col overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <TranscriptionDetailPage noteId={tab.resourceId} />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'semantic-graph':
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <div className="flex h-full min-h-0 flex-col overflow-hidden" style={{ background: 'var(--dome-bg)' }}>
               <SemanticGraphView focusResourceId={tab.resourceId} />
             </div>
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     case 'artifact':
       if (!tab.resourceId) return <NoResource />;
       return (
-        <ErrorBoundary>
+        <TabBoundary tab={tab}>
           <Suspense fallback={<Loading />}>
             <ArtifactWorkspaceClient resourceId={tab.resourceId} />
           </Suspense>
-        </ErrorBoundary>
+        </TabBoundary>
       );
 
     default:
@@ -559,9 +598,9 @@ export default function ContentRouter() {
             isActive={isActive}
             isPersistent={isPersistent}
           >
-            <ErrorBoundary>
+            <TabBoundary tab={tab}>
               <TabContentWithSplit tab={tab} />
-            </ErrorBoundary>
+            </TabBoundary>
           </TabPaneShell>
         );
       })}

--- a/app/components/shell/FolderTabView.tsx
+++ b/app/components/shell/FolderTabView.tsx
@@ -373,10 +373,8 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
     }
   }, [effectiveProjectId, listFolderId, t, openResourceTab]);
 
-  const handleUpload = useCallback(async () => {
-    if (!window.electron?.selectFiles || !window.electron?.resource?.importMultiple) return;
-    const paths = await window.electron.selectFiles({ properties: ['openFile', 'multiSelections'] });
-    if (!paths?.length) return;
+  const importPathsIntoView = useCallback(async (paths: string[]) => {
+    if (!paths.length || !window.electron?.resource?.importMultiple) return;
     const result = await window.electron.resource.importMultiple(paths, effectiveProjectId);
     if (listFolderId && result?.data?.length) {
       const moves: Promise<unknown>[] = [];
@@ -388,6 +386,54 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
     }
     await refetch();
   }, [effectiveProjectId, listFolderId, refetch]);
+
+  const handleUpload = useCallback(async () => {
+    if (!window.electron?.selectFiles) return;
+    const paths = await window.electron.selectFiles({ properties: ['openFile', 'multiSelections'] });
+    if (!paths?.length) return;
+    await importPathsIntoView(paths);
+  }, [importPathsIntoView]);
+
+  // ── Drag & drop import from Finder / OS file explorer ─────────────────────
+  // dragenter/dragleave fire on every child; a depth counter keeps the overlay
+  // stable until the pointer actually leaves the view.
+  const dragDepthRef = useRef(0);
+  const [osDropActive, setOsDropActive] = useState(false);
+
+  const isOsFileDrag = useCallback((e: React.DragEvent) => {
+    return Array.from(e.dataTransfer?.types ?? []).includes('Files');
+  }, []);
+
+  const handleOsDragEnter = useCallback((e: React.DragEvent) => {
+    if (!isOsFileDrag(e)) return;
+    e.preventDefault();
+    dragDepthRef.current += 1;
+    setOsDropActive(true);
+  }, [isOsFileDrag]);
+
+  const handleOsDragOver = useCallback((e: React.DragEvent) => {
+    if (!isOsFileDrag(e)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  }, [isOsFileDrag]);
+
+  const handleOsDragLeave = useCallback((e: React.DragEvent) => {
+    if (!isOsFileDrag(e)) return;
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setOsDropActive(false);
+  }, [isOsFileDrag]);
+
+  const handleOsDrop = useCallback(async (e: React.DragEvent) => {
+    if (!isOsFileDrag(e)) return;
+    e.preventDefault();
+    dragDepthRef.current = 0;
+    setOsDropActive(false);
+    const files = Array.from(e.dataTransfer.files ?? []);
+    if (!files.length) return;
+    const paths = (window.electron?.getPathsForFiles?.(files) ?? []).filter(Boolean) as string[];
+    if (!paths.length) return;
+    await importPathsIntoView(paths);
+  }, [isOsFileDrag, importPathsIntoView]);
 
   const handleAddUrl = useCallback((url: string) => {
     if (url && window.electron?.db?.resources?.create) {
@@ -584,7 +630,21 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
       : t('folder.itemCount', { count: itemCount });
 
   return (
-    <div className="dome-folder-view">
+    <div
+      className="dome-folder-view"
+      onDragEnter={handleOsDragEnter}
+      onDragOver={handleOsDragOver}
+      onDragLeave={handleOsDragLeave}
+      onDrop={handleOsDrop}
+    >
+      {osDropActive && (
+        <div className="dome-folder-view__drop-overlay" aria-hidden>
+          <div className="dome-folder-view__drop-overlay-card">
+            <Upload className="size-6" aria-hidden />
+            <span>{t('folder.dropToImport', 'Suelta para importar aquí')}</span>
+          </div>
+        </div>
+      )}
       <div className="dome-folder-view__toolbar">
         <div className="dome-folder-view__nav-controls">
           <button

--- a/app/components/ui/DomeResourceIcon.tsx
+++ b/app/components/ui/DomeResourceIcon.tsx
@@ -30,7 +30,9 @@ export default function DomeResourceIcon({
   style,
 }: DomeResourceIconProps) {
   const kind = kindOverride ?? inferResourceVisualKind(type, name);
-  const Icon = RESOURCE_ICON_MAP[kind];
+  // Defensive fallback: an out-of-map `kind` override must degrade to the
+  // generic file icon, never render `undefined` (React error 130).
+  const Icon = RESOURCE_ICON_MAP[kind] ?? RESOURCE_ICON_MAP.file;
   return (
     <Icon
       size={size}

--- a/app/components/ui/ErrorState.tsx
+++ b/app/components/ui/ErrorState.tsx
@@ -1,12 +1,15 @@
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import DomeListState from '@/components/ui/DomeListState';
 
 interface ErrorStateProps {
   error: string;
   onRetry?: () => void;
+  /** Extra escape hatch rendered under the retry button (e.g. "go home"). */
+  action?: ReactNode;
 }
 
-export default function ErrorState({ error, onRetry }: ErrorStateProps) {
+export default function ErrorState({ error, onRetry, action }: ErrorStateProps) {
   const { t } = useTranslation();
   return (
     <DomeListState
@@ -14,6 +17,7 @@ export default function ErrorState({ error, onRetry }: ErrorStateProps) {
       errorMessage={error}
       onRetry={onRetry}
       retryLabel={t('ui.try_again')}
+      action={action}
       fullHeight
     />
   );

--- a/app/styles/folder-view.css
+++ b/app/styles/folder-view.css
@@ -1,12 +1,44 @@
 /* Filesystem-style folder tab — minimal Finder / Linear aesthetic */
 
 .dome-folder-view {
+  position: relative;
   display: flex;
   flex-direction: column;
   height: 100%;
   background: var(--dome-bg);
   container-type: inline-size;
   container-name: folder-view;
+}
+
+/* ── OS drag & drop import overlay ── */
+
+.dome-folder-view__drop-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  background: color-mix(in srgb, var(--dome-bg, var(--bg)) 72%, transparent);
+  border: 2px dashed var(--dome-accent, var(--accent));
+  border-radius: var(--radius-lg, 8px);
+  animation: overlay-appear 0.15s ease-out;
+}
+
+.dome-folder-view__drop-overlay-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 20px 28px;
+  border-radius: var(--radius-xl, 12px);
+  border: 1px solid var(--dome-border, var(--border));
+  background: var(--dome-surface, var(--bg-secondary));
+  color: var(--dome-accent, var(--accent));
+  font-size: 13px;
+  font-weight: 600;
+  box-shadow: var(--shadow-lg, 0 10px 15px -3px rgba(0, 0, 0, 0.1));
 }
 
 /* ── Toolbar (single row) ── */

--- a/docs/architecture/ipc-channels.md
+++ b/docs/architecture/ipc-channels.md
@@ -1,7 +1,7 @@
 # Canales IPC (autogenerado)
 
 > **No edites a mano.** Regenera con `pnpm run generate:ipc-inventory`.
-> Última generación: 2026-07-05T11:28:33.492Z
+> Última generación: 2026-07-05T18:39:44.156Z
 
 Canales detectados vía `ipcMain.handle` / `ipcMain.on` en `electron/ipc/**/*.cjs`.
 
@@ -448,22 +448,22 @@ Canales detectados vía `ipcMain.handle` / `ipcMain.on` en `electron/ipc/**/*.cj
 | `quiz:createRun` | `electron/ipc/learn/quiz.cjs:25` |
 | `quiz:getRun` | `electron/ipc/learn/quiz.cjs:110` |
 | `quiz:listRuns` | `electron/ipc/learn/quiz.cjs:92` |
-| `resource:delete` | `electron/ipc/data/resources.cjs:716` |
-| `resource:duplicate` | `electron/ipc/data/resources.cjs:676` |
-| `resource:export` | `electron/ipc/data/resources.cjs:624` |
-| `resource:extractPptImages` | `electron/ipc/data/resources.cjs:402` |
-| `resource:getFilePath` | `electron/ipc/data/resources.cjs:282` |
-| `resource:import` | `electron/ipc/data/resources.cjs:30` |
-| `resource:importFromContent` | `electron/ipc/data/resources.cjs:814` |
-| `resource:importMultiple` | `electron/ipc/data/resources.cjs:174` |
-| `resource:readDocumentContent` | `electron/ipc/data/resources.cjs:439` |
-| `resource:readFile` | `electron/ipc/data/resources.cjs:352` |
-| `resource:readFileBuffer` | `electron/ipc/data/resources.cjs:314` |
-| `resource:regenerateThumbnail` | `electron/ipc/data/resources.cjs:742` |
-| `resource:saveDocxFromHtml` | `electron/ipc/data/resources.cjs:537` |
-| `resource:scheduleIndex` | `electron/ipc/data/resources.cjs:144` |
-| `resource:setThumbnail` | `electron/ipc/data/resources.cjs:781` |
-| `resource:writeExcelContent` | `electron/ipc/data/resources.cjs:480` |
+| `resource:delete` | `electron/ipc/data/resources.cjs:719` |
+| `resource:duplicate` | `electron/ipc/data/resources.cjs:679` |
+| `resource:export` | `electron/ipc/data/resources.cjs:627` |
+| `resource:extractPptImages` | `electron/ipc/data/resources.cjs:405` |
+| `resource:getFilePath` | `electron/ipc/data/resources.cjs:285` |
+| `resource:import` | `electron/ipc/data/resources.cjs:203` |
+| `resource:importFromContent` | `electron/ipc/data/resources.cjs:817` |
+| `resource:importMultiple` | `electron/ipc/data/resources.cjs:250` |
+| `resource:readDocumentContent` | `electron/ipc/data/resources.cjs:442` |
+| `resource:readFile` | `electron/ipc/data/resources.cjs:355` |
+| `resource:readFileBuffer` | `electron/ipc/data/resources.cjs:317` |
+| `resource:regenerateThumbnail` | `electron/ipc/data/resources.cjs:745` |
+| `resource:saveDocxFromHtml` | `electron/ipc/data/resources.cjs:540` |
+| `resource:scheduleIndex` | `electron/ipc/data/resources.cjs:220` |
+| `resource:setThumbnail` | `electron/ipc/data/resources.cjs:784` |
+| `resource:writeExcelContent` | `electron/ipc/data/resources.cjs:483` |
 | `runs:abort` | `electron/ipc/agents/runs.cjs:66` |
 | `runs:delete` | `electron/ipc/agents/runs.cjs:77` |
 | `runs:get` | `electron/ipc/agents/runs.cjs:6` |
@@ -551,7 +551,7 @@ Canales detectados vía `ipcMain.handle` / `ipcMain.on` en `electron/ipc/**/*.cj
 | `updater:download` | `electron/ipc/core/updater.cjs:20` |
 | `updater:install` | `electron/ipc/core/updater.cjs:31` |
 | `updater:skip` | `electron/ipc/core/updater.cjs:42` |
-| `vault:openRoot` | `electron/ipc/data/resources.cjs:695` |
+| `vault:openRoot` | `electron/ipc/data/resources.cjs:698` |
 | `web:get-youtube-thumbnail` | `electron/ipc/integrations/web.cjs:43` |
 | `web:process` | `electron/ipc/integrations/web.cjs:116` |
 | `web:save-screenshot` | `electron/ipc/integrations/web.cjs:60` |

--- a/electron/ipc/data/resources.cjs
+++ b/electron/ipc/data/resources.cjs
@@ -22,27 +22,91 @@ async function extractDocumentTextOffMain(fullPath, mimeType) {
   }
 }
 
+// Text files that import as editable vault notes (same pipeline as creating a
+// document in the vault) instead of opaque 'document' files no viewer can open.
+const NOTE_IMPORT_EXTS = new Set(['.md', '.markdown', '.txt']);
+// Above this size the file goes through the regular vault file import — the
+// note editor is not meant for multi-megabyte documents.
+const NOTE_IMPORT_MAX_BYTES = 1024 * 1024;
+
+/** Strip one leading YAML frontmatter block (Obsidian-style exports). */
+function stripLeadingFrontmatter(raw) {
+  const m = String(raw).match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  return m ? String(raw).slice(m[0].length) : String(raw);
+}
+
 function register({ ipcMain, fs, path, windowManager, database, fileStorage, thumbnail, documentExtractor, documentGenerator, docxConverter, initModule, ollamaService, sanitizePath }) {
   semanticIndexScheduler.init(database);
+
   /**
-   * Import a file: copy to internal storage and create resource
+   * Import a markdown / plain-text file as a vault NOTE: content into the DB
+   * `content` column (markdown) + `.md` mirror via writeNoteMarkdown — exactly
+   * what `db:resources:create` does for documents created inside the vault.
    */
-  ipcMain.handle('resource:import', async (event, { filePath, projectId, type, title }) => {
-    if (!windowManager.isAuthorized(event.sender.id)) {
-      return { success: false, error: 'Unauthorized' };
+  function importTextFileAsNote(filePath, { projectId, title }) {
+    const queries = database.getQueries();
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const stripped = stripLeadingFrontmatter(raw);
+    const markdown = stripped.trim() ? stripped : raw;
+
+    const originalName = path.basename(filePath);
+    const resourceTitle =
+      (title && String(title).trim()) ||
+      originalName.replace(/\.[^.]+$/, '').trim() ||
+      'Untitled';
+
+    const resourceId = generateId();
+    const now = Date.now();
+    queries.createResource.run(
+      resourceId,
+      projectId,
+      'note',
+      resourceTitle,
+      markdown,
+      null, // file_path
+      null, // folder_id (caller moves it afterwards if needed)
+      null, // metadata
+      now,
+      now
+    );
+    vaultStore.writeNoteMarkdown({ id: resourceId, markdown }, { database, fileStorage });
+
+    const resource = queries.getResourceById.get(resourceId);
+    windowManager.broadcast('resource:created', resource);
+    if (semanticIndexScheduler.shouldIndex(resource)) {
+      semanticIndexScheduler.scheduleSemanticReindex(resourceId);
+    }
+    autoMetadata.scheduleCloudAutoMetadata(resourceId, { database, fileStorage, windowManager });
+    return resource;
+  }
+
+  /**
+   * Vault-native single-file import shared by `resource:import` and
+   * `resource:importMultiple` (the import buttons). Markdown/plain text
+   * becomes a note; everything else is referenced in the project vault.
+   */
+  async function importFileAsResource(filePath, { projectId, type, title }) {
+    // Validate file exists
+    if (!fs.existsSync(filePath)) {
+      return { success: false, error: 'File not found' };
     }
 
-    try {
-      // Validate file exists
-      if (!fs.existsSync(filePath)) {
-        return { success: false, error: 'File not found' };
+    const ext = path.extname(filePath).toLowerCase();
+    if (NOTE_IMPORT_EXTS.has(ext)) {
+      try {
+        const stat = fs.statSync(filePath);
+        if (stat.size <= NOTE_IMPORT_MAX_BYTES) {
+          const resource = importTextFileAsNote(filePath, { projectId, title });
+          return { success: true, data: resource, thumbnailDataUrl: null };
+        }
+      } catch (noteErr) {
+        console.warn('[Resource] Note import fell back to file import:', noteErr.message);
       }
-
-      const ext = path.extname(filePath).toLowerCase();
-      const effectiveType = fileStorage.classifyFileType(ext, type);
-      const queries = database.getQueries();
-      const resourceId = generateId();
-      const originalName = path.basename(filePath);
+    }
+    const effectiveType = fileStorage.classifyFileType(ext, type);
+    const queries = database.getQueries();
+    const resourceId = generateId();
+    const originalName = path.basename(filePath);
 
       // Import the file INTO the project's vault (referenced in place — no
       // content-addressed copy). Vault duplicates are allowed.
@@ -56,13 +120,13 @@ function register({ ipcMain, fs, path, windowManager, database, fileStorage, thu
       const fullPath = importResult.absPath;
       const thumbnailData = await thumbnail.generateThumbnail(
         fullPath,
-        type,
+        effectiveType,
         importResult.mimeType
       );
 
       // Extract video metadata if applicable
       let metadata = null;
-      if (type === 'video') {
+      if (effectiveType === 'video') {
         try {
           metadata = await thumbnail.extractVideoMetadata(fullPath);
         } catch (metadataError) {
@@ -80,7 +144,7 @@ function register({ ipcMain, fs, path, windowManager, database, fileStorage, thu
         }
       }
       // Extract text from PDFs on import (so resource_get has content without on-demand extraction)
-      const isPdf = type === 'pdf' || (importResult.mimeType || '').includes('pdf') || (originalName || '').toLowerCase().endsWith('.pdf');
+      const isPdf = effectiveType === 'pdf' || (importResult.mimeType || '').includes('pdf') || (originalName || '').toLowerCase().endsWith('.pdf');
       if (isPdf && !contentText) {
         try {
           contentText = await documentExtractor.extractTextFromPDF(fullPath, 50000);
@@ -131,6 +195,18 @@ function register({ ipcMain, fs, path, windowManager, database, fileStorage, thu
         data: resource,
         thumbnailDataUrl: thumbnailData,
       };
+  }
+
+  /**
+   * Import a file: reference it in the project vault and create the resource
+   */
+  ipcMain.handle('resource:import', async (event, { filePath, projectId, type, title }) => {
+    if (!windowManager.isAuthorized(event.sender.id)) {
+      return { success: false, error: 'Unauthorized' };
+    }
+
+    try {
+      return await importFileAsResource(filePath, { projectId, type, title });
     } catch (error) {
       console.error('[Resource] Error importing file:', error);
       return { success: false, error: error.message };
@@ -179,91 +255,18 @@ function register({ ipcMain, fs, path, windowManager, database, fileStorage, thu
     const results = [];
     const errors = [];
 
+    // Same vault-native pipeline as `resource:import` (markdown/plain text →
+    // editable note; other files referenced in the project vault). The legacy
+    // internal-storage copy left imports invisible to the vault (issue: "md
+    // imports corrupt documents").
     for (const filePath of filePaths) {
       try {
-        if (!fs.existsSync(filePath)) {
-          errors.push({ filePath, error: 'File not found' });
-          continue;
+        const result = await importFileAsResource(filePath, { projectId, type });
+        if (result.success) {
+          results.push({ success: true, data: result.data });
+        } else {
+          errors.push({ filePath, error: result.error, duplicate: result.duplicate });
         }
-
-        // Determine type from extension if not provided
-        const ext = path.extname(filePath).toLowerCase();
-        const fileType = fileStorage.classifyFileType(ext, type);
-
-        const importResult = await fileStorage.importFile(filePath, fileType);
-
-        // Check for duplicate
-        const queries = database.getQueries();
-        const existingResource = queries.findByHash.get(importResult.hash);
-        if (existingResource) {
-          errors.push({
-            filePath,
-            error: 'duplicate',
-            duplicate: existingResource,
-          });
-          continue;
-        }
-
-        // Generate thumbnail
-        const fullPath = fileStorage.getFullPath(importResult.internalPath);
-        const thumbnailData = await thumbnail.generateThumbnail(
-          fullPath,
-          fileType,
-          importResult.mimeType
-        );
-
-        // Extract text for documents, spreadsheets and presentations
-        let contentText = null;
-        if (fileType === 'document' || fileType === 'excel' || fileType === 'ppt') {
-          try {
-            contentText = await extractDocumentTextOffMain(fullPath, importResult.mimeType);
-          } catch (e) {
-            console.warn('[Resource] Document extraction failed:', e.message);
-          }
-        }
-        const isPdf = fileType === 'pdf' || (importResult.mimeType || '').includes('pdf') || (importResult.originalName || '').toLowerCase().endsWith('.pdf');
-        if (isPdf && !contentText) {
-          try {
-            contentText = await documentExtractor.extractTextFromPDF(fullPath, 50000);
-          } catch (e) {
-            console.warn('[Resource] PDF extraction failed:', e.message);
-          }
-        }
-
-        // Create resource
-        const resourceId = generateId();
-        const now = Date.now();
-
-        queries.createResourceWithFile.run(
-          resourceId,
-          projectId,
-          fileType,
-          importResult.originalName,
-          contentText,
-          null,
-          importResult.internalPath,
-          importResult.mimeType,
-          importResult.size,
-          importResult.hash,
-          thumbnailData,
-          importResult.originalName,
-          null,
-          now,
-          now
-        );
-
-        const resource = queries.getResourceById.get(resourceId);
-
-        // Broadcast so Home and other windows update immediately
-        windowManager.broadcast('resource:created', resource);
-
-        if (semanticIndexScheduler.shouldIndex(resource)) {
-          semanticIndexScheduler.scheduleSemanticReindex(resourceId);
-        }
-
-        autoMetadata.scheduleCloudAutoMetadata(resourceId, { database, fileStorage, windowManager });
-
-        results.push({ success: true, data: resource });
       } catch (error) {
         errors.push({ filePath, error: error.message });
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dome",
-  "version": "2.8.8",
+  "version": "2.8.9",
   "description": "Aplicación de escritorio inteligente para gestión de conocimiento e investigación",
   "author": "Dome Team",
   "repository": {

--- a/packages/i18n/locales/en/folder.json
+++ b/packages/i18n/locales/en/folder.json
@@ -48,5 +48,6 @@
   "path_copied": "Path copied",
   "duplicate": "Duplicate",
   "copy_suffix": "copy",
-  "no_file_on_disk": "This item has no file on disk yet"
+  "no_file_on_disk": "This item has no file on disk yet",
+  "dropToImport": "Drop to import here"
 }

--- a/packages/i18n/locales/es/folder.json
+++ b/packages/i18n/locales/es/folder.json
@@ -48,5 +48,6 @@
   "path_copied": "Ruta copiada",
   "duplicate": "Duplicar",
   "copy_suffix": "copia",
-  "no_file_on_disk": "Este elemento aún no tiene archivo en el disco"
+  "no_file_on_disk": "Este elemento aún no tiene archivo en el disco",
+  "dropToImport": "Suelta para importar aquí"
 }

--- a/packages/i18n/locales/fr/folder.json
+++ b/packages/i18n/locales/fr/folder.json
@@ -48,5 +48,6 @@
   "path_copied": "Chemin copié",
   "duplicate": "Dupliquer",
   "copy_suffix": "copie",
-  "no_file_on_disk": "Cet élément n'a pas encore de fichier sur le disque"
+  "no_file_on_disk": "Cet élément n'a pas encore de fichier sur le disque",
+  "dropToImport": "Déposez pour importer ici"
 }

--- a/packages/i18n/locales/pt/folder.json
+++ b/packages/i18n/locales/pt/folder.json
@@ -48,5 +48,6 @@
   "path_copied": "Caminho copiado",
   "duplicate": "Duplicar",
   "copy_suffix": "cópia",
-  "no_file_on_disk": "Este item ainda não tem arquivo no disco"
+  "no_file_on_disk": "Este item ainda não tem arquivo no disco",
+  "dropToImport": "Solte para importar aqui"
 }


### PR DESCRIPTION
## Resumen

Hotfix **v2.8.9** con tres cambios: el crash de arranque del Home reportado en Sentry, la corrupción al importar `.md` desde los botones, y drag & drop de archivos desde Finder/Explorador a la carpeta abierta.

### 1. fix(home): crash React #130 en el arranque (Sentry 132319823, dome@2.8.8)

`ContinueActivityList` (widget "Continuar" del Home editorial) casteaba el `resourceType` crudo de la BD a `ResourceVisualKind` y lo pasaba como override de icono, saltándose el mapeo tipo→kind. `'document'` (cualquier docx importado) no existe en `RESOURCE_ICON_MAP` → `<undefined/>` → el tab Home crasheaba en **cada arranque** mientras hubiera un documento en la actividad reciente, dejando al usuario atrapado en el bucle de "Reintentar".

- **Causa raíz confirmada por simbolización**: worktree en el tag v2.8.8 + `vite build --sourcemap` para resolver el `componentStack` minificado del evento de Sentry (`Bs` → ContinueActivityList, `B0`/`bha` → DomeResourceIcon/Box).
- **Reproducido y verificado**: bundle v2.8.8 + perfil con un docx importado → crash exacto; bundle arreglado → Home renderiza limpio.
- Fix: `inferResourceVisualKind()` en vez del cast + fallback `?? RESOURCE_ICON_MAP.file` en `DomeResourceIcon`.
- Red de seguridad: `TabBoundary` por tab en `ContentRouter` (adjunta `tabType`/`tabId`/título/`resourceId` al reporte de Sentry y añade botón "Ir al inicio" al fallback de error), y fallbacks de estilo/icono en `ArtifactCard` para tipos de artifact de otras versiones.

### 2. fix(import): imports de los botones unificados en el pipeline vault-nativo; `.md`/`.txt` → notas de vault

Los botones de import usaban `resource:importMultiple`, que seguía en el flujo legacy (storage interno content-addressed): los archivos quedaban sin `vault_path` (invisibles para el vault) y los `.md` acababan como `document` opacos → "Unsupported file type".

- `importFileAsResource()` compartido respalda ahora `resource:import` **y** `resource:importMultiple` (vault-nativo, duplicados permitidos como en el resto del vault, thumbnails y extracción de texto conservados).
- `.md`/`.markdown`/`.txt` (≤1 MB) se importan como **notas de vault reales** — mismo pipeline que crear un documento dentro del vault (markdown en `content` + mirror `.md` vía `writeNoteMarkdown`; el frontmatter YAML de origen se descarta). Archivos de texto mayores caen al import de fichero normal.
- Bug heredado corregido: thumbnail y metadatos de vídeo usaban el `type` del renderer (que los botones no envían) en vez del `effectiveType` clasificado.

### 3. feat(vault): drag & drop desde Finder/Explorador a la carpeta abierta

`FolderTabView` (carpetas y raíz del workspace) acepta arrastres de archivos del SO: overlay "Suelta para importar aquí" estable (contador de profundidad para dragenter/leave), rutas reales vía el puente `getPathsForFiles` existente (webUtils), import por el pipeline unificado y move a la carpeta abierta. Clave i18n nueva en en/es/fr/pt. Un drop fuera de zona es inocuo (`will-navigate` ya bloquea `file://`).

### chore: release v2.8.9

Bump de versión para lanzar el hotfix. Tras el merge: `gh release create v2.8.9` y CI construye/adjunta los artefactos.

## Verificación

- Build de producción + smoke por CDP (perfil aislado `DOME_PROFILE`): crash v2.8.8 reproducido y ausente con el fix; barrido de las 14 vistas del sidebar sin errores.
- `.md` con frontmatter → nota que abre en el editor con mirror en el vault; PDF/imagen → vault con thumbnail.
- Drag & drop probado con arrastre real desde Finder (overlay + import + move a carpeta OK).
- `tsc --noEmit`, eslint, `check:design-system`, `check:ipc-zod` en verde. Sin canales IPC nuevos ni dependencias nuevas (no toca asarUnpack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBAidbxybgjh18op1P4aF5