### PR TITLE
fix(ci): triage when-expression shell helper

### DIFF
--- a/Jenkinsfile.quality-loop
+++ b/Jenkinsfile.quality-loop
@@ -148,9 +148,7 @@ pipeline {
     stage('Mechanical fix') {
       when {
         expression {
-          if (!fileExists('.quality-loop/triage-applied.json')) return true
-          def applied = readJSON file: '.quality-loop/triage-applied.json'
-          return applied.fixCount > 0
+          return sh(script: 'bash scripts/jenkins/triage-has-fixes.sh "$PWD"', returnStatus: true) == 0
         }
       }
       steps {
@@ -185,9 +183,7 @@ pipeline {
       when {
         allOf {
           expression {
-            if (!fileExists('.quality-loop/triage-applied.json')) return true
-            def applied = readJSON file: '.quality-loop/triage-applied.json'
-            return applied.fixCount > 0
+            return sh(script: 'bash scripts/jenkins/triage-has-fixes.sh "$PWD"', returnStatus: true) == 0
           }
           expression {
             return sh(script: 'bash scripts/jenkins/source-tree-clean.sh', returnStatus: true) == 0

--- a/scripts/jenkins/triage-has-fixes.sh
+++ b/scripts/jenkins/triage-has-fixes.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Exit 0 when triage left issues for the fixer (fixCount > 0).
+# Missing triage-applied.json → 0 (backward compat / pre-triage runs).
+set -euo pipefail
+
+ROOT="${1:-.}"
+APPLIED="$ROOT/.quality-loop/triage-applied.json"
+
+if [[ ! -f "$APPLIED" ]]; then
+  exit 0
+fi
+
+node -e "
+const j = require(process.argv[1]);
+const n = Number(j.fixCount || 0);
+process.exit(n > 0 ? 0 : 1);
+" "$APPLIED"


### PR DESCRIPTION
## Summary
- Replace `readJSON` in Jenkins `when{}` expressions (crashed build #76) with `scripts/jenkins/triage-has-fixes.sh`.

## Context
Build #76 triage worked (`fix=2 defer=1` — migrations deferred) but pipeline died evaluating Mechanical fix `when` block.

## Test plan
- [ ] CI passes
- [ ] Jenkins build reaches Agent fix after triage