### PR TITLE
feat(sonar-loop): fast batch triage with MiniMax-M2.7-highspeed

### DIFF
--- a/.cursor/prompts/sonar-triage-batch-ci.md
+++ b/.cursor/prompts/sonar-triage-batch-ci.md
@@ -1,0 +1,38 @@
+# Sonar quality loop — batch triage (CI)
+
+You are a **fast triage planner**. Do not edit files, do not run builds, do not create commits or PRs.
+
+## Your job
+
+Given the attached Sonar batch, decide which issues the **fixer agent** (MiniMax-M3, ~50 min budget) should attempt **this run** vs which to **defer** to a future dedicated run.
+
+## Decision rules (priority order)
+
+1. **SECURITY / RELIABILITY** → prefer `fix` unless clearly impossible in one run.
+2. **Quick maintainability** (void operator S3735/S7735, nesting S2004 in a single small file) → `fix`.
+3. **`electron/core/db/migrations.cjs`** with S3776 / high complexity:
+   - **DEFER** when the batch also contains other files (mixed batch) — migrations need a dedicated run with full test validation.
+   - **FIX** only when it is the **sole** issue in the batch.
+4. **Large files** (>1500 lines) with S3776 → **DEFER** if combined with any other non-trivial issue in the batch.
+5. **Never fix everything by default** — prefer a **focused subset** (1–2 issues) that fits ~30–40 min of careful work over risking timeout on 3 heavy issues.
+6. If unsure → **defer** (safer than a failed Jenkins run).
+
+## Output (mandatory)
+
+Reply with **only** a single JSON object (no markdown fence, no prose):
+
+```json
+{
+  "fix": ["sonar-issue-key-1"],
+  "defer": ["sonar-issue-key-2"],
+  "rationale": {
+    "sonar-issue-key-1": "one line why fix now",
+    "sonar-issue-key-2": "one line why defer"
+  },
+  "notes": "short summary"
+}
+```
+
+- Every batch issue key must appear in exactly one of `fix` or `defer`.
+- `fix` may be empty if all should defer (pipeline will skip the fixer).
+- Use exact Sonar `key` values from the batch JSON.

--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -16,6 +16,8 @@ pipeline {
     SONAR_BATCH_SIZE = '3'
     SONAR_LOOP_REVIEWER = '1'
     SONAR_LOOP_TIMEOUT_MS = '3000000'
+    SONAR_TRIAGE_MODEL = 'MiniMax-M2.7-highspeed'
+    SONAR_TRIAGE_TIMEOUT_MS = '180000'
   }
 
   stages {
@@ -124,7 +126,33 @@ pipeline {
       }
     }
 
