### PR TITLE
fix(sonar-loop): 50 min OpenCode agent timeout

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -15,6 +15,7 @@ pipeline {
     XVFB_DISPLAY = ':99'
     SONAR_BATCH_SIZE = '10'
     SONAR_LOOP_REVIEWER = '1'
+    SONAR_LOOP_TIMEOUT_MS = '3000000'
   }
 
   stages {

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -47,7 +47,7 @@ Variables de entorno en el job (Environment / pipeline):
 |----------|---------|
 | `SONAR_BATCH_SIZE` | `10` (issues por batch en pick-batch) |
 | `SONAR_LOOP_MODEL` | `MiniMax-M3` (1M context) |
-| `SONAR_LOOP_TIMEOUT_MS` | `900000` (15 min fixer — único límite duro del agente; sin cap de steps en OpenCode) |
+| `SONAR_LOOP_TIMEOUT_MS` | `3000000` (50 min fixer — único límite duro del agente; sin cap de steps en OpenCode) |
 | `SONAR_REVIEW_TIMEOUT_MS` | `300000` (5 min reviewer) |
 | `SONAR_LOOP_REVIEWER` | `1` — set `0` to skip LLM reviewer stage |
 | `SONAR_LOOP_MAX_CHANGED_FILES` | `15` |

--- a/scripts/sonar/run-opencode-agent.mjs
+++ b/scripts/sonar/run-opencode-agent.mjs
@@ -19,7 +19,7 @@ const ROOT = path.join(__dirname, '../..');
 const args = parseArgs(process.argv.slice(2));
 const batchPath = path.resolve(args.batch || '.quality-loop/batch.json');
 const model = args.model || process.env.SONAR_LOOP_MODEL || 'MiniMax-M3';
-const timeoutMs = Number(process.env.SONAR_LOOP_TIMEOUT_MS || 900_000);
+const timeoutMs = Number(process.env.SONAR_LOOP_TIMEOUT_MS || 3_000_000);
 const opencodeConfig = path.resolve(
   process.env.OPENCODE_CONFIG || path.join(ROOT, 'scripts/sonar/opencode.ci.json'),
 );


### PR DESCRIPTION
## Summary
- Sets `SONAR_LOOP_TIMEOUT_MS=3000000` (50 min) in Jenkinsfile, runner default, and docs.
- Build #60 timed out at 15 min with the agent mid-batch after step-cap removal worked.

## Test plan
- [ ] Merge and re-run `dome-quality-loop` manually