### PR TITLE
fix(sonar-loop): reduce batch size from 10 to 3 issues

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -13,7 +13,7 @@ pipeline {
     SONAR_HOST_URL = 'https://sonar.dowi.es'
     GITHUB_REPOSITORY = 'maxprain12/dome'
     XVFB_DISPLAY = ':99'
-    SONAR_BATCH_SIZE = '10'
+    SONAR_BATCH_SIZE = '3'
     SONAR_LOOP_REVIEWER = '1'
     SONAR_LOOP_TIMEOUT_MS = '3000000'
   }

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -45,7 +45,7 @@ Variables de entorno en el job (Environment / pipeline):
 
 | Variable | Default |
 |----------|---------|
-| `SONAR_BATCH_SIZE` | `10` (issues por batch en pick-batch) |
+| `SONAR_BATCH_SIZE` | `3` (issues por batch en pick-batch) |
 | `SONAR_LOOP_MODEL` | `MiniMax-M3` (1M context) |
 | `SONAR_LOOP_TIMEOUT_MS` | `3000000` (50 min fixer — único límite duro del agente; sin cap de steps en OpenCode) |
 | `SONAR_REVIEW_TIMEOUT_MS` | `300000` (5 min reviewer) |
@@ -124,7 +124,7 @@ export OPENCODE_CONFIG="$PWD/scripts/sonar/opencode.ci.json"
 export OPENCODE_DISABLE_AUTOUPDATE=1
 
 # Batch de prueba
-pnpm run sonar:pick-batch -- --size=10 --out=.quality-loop/batch.json
+pnpm run sonar:pick-batch -- --size=3 --out=.quality-loop/batch.json
 
 # Dry run (sin API)
 pnpm run sonar:run-agent -- --dry-run
@@ -163,7 +163,7 @@ Mismo prompt que usa el harness interactivo: [`.cursor/prompts/sonar-fix-batch.m
 
 Tras merge a `main`:
 
-1. Build manual de `dome-quality-loop` con batch reducido (`SONAR_BATCH_SIZE=3` en el job) para pruebas
+1. Build manual de `dome-quality-loop` (default `SONAR_BATCH_SIZE=3`) para pruebas
 2. Confirmar stage *Agent fix (OpenCode)* verde y `verify-loop-diff.sh` sin falsos positivos
 3. PR auto-merge solo si CI pasa — **no confiar en auto-merge hasta 1 run verde**
 


### PR DESCRIPTION
## Summary
- Reduce `SONAR_BATCH_SIZE` from 10 to 3 in `Jenkinsfile.quality-loop` so the OpenCode fixer can complete within the 50-minute timeout.
- Update `docs/automation/sonar-quality-loop.md` to reflect the new default.

## Context
Build #62 timed out at 50 min with a 10-issue batch that included `migrations.cjs` (4026 lines). Smaller batches should allow the pipeline to reach fast gates, verify, reviewer, and PR creation.

## Test plan
- [ ] CI passes
- [ ] Manual Jenkins build #63 after merge — expect batch of 3 issues and agent completion within timeout