+    stage('Batch triage (OpenCode)') {
+      steps {
+        withCredentials([
+          string(credentialsId: 'minimax-api-key', variable: 'MINIMAX_API_KEY'),
+        ]) {
+          sh '''
+            set -eux
+            export OPENCODE_CONFIG="$PWD/scripts/sonar/opencode.ci.json"
+            export OPENCODE_DISABLE_AUTOUPDATE=1
+            export SONAR_TRIAGE_MODEL="${SONAR_TRIAGE_MODEL:-MiniMax-M2.7-highspeed}"
+            export SONAR_TRIAGE_TIMEOUT_MS="${SONAR_TRIAGE_TIMEOUT_MS:-180000}"
+            pnpm run sonar:run-triage -- --batch=.quality-loop/batch.json
+            pnpm run sonar:apply-triage -- --batch=.quality-loop/batch.json
+          '''
+        }
+        archiveArtifacts artifacts: '.quality-loop/triage-verdict.json,.quality-loop/triage-applied.json,.quality-loop/batch-deferred.json,.quality-loop/batch.json', allowEmptyArchive: true
+      }
+    }
+
     stage('Mechanical fix') {
+      when {
+        expression {
+          if (!fileExists('.quality-loop/triage-applied.json')) return true
+          def applied = readJSON file: '.quality-loop/triage-applied.json'
+          return applied.fixCount > 0
+        }
+      }
       steps {
         script {
           def batchText = fileExists('.quality-loop/batch.json') ? readFile('.quality-loop/batch.json') : '{}'
@@ -155,8 +183,15 @@ pipeline {
 
     stage('Agent fix (OpenCode)') {
       when {
-        expression {
-          return sh(script: 'bash scripts/jenkins/source-tree-clean.sh', returnStatus: true) == 0
+        allOf {
+          expression {
+            if (!fileExists('.quality-loop/triage-applied.json')) return true
+            def applied = readJSON file: '.quality-loop/triage-applied.json'
+            return applied.fixCount > 0
+          }
+          expression {
+            return sh(script: 'bash scripts/jenkins/source-tree-clean.sh', returnStatus: true) == 0
+          }
         }
       }
       steps {

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -50,6 +50,8 @@ Variables de entorno en el job (Environment / pipeline):
 | `SONAR_LOOP_TIMEOUT_MS` | `3000000` (50 min fixer — único límite duro del agente; sin cap de steps en OpenCode) |
 | `SONAR_REVIEW_TIMEOUT_MS` | `300000` (5 min reviewer) |
 | `SONAR_LOOP_REVIEWER` | `1` — set `0` to skip LLM reviewer stage |
+| `SONAR_TRIAGE_MODEL` | `MiniMax-M2.7-highspeed` (fast triage before fixer) |
+| `SONAR_TRIAGE_TIMEOUT_MS` | `180000` (3 min triage agent) |
 | `SONAR_LOOP_MAX_CHANGED_FILES` | `15` |
 | `OPENCODE_CONFIG` | `scripts/sonar/opencode.ci.json` |
 
@@ -98,13 +100,14 @@ pnpm run sonar:run-agent -- --dry-run
 1. Sync Sonar → GitHub issues (`pnpm run sonar:sync-github`) — cap 50 issues abiertas
 2. Pick batch → `.quality-loop/batch.json`
 3. **Validate batch** — `pnpm run sonar:validate-batch`
-4. Fix mecánico void (**S7735 only**) → fast gates; revert si fallan
-5. **Agent fix (OpenCode `sonar-fix`)** — si árbol limpio
-6. **Fast gates (parallel)** — typecheck, lint, scope, diff safety → `.quality-loop/fast-gates.json`
-7. **Full verify** — `verify-batch-pr.sh` (mirror GitHub CI)
-8. **Agent review (OpenCode `sonar-reviewer`)** — read-only; `APPROVE` required (disable with `SONAR_LOOP_REVIEWER=0`)
-9. Verify & PR — commit + push + PR (**auto-merge squash** cuando pase GitHub CI)
-10. Close resolved en Sonar (fail-soft)
+4. **Batch triage (OpenCode `sonar-triage`)** — MiniMax-M2.7-highspeed decides fix vs defer; `apply-batch-triage` filters batch
+5. Fix mecánico void (**S7735 only**) → fast gates; revert si fallan
+6. **Agent fix (OpenCode `sonar-fix`)** — si hay issues en fix subset y árbol limpio
+7. **Fast gates (parallel)** — typecheck, lint, scope, diff safety → `.quality-loop/fast-gates.json`
+8. **Full verify** — `verify-batch-pr.sh` (mirror GitHub CI)
+9. **Agent review (OpenCode `sonar-reviewer`)** — read-only; `APPROVE` required (disable with `SONAR_LOOP_REVIEWER=0`)
+10. Verify & PR — commit + push + PR (**auto-merge squash** cuando pase GitHub CI)
+11. Close resolved en Sonar (fail-soft)
 
 ### Auto-merge de PRs
 
@@ -141,6 +144,8 @@ pnpm run sonar:fetch-issues
 pnpm run sonar:sync-github
 pnpm run sonar:pick-batch
 pnpm run sonar:validate-batch
+pnpm run sonar:run-triage
+pnpm run sonar:apply-triage
 pnpm run sonar:fast-gates
 pnpm run sonar:run-agent
 pnpm run sonar:run-reviewer
@@ -148,7 +153,8 @@ pnpm run sonar:close-resolved
 ```
 
 Config OpenCode CI: [`scripts/sonar/opencode.ci.json`](../../scripts/sonar/opencode.ci.json)  
-Prompt del agente: [`.cursor/prompts/sonar-fix-batch-ci.md`](../.cursor/prompts/sonar-fix-batch-ci.md)
+Prompt del agente fixer: [`.cursor/prompts/sonar-fix-batch-ci.md`](../.cursor/prompts/sonar-fix-batch-ci.md)  
+Prompt triage: [`.cursor/prompts/sonar-triage-batch-ci.md`](../.cursor/prompts/sonar-triage-batch-ci.md)
 
 ## Iteración manual (desarrollo)
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "sonar:pick-batch": "node scripts/sonar/pick-batch.mjs",
     "sonar:validate-batch": "node scripts/sonar/validate-batch.mjs",
     "sonar:validate-scope": "node scripts/sonar/validate-batch-scope.mjs",
+    "sonar:run-triage": "node scripts/sonar/run-opencode-triage.mjs",
+    "sonar:apply-triage": "node scripts/sonar/apply-batch-triage.mjs",
     "sonar:fast-gates": "bash scripts/jenkins/run-fast-gates.sh",
     "sonar:verify-batch": "bash scripts/jenkins/verify-batch-pr.sh",
     "sonar:close-resolved": "node scripts/sonar/close-resolved.mjs",

--- a/scripts/sonar/apply-batch-triage.mjs
+++ b/scripts/sonar/apply-batch-triage.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Apply triage verdict to batch.json (fix subset only).
+ *
+ * Usage: node scripts/sonar/apply-batch-triage.mjs --batch=.quality-loop/batch.json
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from './lib.mjs';
+import { heuristicBatchTriage } from './triage-batch-heuristic.mjs';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const args = parseArgs(process.argv.slice(2));
+const batchPath = path.resolve(args.batch || '.quality-loop/batch.json');
+const verdictPath = path.resolve(args.verdict || '.quality-loop/triage-verdict.json');
+const outDir = path.dirname(batchPath);
+
+if (!fs.existsSync(batchPath)) {
+  console.error(`Batch file not found: ${batchPath}`);
+  process.exit(1);
+}
+
+/** @type {{ batch?: Array<Record<string, unknown>>, pickedAt?: string, batchSize?: number, count?: number, triage?: Record<string, unknown> }} */
+const original = JSON.parse(fs.readFileSync(batchPath, 'utf8'));
+const issues = original.batch || [];
+
+/** @type {{ fix?: string[], defer?: string[], source?: string, notes?: string }} */
+let verdict;
+if (fs.existsSync(verdictPath)) {
+  verdict = JSON.parse(fs.readFileSync(verdictPath, 'utf8'));
+} else {
+  verdict = heuristicBatchTriage(original);
+}
+
+const fixKeys = new Set((verdict.fix || []).map(String));
+const deferKeys = new Set((verdict.defer || []).map(String));
+
+const fixIssues = issues.filter((i) => fixKeys.has(String(i.key || i.sonarKey)));
+const deferIssues = issues.filter((i) => deferKeys.has(String(i.key || i.sonarKey)));
+
+// Issues missing from both lists → defer (safe default)
+const unclassified = issues.filter(
+  (i) => !fixKeys.has(String(i.key || i.sonarKey)) && !deferKeys.has(String(i.key || i.sonarKey)),
+);
+if (unclassified.length > 0) {
+  console.warn(
+    `[SonarTriage] ${unclassified.length} issue(s) not classified — deferring:`,
+    unclassified.map((i) => i.key).join(', '),
+  );
+  for (const i of unclassified) {
+    deferIssues.push(i);
+    deferKeys.add(String(i.key || i.sonarKey));
+  }
+}
+
+const filtered = {
+  ...original,
+  count: fixIssues.length,
+  triage: {
+    appliedAt: new Date().toISOString(),
+    source: verdict.source || 'unknown',
+    notes: verdict.notes || '',
+    fixKeys: [...fixKeys],
+    deferKeys: [...deferKeys],
+  },
+  batch: fixIssues,
+};
+
+fs.writeFileSync(batchPath, `${JSON.stringify(filtered, null, 2)}\n`);
+fs.writeFileSync(
+  path.join(outDir, 'batch-deferred.json'),
+  `${JSON.stringify(
+    {
+      deferredAt: new Date().toISOString(),
+      count: deferIssues.length,
+      batch: deferIssues,
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+const applied = {
+  fixCount: fixIssues.length,
+  deferCount: deferIssues.length,
+  allDeferred: fixIssues.length === 0,
+  source: verdict.source || 'unknown',
+};
+
+fs.writeFileSync(path.join(outDir, 'triage-applied.json'), `${JSON.stringify(applied, null, 2)}\n`);
+
+console.log(
+  `apply-batch-triage: ${fixIssues.length} fix, ${deferIssues.length} defer (source=${applied.source})`,
+);
+
+if (fixIssues.length === 0) {
+  console.log('apply-batch-triage: all issues deferred — fixer stages will be skipped');
+}
+
+process.exit(0);

--- a/scripts/sonar/build-opencode-triage-prompt.mjs
+++ b/scripts/sonar/build-opencode-triage-prompt.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Build triage user prompt from batch JSON.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { batchAllowedFiles, componentToRelativePath, parseArgs } from './lib.mjs';
+import { formatIssue } from './build-opencode-prompt.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '../..');
+
+const args = parseArgs(process.argv.slice(2));
+const batchPath = path.resolve(args.batch || '.quality-loop/batch.json');
+
+const MIGRATIONS_CJS = 'electron/core/db/migrations.cjs';
+
+/** @param {string} file */
+function fileLineCount(file) {
+  try {
+    const abs = path.resolve(ROOT, file);
+    const src = fs.readFileSync(abs, 'utf8');
+    return src.split('\n').length;
+  } catch {
+    return 0;
+  }
+}
+
+export function buildOpencodeTriagePrompt(batchPathArg = batchPath) {
+  const resolved = path.isAbsolute(batchPathArg)
+    ? batchPathArg
+    : path.resolve(ROOT, batchPathArg);
+  const batchPayload = JSON.parse(fs.readFileSync(resolved, 'utf8'));
+  const issues = batchPayload.batch || [];
+  const allowed = [...batchAllowedFiles(batchPayload)].sort();
+
+  const fileHints = allowed
+    .map((f) => {
+      const lines = fileLineCount(f);
+      const tag =
+        f === MIGRATIONS_CJS
+          ? ' **CRITICAL DB MIGRATIONS**'
+          : lines > 1500
+            ? ' **LARGE FILE**'
+            : '';
+      return `- \`${f}\` (~${lines} lines)${tag}`;
+    })
+    .join('\n');
+
+  const issueBlock =
+    issues.length > 0
+      ? issues.map(formatIssue).join('\n\n')
+      : '_No issues in batch._';
+
+  return `Triage this Sonar batch of ${issues.length} issue(s) for the quality-loop fixer.
+
+Fixer budget: ~50 minutes (MiniMax-M3). Prefer a focused subset that can complete with tests.
+
+## Batch issues
+${issueBlock}
+
+## Files in batch
+${fileHints}
+
+Decide fix vs defer for each issue key. Reply with ONLY the JSON object from your system prompt.`;
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  process.stdout.write(buildOpencodeTriagePrompt());
+}

--- a/scripts/sonar/opencode.ci.json
+++ b/scripts/sonar/opencode.ci.json
@@ -28,6 +28,25 @@
         "skill": "deny"
       }
     },
+    "sonar-triage": {
+      "mode": "primary",
+      "description": "Sonar quality loop — fast batch triage (fix vs defer)",
+      "model": "minimax/MiniMax-M2.7-highspeed",
+      "prompt": "{file:../../.cursor/prompts/sonar-triage-batch-ci.md}",
+      "permission": {
+        "read": "allow",
+        "edit": "deny",
+        "glob": "allow",
+        "grep": "allow",
+        "list": "allow",
+        "bash": "deny",
+        "webfetch": "deny",
+        "websearch": "deny",
+        "task": "deny",
+        "todowrite": "deny",
+        "skill": "deny"
+      }
+    },
     "sonar-reviewer": {
       "mode": "primary",
       "description": "Sonar quality loop — read-only diff reviewer before PR",

--- a/scripts/sonar/run-opencode-triage.mjs
+++ b/scripts/sonar/run-opencode-triage.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Run fast OpenCode triage agent (MiniMax-M2.7-highspeed) before the fixer.
+ *
+ * Usage:
+ *   MINIMAX_API_KEY=... pnpm run sonar:run-triage -- --batch=.quality-loop/batch.json
+ */
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildOpencodeTriagePrompt } from './build-opencode-triage-prompt.mjs';
+import { parseArgs } from './lib.mjs';
+import { heuristicBatchTriage } from './triage-batch-heuristic.mjs';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const args = parseArgs(process.argv.slice(2));
+const batchPath = path.resolve(args.batch || '.quality-loop/batch.json');
+const model = args.model || process.env.SONAR_TRIAGE_MODEL || 'MiniMax-M2.7-highspeed';
+const timeoutMs = Number(process.env.SONAR_TRIAGE_TIMEOUT_MS || 180_000);
+const opencodeConfig = path.resolve(
+  process.env.OPENCODE_CONFIG || path.join(ROOT, 'scripts/sonar/opencode.ci.json'),
+);
+
+/** @param {string} text */
+function extractTriageJson(text) {
+  const fenced = text.match(/```(?:json)?\s*(\{[\s\S]*?"fix"[\s\S]*?\})\s*```/);
+  if (fenced) return fenced[1];
+
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start >= 0 && end > start) {
+    const slice = text.slice(start, end + 1);
+    if (slice.includes('"fix"') && slice.includes('"defer"')) return slice;
+  }
+  return null;
+}
+
+function requireOpencode() {
+  const which = spawnSync('command', ['-v', 'opencode'], { shell: true, encoding: 'utf8' });
+  if (which.status !== 0) {
+    console.error('ERROR: opencode CLI not found');
+    process.exit(1);
+  }
+}
+
+if (!fs.existsSync(batchPath)) {
+  console.error(`Batch file not found: ${batchPath}`);
+  process.exit(1);
+}
+
+if (!process.env.MINIMAX_API_KEY) {
+  console.error('Missing MINIMAX_API_KEY');
+  process.exit(1);
+}
+
+requireOpencode();
+
+const batchPayload = JSON.parse(fs.readFileSync(batchPath, 'utf8'));
+const prompt = buildOpencodeTriagePrompt(batchPath);
+const startedAt = new Date().toISOString();
+const outDir = path.join(ROOT, '.quality-loop');
+fs.mkdirSync(outDir, { recursive: true });
+
+console.log('[SonarTriage] engine: opencode');
+console.log('[SonarTriage] model: minimax/' + model);
+
+const env = {
+  ...process.env,
+  OPENCODE_CONFIG: opencodeConfig,
+  OPENCODE_DISABLE_AUTOUPDATE: '1',
+  OPENCODE_CLIENT: 'dome-sonar-loop-triage',
+};
+
+const result = spawnSync(
+  'opencode',
+  [
+    'run',
+    '--auto',
+    '--agent',
+    'sonar-triage',
+    '--model',
+    `minimax/${model}`,
+    '--file',
+    batchPath,
+  ],
+  {
+    cwd: ROOT,
+    env,
+    input: prompt,
+    encoding: 'utf8',
+    maxBuffer: 8 * 1024 * 1024,
+    timeout: timeoutMs,
+  },
+);
+
+const stdout = result.stdout || '';
+const stderr = result.stderr || '';
+const exitCode = result.status ?? 1;
+
+/** @type {Record<string, unknown>} */
+let verdict = heuristicBatchTriage(batchPayload);
+let source = 'heuristic-fallback';
+
+const rawJson = extractTriageJson(stdout);
+if (rawJson && exitCode === 0) {
+  try {
+    const parsed = JSON.parse(rawJson);
+    if (Array.isArray(parsed.fix) && Array.isArray(parsed.defer)) {
+      verdict = parsed;
+      source = 'opencode';
+    }
+  } catch {
+    console.warn('[SonarTriage] Invalid JSON from agent — using heuristic fallback');
+  }
+} else {
+  console.warn(
+    '[SonarTriage] Agent failed or no JSON — using heuristic fallback:',
+    result.error?.message || stderr.slice(0, 300) || `exit ${exitCode}`,
+  );
+}
+
+const payload = {
+  startedAt,
+  finishedAt: new Date().toISOString(),
+  exitCode,
+  source,
+  model,
+  ...verdict,
+};
+
+fs.writeFileSync(path.join(outDir, 'triage-verdict.json'), `${JSON.stringify(payload, null, 2)}\n`);
+
+if (stdout) process.stdout.write(stdout);
+if (stderr) process.stderr.write(stderr);
+
+console.log(
+  `[SonarTriage] fix=${(verdict.fix || []).length} defer=${(verdict.defer || []).length} source=${source}`,
+);
+process.exit(0);

--- a/scripts/sonar/triage-batch-heuristic.mjs
+++ b/scripts/sonar/triage-batch-heuristic.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Deterministic batch triage fallback when the LLM triage agent fails.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { componentToRelativePath, parseArgs } from './lib.mjs';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const MIGRATIONS_CJS = 'electron/core/db/migrations.cjs';
+const LARGE_FILE_LINES = 1500;
+const MAX_FIX_PER_RUN = 2;
+
+/** @param {string} file */
+function fileLineCount(file) {
+  try {
+    const abs = path.resolve(ROOT, file);
+    return fs.readFileSync(abs, 'utf8').split('\n').length;
+  } catch {
+    return 0;
+  }
+}
+
+/** @param {string} rule */
+function isHeavyComplexity(rule) {
+  const r = String(rule || '');
+  return r.endsWith(':S3776') || r.endsWith(':S1541');
+}
+
+/**
+ * @param {{ batch?: Array<Record<string, unknown>> }} batchPayload
+ * @returns {{ fix: string[], defer: string[], rationale: Record<string, string>, notes: string, source: string }}
+ */
+export function heuristicBatchTriage(batchPayload) {
+  const issues = batchPayload.batch || [];
+  /** @type {string[]} */
+  const fix = [];
+  /** @type {string[]} */
+  const defer = [];
+  /** @type {Record<string, string>} */
+  const rationale = {};
+
+  const entries = issues.map((issue) => {
+    const file = componentToRelativePath(String(issue.component || ''));
+    const key = String(issue.key || issue.sonarKey || '');
+    const rule = String(issue.rule || '');
+    return { key, file, rule, lines: fileLineCount(file) };
+  });
+
+  const migrationEntries = entries.filter((e) => e.file === MIGRATIONS_CJS);
+  const otherEntries = entries.filter((e) => e.file !== MIGRATIONS_CJS);
+
+  if (migrationEntries.length > 0 && otherEntries.length > 0) {
+    for (const m of migrationEntries) {
+      defer.push(m.key);
+      rationale[m.key] = 'migrations.cjs deferred — needs dedicated run when mixed with other issues';
+    }
+    for (const o of otherEntries) {
+      fix.push(o.key);
+      rationale[o.key] = 'lighter issue — fix this run';
+    }
+    return {
+      fix,
+      defer,
+      rationale,
+      notes: 'Heuristic: defer migrations in mixed batch',
+      source: 'heuristic',
+    };
+  }
+
+  const heavyEntries = entries.filter(
+    (e) => e.file === MIGRATIONS_CJS || (e.lines > LARGE_FILE_LINES && isHeavyComplexity(e.rule)),
+  );
+
+  if (entries.length <= MAX_FIX_PER_RUN || heavyEntries.length === 0) {
+    for (const e of entries) {
+      fix.push(e.key);
+      rationale[e.key] = 'eligible for this run';
+    }
+    return { fix, defer, rationale, notes: 'Heuristic: all issues fit budget', source: 'heuristic' };
+  }
+
+  const sorted = [...entries].sort((a, b) => {
+    const aHeavy = heavyEntries.some((h) => h.key === a.key) ? 1 : 0;
+    const bHeavy = heavyEntries.some((h) => h.key === b.key) ? 1 : 0;
+    if (aHeavy !== bHeavy) return aHeavy - bHeavy;
+    return a.lines - b.lines;
+  });
+
+  for (let i = 0; i < sorted.length; i++) {
+    const e = sorted[i];
+    if (i < MAX_FIX_PER_RUN) {
+      fix.push(e.key);
+      rationale[e.key] = 'selected — within per-run fix cap';
+    } else {
+      defer.push(e.key);
+      rationale[e.key] = 'deferred — batch too heavy for one run';
+    }
+  }
+
+  return {
+    fix,
+    defer,
+    rationale,
+    notes: `Heuristic: capped at ${MAX_FIX_PER_RUN} fixes`,
+    source: 'heuristic',
+  };
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  const args = parseArgs(process.argv.slice(2));
+  const batchPath = path.resolve(args.batch || '.quality-loop/batch.json');
+  const payload = JSON.parse(fs.readFileSync(batchPath, 'utf8'));
+  process.stdout.write(`${JSON.stringify(heuristicBatchTriage(payload), null, 2)}\n`);
+}


### PR DESCRIPTION
## Summary
- Add **Batch triage** stage before the fixer: OpenCode agent `sonar-triage` on **MiniMax-M2.7-highspeed** (~3 min) decides which batch issues to fix now vs defer.
- `apply-batch-triage` filters `batch.json`; deferred issues saved to `batch-deferred.json`.
- Heuristic fallback when triage LLM fails (e.g. defer `migrations.cjs` in mixed batches).
- Skip mechanical fix / fixer / PR stages when all issues deferred (`triage-applied.json` `fixCount=0`).

## Context
Builds #71/#74 timed out on 3-issue batches mixing quick fixes with `migrations.cjs` S3776. Triage focuses the M3 fixer on 1–2 achievable issues per run.

## Test plan
- [ ] CI passes
- [ ] Jenkins build #75: triage defers migrations, fixer completes on ChatMessage + IssueDetailPanel, PR created