### PR TITLE
fix(sonar-loop): drop diff-line cap and migration safety agent guidance

### DIFF
--- a/.cursor/prompts/sonar-fix-batch-ci.md
+++ b/.cursor/prompts/sonar-fix-batch-ci.md
@@ -42,6 +42,28 @@ Line numbers in IPC handlers change → `ipc-channels.md` must stay in sync. The
 - `app/globals.css` and large `electron/**/*.cjs` files: surgical edits only; deleting thousands of lines is a failure.
 - **Void operator (S7735):** remove `void` only as an expression operator (`() => void save()`). Never strip `void` from TypeScript types (`() => void`, `Promise<void>`).
 
+## Large migration files (`electron/core/db/migrations.cjs`)
+
+This file is **critical infrastructure**: it upgrades every user's SQLite database on app start. A mistake can brick local data or leave schema half-applied.
+
+When the batch includes `electron/core/db/migrations.cjs` (especially S3776 / cognitive complexity):
+
+1. **Treat it as high-risk** — behavior must stay identical for every `schema_version` step; do not change SQL, version numbers, or migration order.
+2. **Work in sections** — read and refactor one migration block (or a small group) at a time; after each section, validate before moving on.
+3. **Prefer extraction** — move repeated logic into top-level helpers or per-version functions; keep `applyMigrations` as a thin orchestrator. Avoid deleting migration bodies.
+4. **Review affected areas** after each edit:
+   - `applyMigrations(db, fromVersion, invalidateQueries)` contract unchanged
+   - `settings.schema_version` still updated correctly
+   - Callers: `electron/core/database.cjs`, `electron/core/db/drizzle-bridge.cjs`
+5. **Run migration unit tests** after every meaningful change (mandatory before finish):
+
+   ```bash
+   node --test electron/__tests__/drizzle-bridge.test.mjs electron/__tests__/migration-backup.test.mjs
+   ```
+
+   If a test fails, fix before continuing. Then run full `bash scripts/jenkins/verify-batch-pr.sh`.
+6. **Do not** use bulk transform scripts that rewrite the whole file without re-running tests between steps.
+
 ## Scope manifest
 
 The user message includes `ALLOWED_FILES` and per-issue `ACTION` / `DONE_WHEN`. **Only edit ALLOWED_FILES.** If IPC changes require it, regenerate `docs/architecture/ipc-channels.md` via verify script only.

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -51,7 +51,6 @@ Variables de entorno en el job (Environment / pipeline):
 | `SONAR_REVIEW_TIMEOUT_MS` | `300000` (5 min reviewer) |
 | `SONAR_LOOP_REVIEWER` | `1` — set `0` to skip LLM reviewer stage |
 | `SONAR_LOOP_MAX_CHANGED_FILES` | `15` |
-| `SONAR_LOOP_MAX_TOTAL_DIFF_LINES` | `800` |
 | `OPENCODE_CONFIG` | `scripts/sonar/opencode.ci.json` |
 
 ### Agente Jenkins (Linux)

--- a/scripts/sonar/build-opencode-prompt.mjs
+++ b/scripts/sonar/build-opencode-prompt.mjs
@@ -16,9 +16,24 @@ const ROOT = path.join(__dirname, '../..');
 const args = parseArgs(process.argv.slice(2));
 const batchPath = path.resolve(args.batch || '.quality-loop/batch.json');
 
-/** @param {string} rule */
-function actionHint(rule) {
+const MIGRATIONS_CJS = 'electron/core/db/migrations.cjs';
+
+/** @param {string} file */
+function isMigrationsFile(file) {
+  return file === MIGRATIONS_CJS || file.endsWith('/migrations.cjs');
+}
+
+/** @param {string} rule @param {string} file */
+function actionHint(rule, file = '') {
   const r = String(rule || '');
+  if (isMigrationsFile(file)) {
+    return [
+      'CRITICAL: preserve every migration step exactly — same SQL, version order, and schema_version updates.',
+      'Refactor incrementally (extract helpers / per-version functions); review each block you touch.',
+      'After each section: `node --test electron/__tests__/drizzle-bridge.test.mjs electron/__tests__/migration-backup.test.mjs`.',
+      'Then full verify-batch-pr.sh before finishing.',
+    ].join(' ');
+  }
   if (isVoidOperatorRule(r)) {
     return 'Remove void **operator** only (`() => void fn()` → `() => fn()`). Never remove `void` from type annotations (`() => void`).';
   }
@@ -42,7 +57,7 @@ export function formatIssue(issue) {
     `- RULE: \`${issue.rule || 'unknown'}\`${impact ? ` (${impact})` : ''}`,
     `- FILE: \`${file}${line}\``,
     `- MESSAGE: ${issue.message || issue.title || ''}`,
-    `- ACTION: ${actionHint(String(issue.rule || ''))}`,
+    `- ACTION: ${actionHint(String(issue.rule || ''), file)}`,
     `- DONE_WHEN: issue rule satisfied; verify-batch-pr.sh passes`,
     issue.githubNumber ? `- GitHub: #${issue.githubNumber}` : null,
   ]
@@ -57,6 +72,7 @@ function buildOpencodePrompt(batchPathArg = batchPath) {
   const batchPayload = JSON.parse(fs.readFileSync(resolved, 'utf8'));
   const issues = batchPayload.batch || [];
   const allowed = [...batchAllowedFiles(batchPayload)].sort();
+  const hasMigrations = allowed.some(isMigrationsFile);
   const issueBlock =
     issues.length > 0
       ? issues.map(formatIssue).join('\n\n')
@@ -73,7 +89,17 @@ FORBIDDEN:
 - Touching files outside ALLOWED_FILES (except regenerating \`docs/architecture/ipc-channels.md\` after IPC edits)
 - \`pnpm-lock.yaml\`, \`package.json\`, \`.jenkins-*\`, deleting/truncating large files
 - Unrequested refactors, renames, or behavior changes
+${hasMigrations ? `
+## Migration safety (mandatory — \`${MIGRATIONS_CJS}\` in batch)
 
+This batch touches the SQLite migration chain. **Data loss or partial schema upgrades are unacceptable.**
+
+- Refactor in small sections; validate after each section.
+- Run after every meaningful edit:
+  \`node --test electron/__tests__/drizzle-bridge.test.mjs electron/__tests__/migration-backup.test.mjs\`
+- Confirm \`applyMigrations\` contract and \`schema_version\` progression unchanged.
+- Finish with \`bash scripts/jenkins/verify-batch-pr.sh\` exit 0.
+` : ''}
 ## Issues
 
 ${issueBlock}`;

--- a/scripts/sonar/validate-batch-scope.mjs
+++ b/scripts/sonar/validate-batch-scope.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Ensure quality-loop diff stays within batch file scope and size limits.
+ * Ensure quality-loop diff stays within batch file scope (no global diff-line cap).
  *
  * Usage: node scripts/sonar/validate-batch-scope.mjs --batch=.quality-loop/batch.json
  */
@@ -16,7 +16,6 @@ const args = parseArgs(process.argv.slice(2));
 const batchPath = path.resolve(args.batch || '.quality-loop/batch.json');
 
 const maxChangedFiles = Number(process.env.SONAR_LOOP_MAX_CHANGED_FILES || 15);
-const maxTotalDiffLines = Number(process.env.SONAR_LOOP_MAX_TOTAL_DIFF_LINES || 800);
 
 const FORBIDDEN_PREFIXES = ['.jenkins-', 'coverage/'];
 const FORBIDDEN_EXACT = new Set(['pnpm-lock.yaml', 'package.json']);
@@ -81,11 +80,6 @@ for (const file of changed) {
 
 if (changed.length > maxChangedFiles) {
   console.error(`ERROR: ${changed.length} files changed (max ${maxChangedFiles})`);
-  fail = 1;
-}
-
-if (totalLines > maxTotalDiffLines) {
-  console.error(`ERROR: ${totalLines} total diff lines (max ${maxTotalDiffLines})`);
   fail = 1;
 }
 


### PR DESCRIPTION
## Summary
- Remove the `SONAR_LOOP_MAX_TOTAL_DIFF_LINES` (800) gate from `validate-batch-scope.mjs` so large `migrations.cjs` refactors are not blocked at fast gates.
- Add a **Large migration files** section to `sonar-fix-batch-ci.md` with incremental refactor rules and mandatory unit tests.
- Inject migration safety block + per-issue ACTION hints in `build-opencode-prompt.mjs` when `migrations.cjs` is in the batch.

## Context
Build #71 failed fast gates with `scope=1` after a valid agent refactor (~32 min, batch of 3). Typecheck/lint passed; diff size exceeded the 800-line cap.

## Test plan
- [ ] CI passes
- [ ] Next Jenkins `dome-quality-loop` build reaches Full verify / PR after agent fixes migrations batch