### PR TITLE
refactor: decompose the highest-complexity Sonar hotspots (10 issues)

### DIFF
--- a/app/components/many/ManyChatHeader.tsx
+++ b/app/components/many/ManyChatHeader.tsx
@@ -38,6 +38,252 @@ interface ManyChatHeaderProps {
   children?: ReactNode;
 }
 
+type TranslateFn = ReturnType<typeof useTranslation>['t'];
+
+interface HeaderPresentation {
+  isThinking: boolean;
+  isSpeaking: boolean;
+  titleText: string;
+  statusBadgeLabel: string | null;
+  subtitleText: string | null;
+  fullscreenLabel: string;
+  headerClass: string;
+}
+
+function deriveHeaderPresentation(
+  props: Pick<
+    ManyChatHeaderProps,
+    'status' | 'sessionTitle' | 'loadingHint' | 'isPopout' | 'isFullscreenActive'
+  >,
+  t: TranslateFn,
+): HeaderPresentation {
+  const { status, sessionTitle, loadingHint, isPopout, isFullscreenActive } = props;
+  const isThinking = status === 'thinking';
+  const isSpeaking = status === 'speaking';
+  const isMac =
+    typeof window !== 'undefined' && Boolean(window.electron?.isMac ?? window.electron?.platform === 'darwin');
+  const needsRightChromeInset =
+    typeof window !== 'undefined' &&
+    Boolean(window.electron?.isWindows || window.electron?.isLinux);
+
+  const titleText =
+    sessionTitle && sessionTitle !== 'New chat'
+      ? sanitizeManySessionTitle(sessionTitle)
+      : t('many.many');
+  const statusBadgeLabel = isSpeaking
+    ? t('many.speaking')
+    : isThinking
+      ? t('many.thinking')
+      : null;
+  const subtitleText = !isThinking && !isSpeaking ? loadingHint || null : null;
+
+  const fullscreenLabel = isFullscreenActive ? t('many.exit_fullscreen') : t('many.fullscreen');
+
+  const headerClass = cn(
+    'many-chat-header flex items-center gap-3 shrink-0 border-b',
+    !isPopout && 'many-chat-header--docked',
+    isPopout && 'many-chat-header--popout drag-region',
+    isPopout && isMac && 'nav-mac',
+    isPopout && needsRightChromeInset && 'win-titlebar-padding',
+  );
+
+  return { isThinking, isSpeaking, titleText, statusBadgeLabel, subtitleText, fullscreenLabel, headerClass };
+}
+
+function HeaderTitleBlock({
+  p,
+  isPopout,
+  contextDescription,
+}: {
+  p: HeaderPresentation;
+  isPopout: boolean;
+  contextDescription: string;
+}) {
+  return (
+    <div className="min-w-0 flex-1 flex flex-col" style={{ gap: 2 }}>
+      <div className="flex items-center gap-1.5 min-w-0">
+        <span
+          className={cn(
+            'many-hd-title text-sm font-semibold leading-[1.3] overflow-hidden text-ellipsis whitespace-nowrap',
+            isPopout ? 'text-[var(--dome-text)]' : 'text-[var(--primary-text)]',
+          )}
+        >
+          {p.titleText}
+        </span>
+        {(p.isThinking || p.isSpeaking) && p.statusBadgeLabel ? (
+          <span className="many-hd-status-badge text-xs text-[var(--accent)] font-medium px-2 py-px rounded-full bg-[var(--accent-bg)] leading-[1.6] shrink min-w-0 max-w-[140px] truncate">
+            {p.statusBadgeLabel}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="flex items-center flex-wrap min-w-0" style={{ gap: 5 }}>
+        {/* Model selector intentionally NOT rendered here: it already lives in the
+            composer/input pill, so showing it in the header too is redundant. */}
+        {contextDescription ? (
+          <span className="many-hd-chip many-hd-chip--accent many-hd-meta--extra">
+            {contextDescription}
+          </span>
+        ) : null}
+        {p.subtitleText ? (
+          <span className="many-hd-meta--extra many-hd-subtitle">
+            {p.subtitleText}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+interface HeaderActionsProps {
+  p: HeaderPresentation;
+  historyOpen: boolean;
+  showHistoryToggle: boolean;
+  showFullscreenToggle: boolean;
+  isFullscreenActive: boolean;
+  onToggleFullscreen?: () => void;
+  showPopoutToggle: boolean;
+  onPopout?: () => void;
+  onStartNewChat: () => void;
+  onToggleHistory: () => void;
+  t: TranslateFn;
+}
+
+function HeaderWideActions({
+  p,
+  historyOpen,
+  showHistoryToggle,
+  showFullscreenToggle,
+  isFullscreenActive,
+  onToggleFullscreen,
+  showPopoutToggle,
+  onPopout,
+  onStartNewChat,
+  onToggleHistory,
+  t,
+}: HeaderActionsProps) {
+  return (
+    <div className="many-hd-actions--wide flex items-center" style={{ gap: 2 }}>
+      {showFullscreenToggle && onToggleFullscreen ? (
+        <button
+          type="button"
+          className="many-icon-btn"
+          onClick={onToggleFullscreen}
+          title={p.fullscreenLabel}
+          aria-label={p.fullscreenLabel}
+        >
+          {isFullscreenActive ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+        </button>
+      ) : null}
+      {showPopoutToggle && onPopout ? (
+        <button
+          type="button"
+          className="many-icon-btn"
+          onClick={onPopout}
+          title={t('many.open_popout')}
+          aria-label={t('many.open_popout')}
+        >
+          <ExternalLink size={16} />
+        </button>
+      ) : null}
+      <button
+        type="button"
+        className="many-icon-btn"
+        onClick={onStartNewChat}
+        title={t('many.newChat')}
+        aria-label={t('many.newChat')}
+      >
+        <Plus size={16} />
+      </button>
+      {showHistoryToggle ? (
+        <button
+          type="button"
+          className="many-icon-btn"
+          onClick={onToggleHistory}
+          title={t('many.toggle_history')}
+          aria-label={t('many.toggle_history')}
+          style={historyOpen ? { background: 'var(--bg-hover)', color: 'var(--accent)' } : undefined}
+        >
+          <Clock size={14} />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function HeaderCompactMenu({
+  p,
+  historyOpen,
+  showHistoryToggle,
+  showFullscreenToggle,
+  isFullscreenActive,
+  onToggleFullscreen,
+  showPopoutToggle,
+  onPopout,
+  onStartNewChat,
+  onToggleHistory,
+  t,
+}: HeaderActionsProps) {
+  return (
+    <div className="many-hd-actions--compact">
+      <Menu shadow="md" width={236} position="bottom-end" radius="md">
+        <Menu.Target>
+          <button
+            type="button"
+            className="many-icon-btn"
+            aria-label={t('many.more_actions')}
+            title={t('many.more_actions')}
+          >
+            <MoreHorizontal size={16} strokeWidth={2} />
+          </button>
+        </Menu.Target>
+        <Menu.Dropdown>
+          {/* Chat actions first — the primary, most-used ones */}
+          <Menu.Item
+            leftSection={<Plus size={15} />}
+            onClick={onStartNewChat}
+            fw={600}
+          >
+            {t('many.newChat')}
+          </Menu.Item>
+          {showHistoryToggle ? (
+            <Menu.Item
+              leftSection={<Clock size={15} />}
+              onClick={onToggleHistory}
+              rightSection={
+                historyOpen ? <Check size={14} style={{ color: 'var(--accent)' }} /> : undefined
+              }
+              style={historyOpen ? { background: 'var(--accent-bg)', color: 'var(--accent)' } : undefined}
+            >
+              {t('many.toggle_history')}
+            </Menu.Item>
+          ) : null}
+
+          {(showFullscreenToggle && onToggleFullscreen) || (showPopoutToggle && onPopout) ? (
+            <>
+              <Menu.Divider />
+              <Menu.Label>{t('many.view_section')}</Menu.Label>
+              {showFullscreenToggle && onToggleFullscreen ? (
+                <Menu.Item
+                  leftSection={isFullscreenActive ? <Minimize2 size={15} /> : <Maximize2 size={15} />}
+                  onClick={onToggleFullscreen}
+                >
+                  {p.fullscreenLabel}
+                </Menu.Item>
+              ) : null}
+              {showPopoutToggle && onPopout ? (
+                <Menu.Item leftSection={<ExternalLink size={15} />} onClick={onPopout}>
+                  {t('many.open_popout')}
+                </Menu.Item>
+              ) : null}
+            </>
+          ) : null}
+        </Menu.Dropdown>
+      </Menu>
+    </div>
+  );
+}
+
 const ManyChatHeader = memo(function ManyChatHeader({
   status,
   providerInfo: _providerInfo,
@@ -65,179 +311,35 @@ const ManyChatHeader = memo(function ManyChatHeader({
     contextUsage: ContextUsage,
   });
   const { t } = useTranslation();
-  const isThinking = status === 'thinking';
-  const isSpeaking = status === 'speaking';
-  const isMac =
-    typeof window !== 'undefined' && Boolean(window.electron?.isMac ?? window.electron?.platform === 'darwin');
-  const needsRightChromeInset =
-    typeof window !== 'undefined' &&
-    Boolean(window.electron?.isWindows || window.electron?.isLinux);
+  const p = deriveHeaderPresentation({ status, sessionTitle, loadingHint, isPopout, isFullscreenActive }, t);
 
-  const titleText =
-    sessionTitle && sessionTitle !== 'New chat'
-      ? sanitizeManySessionTitle(sessionTitle)
-      : t('many.many');
-  const statusBadgeLabel = isSpeaking
-    ? t('many.speaking')
-    : isThinking
-      ? t('many.thinking')
-      : null;
-  const subtitleText = !isThinking && !isSpeaking ? loadingHint || null : null;
-
-  const fullscreenLabel = isFullscreenActive ? t('many.exit_fullscreen') : t('many.fullscreen');
+  const actionsProps: HeaderActionsProps = {
+    p,
+    historyOpen,
+    showHistoryToggle,
+    showFullscreenToggle,
+    isFullscreenActive,
+    onToggleFullscreen,
+    showPopoutToggle,
+    onPopout,
+    onStartNewChat,
+    onToggleHistory,
+    t,
+  };
 
   return (
-    <div
-      className={cn(
-        'many-chat-header flex items-center gap-3 shrink-0 border-b',
-        !isPopout && 'many-chat-header--docked',
-        isPopout && 'many-chat-header--popout drag-region',
-        isPopout && isMac && 'nav-mac',
-        isPopout && needsRightChromeInset && 'win-titlebar-padding',
-      )}
-      data-status={status}
-    >
+    <div className={p.headerClass} data-status={status}>
       <ManyAvatar size="md" state="idle" className="many-hd-avatar many-hd-avatar--wide shrink-0" />
       <ManyAvatar size="sm" state="idle" className="many-hd-avatar many-hd-avatar--compact shrink-0" />
 
-      <div className="min-w-0 flex-1 flex flex-col" style={{ gap: 2 }}>
-        <div className="flex items-center gap-1.5 min-w-0">
-          <span
-            className={cn(
-              'many-hd-title text-sm font-semibold leading-[1.3] overflow-hidden text-ellipsis whitespace-nowrap',
-              isPopout ? 'text-[var(--dome-text)]' : 'text-[var(--primary-text)]',
-            )}
-          >
-            {titleText}
-          </span>
-          {(isThinking || isSpeaking) && statusBadgeLabel ? (
-            <span className="many-hd-status-badge text-xs text-[var(--accent)] font-medium px-2 py-px rounded-full bg-[var(--accent-bg)] leading-[1.6] shrink min-w-0 max-w-[140px] truncate">
-              {statusBadgeLabel}
-            </span>
-          ) : null}
-        </div>
-
-        <div className="flex items-center flex-wrap min-w-0" style={{ gap: 5 }}>
-          {/* Model selector intentionally NOT rendered here: it already lives in the
-              composer/input pill, so showing it in the header too is redundant. */}
-          {contextDescription ? (
-            <span className="many-hd-chip many-hd-chip--accent many-hd-meta--extra">
-              {contextDescription}
-            </span>
-          ) : null}
-          {subtitleText ? (
-            <span className="many-hd-meta--extra many-hd-subtitle">
-              {subtitleText}
-            </span>
-          ) : null}
-        </div>
-      </div>
+      <HeaderTitleBlock p={p} isPopout={isPopout} contextDescription={contextDescription} />
 
       <div className="flex items-center shrink-0 no-drag many-hd-actions" style={{ gap: 2 }}>
         {contextUsage}
 
-        <div className="many-hd-actions--wide flex items-center" style={{ gap: 2 }}>
-          {showFullscreenToggle && onToggleFullscreen ? (
-            <button
-              type="button"
-              className="many-icon-btn"
-              onClick={onToggleFullscreen}
-              title={fullscreenLabel}
-              aria-label={fullscreenLabel}
-            >
-              {isFullscreenActive ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
-            </button>
-          ) : null}
-          {showPopoutToggle && onPopout ? (
-            <button
-              type="button"
-              className="many-icon-btn"
-              onClick={onPopout}
-              title={t('many.open_popout')}
-              aria-label={t('many.open_popout')}
-            >
-              <ExternalLink size={16} />
-            </button>
-          ) : null}
-          <button
-            type="button"
-            className="many-icon-btn"
-            onClick={onStartNewChat}
-            title={t('many.newChat')}
-            aria-label={t('many.newChat')}
-          >
-            <Plus size={16} />
-          </button>
-          {showHistoryToggle ? (
-            <button
-              type="button"
-              className="many-icon-btn"
-              onClick={onToggleHistory}
-              title={t('many.toggle_history')}
-              aria-label={t('many.toggle_history')}
-              style={historyOpen ? { background: 'var(--bg-hover)', color: 'var(--accent)' } : undefined}
-            >
-              <Clock size={14} />
-            </button>
-          ) : null}
-        </div>
+        <HeaderWideActions {...actionsProps} />
 
-        <div className="many-hd-actions--compact">
-          <Menu shadow="md" width={236} position="bottom-end" radius="md">
-            <Menu.Target>
-              <button
-                type="button"
-                className="many-icon-btn"
-                aria-label={t('many.more_actions')}
-                title={t('many.more_actions')}
-              >
-                <MoreHorizontal size={16} strokeWidth={2} />
-              </button>
-            </Menu.Target>
-            <Menu.Dropdown>
-              {/* Chat actions first — the primary, most-used ones */}
-              <Menu.Item
-                leftSection={<Plus size={15} />}
-                onClick={onStartNewChat}
-                fw={600}
-              >
-                {t('many.newChat')}
-              </Menu.Item>
-              {showHistoryToggle ? (
-                <Menu.Item
-                  leftSection={<Clock size={15} />}
-                  onClick={onToggleHistory}
-                  rightSection={
-                    historyOpen ? <Check size={14} style={{ color: 'var(--accent)' }} /> : undefined
-                  }
-                  style={historyOpen ? { background: 'var(--accent-bg)', color: 'var(--accent)' } : undefined}
-                >
-                  {t('many.toggle_history')}
-                </Menu.Item>
-              ) : null}
-
-              {(showFullscreenToggle && onToggleFullscreen) || (showPopoutToggle && onPopout) ? (
-                <>
-                  <Menu.Divider />
-                  <Menu.Label>{t('many.view_section')}</Menu.Label>
-                  {showFullscreenToggle && onToggleFullscreen ? (
-                    <Menu.Item
-                      leftSection={isFullscreenActive ? <Minimize2 size={15} /> : <Maximize2 size={15} />}
-                      onClick={onToggleFullscreen}
-                    >
-                      {fullscreenLabel}
-                    </Menu.Item>
-                  ) : null}
-                  {showPopoutToggle && onPopout ? (
-                    <Menu.Item leftSection={<ExternalLink size={15} />} onClick={onPopout}>
-                      {t('many.open_popout')}
-                    </Menu.Item>
-                  ) : null}
-                </>
-              ) : null}
-            </Menu.Dropdown>
-          </Menu>
-        </div>
+        <HeaderCompactMenu {...actionsProps} />
 
         {showClose ? (
           <>

--- a/app/components/settings/IndexingSettings.tsx
+++ b/app/components/settings/IndexingSettings.tsx
@@ -31,23 +31,25 @@ interface FullSyncProgressPayload {
   embeddingFailed?: number;
 }
 
-export default function IndexingSettings() {
-  const { t } = useTranslation();
+type TranslateFn = ReturnType<typeof useTranslation>['t'];
+
+function toErrorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+function computeFullSyncPercent(progress: FullSyncProgressPayload | null): number {
+  if (!progress || progress.resourcesTotal <= 0) return 0;
+  if (progress.phase === 'finished') return 100;
+  if (progress.phase === 'starting') return 0;
+  return Math.min(100, Math.round((progress.resourceIndex / progress.resourcesTotal) * 100));
+}
+
+/** Embedding index status: initial load, 8s polling, and live progress events. */
+function useEmbeddingStatus(pausePolling: boolean) {
   const [embedStatus, setEmbedStatus] = useState<SemanticIndexingStatusPayload | null>(null);
   const [embedLoading, setEmbedLoading] = useState(true);
   const [embedError, setEmbedError] = useState<string | null>(null);
-  const [embedReindexBusy, setEmbedReindexBusy] = useState(false);
   const [embedProgress, setEmbedProgress] = useState<{ done: number; total: number } | null>(null);
-
-  const [fullSyncBusy, setFullSyncBusy] = useState(false);
-  const [fullSyncProgress, setFullSyncProgress] = useState<FullSyncProgressPayload | null>(null);
-  const [fullSyncResult, setFullSyncResult] = useState<{
-    totalResources: number;
-    embeddingFailed: number;
-  } | null>(null);
-
-  const [lastError, setLastError] = useState<string | null>(null);
-  const progressCleanupRef = useRef<(() => void) | null>(null);
 
   const loadEmbedStatus = useCallback(async () => {
     setEmbedError(null);
@@ -61,7 +63,7 @@ export default function IndexingSettings() {
       }
     } catch (e) {
       setEmbedStatus(null);
-      setEmbedError(e instanceof Error ? e.message : String(e));
+      setEmbedError(toErrorMessage(e));
     } finally {
       setEmbedLoading(false);
     }
@@ -70,10 +72,10 @@ export default function IndexingSettings() {
   useEffect(() => {
     void loadEmbedStatus();
     const interval = setInterval(() => {
-      if (!embedReindexBusy && !fullSyncBusy) void loadEmbedStatus();
+      if (!pausePolling) void loadEmbedStatus();
     }, 8000);
     return () => clearInterval(interval);
-  }, [loadEmbedStatus, embedReindexBusy, fullSyncBusy]);
+  }, [loadEmbedStatus, pausePolling]);
 
   useEffect(() => {
     const off = window.electron.db.semantic.onProgress((p) => {
@@ -81,6 +83,29 @@ export default function IndexingSettings() {
     });
     return off;
   }, []);
+
+  return {
+    embedStatus,
+    embedLoading,
+    setEmbedLoading,
+    embedError,
+    setEmbedError,
+    embedProgress,
+    setEmbedProgress,
+    loadEmbedStatus,
+  };
+}
+
+/** Full library sync (cloud vision transcription + embeddings) with progress events. */
+function useFullSync(loadEmbedStatus: () => Promise<void>, t: TranslateFn) {
+  const [fullSyncBusy, setFullSyncBusy] = useState(false);
+  const [fullSyncProgress, setFullSyncProgress] = useState<FullSyncProgressPayload | null>(null);
+  const [fullSyncResult, setFullSyncResult] = useState<{
+    totalResources: number;
+    embeddingFailed: number;
+  } | null>(null);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const progressCleanupRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     const off = window.electron.on('indexing:full-sync-progress', (data: FullSyncProgressPayload) => {
@@ -94,18 +119,6 @@ export default function IndexingSettings() {
       off?.();
     };
   }, [loadEmbedStatus]);
-
-  const fullSyncPercent =
-    fullSyncProgress && fullSyncProgress.resourcesTotal > 0
-      ? fullSyncProgress.phase === 'finished'
-        ? 100
-        : fullSyncProgress.phase === 'starting'
-          ? 0
-          : Math.min(
-              100,
-              Math.round((fullSyncProgress.resourceIndex / fullSyncProgress.resourcesTotal) * 100),
-            )
-      : 0;
 
   const handleFullSync = async () => {
     setFullSyncBusy(true);
@@ -124,13 +137,27 @@ export default function IndexingSettings() {
         setLastError(r?.error || t('settings.indexing.error_index_failed'));
       }
     } catch (e) {
-      setLastError(e instanceof Error ? e.message : String(e));
+      setLastError(toErrorMessage(e));
     } finally {
       setFullSyncBusy(false);
       setFullSyncProgress(null);
       void loadEmbedStatus();
     }
   };
+
+  return { fullSyncBusy, fullSyncProgress, fullSyncResult, lastError, handleFullSync };
+}
+
+interface EmbeddingReindexDeps {
+  loadEmbedStatus: () => Promise<void>;
+  setEmbedError: (e: string | null) => void;
+  setEmbedProgress: (p: { done: number; total: number } | null) => void;
+  t: TranslateFn;
+}
+
+/** Re-embed the whole library through the semantic index. */
+function useSemanticReindex({ loadEmbedStatus, setEmbedError, setEmbedProgress, t }: EmbeddingReindexDeps) {
+  const [embedReindexBusy, setEmbedReindexBusy] = useState(false);
 
   const handleSemanticReindexAll = async () => {
     setEmbedReindexBusy(true);
@@ -142,7 +169,7 @@ export default function IndexingSettings() {
         setEmbedError(r.error || t('settings.embeddings.error_load'));
       }
     } catch (e) {
-      setEmbedError(e instanceof Error ? e.message : String(e));
+      setEmbedError(toErrorMessage(e));
     } finally {
       setEmbedReindexBusy(false);
       setEmbedProgress(null);
@@ -150,223 +177,346 @@ export default function IndexingSettings() {
     }
   };
 
+  return { embedReindexBusy, handleSemanticReindexAll };
+}
+
+function FullSyncSection({
+  fullSyncBusy,
+  fullSyncProgress,
+  fullSyncResult,
+  libraryBusy,
+  onFullSync,
+  t,
+}: {
+  fullSyncBusy: boolean;
+  fullSyncProgress: FullSyncProgressPayload | null;
+  fullSyncResult: { totalResources: number; embeddingFailed: number } | null;
+  libraryBusy: boolean;
+  onFullSync: () => Promise<void>;
+  t: TranslateFn;
+}) {
+  const fullSyncPercent = computeFullSyncPercent(fullSyncProgress);
+  return (
+    <div>
+      <DomeSectionLabel className="mb-3 font-bold uppercase tracking-widest opacity-60 text-[var(--dome-text-muted)]">
+        {t('settings.indexing.full_sync_section')}
+      </DomeSectionLabel>
+      <DomeCard className="p-4 space-y-3">
+        <div>
+          <p className="text-sm font-semibold" style={{ color: 'var(--dome-text)' }}>
+            {t('settings.indexing.full_sync_title')}
+          </p>
+          <p className="text-xs mt-1 leading-relaxed" style={{ color: 'var(--dome-text-muted)' }}>
+            {t('settings.indexing.full_sync_hint')}
+          </p>
+        </div>
+        {fullSyncProgress &&
+        fullSyncProgress.phase !== 'finished' &&
+        fullSyncProgress.resourcesTotal > 0 ? (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="truncate" style={{ color: 'var(--dome-text-muted)' }}>
+                {fullSyncProgress.phase === 'embeddings'
+                  ? t('settings.indexing.full_sync_phase_embeddings')
+                  : '…'}
+                {fullSyncProgress.title
+                  ? ` · ${t('settings.indexing.full_sync_progress_res', {
+                      current: fullSyncProgress.resourceIndex,
+                      total: fullSyncProgress.resourcesTotal,
+                      title: fullSyncProgress.title,
+                    })}`
+                  : null}
+              </span>
+              <span className="shrink-0 font-medium" style={{ color: DOME_GREEN }}>
+                {fullSyncPercent}%
+              </span>
+            </div>
+            <DomeProgressBar value={fullSyncPercent} max={100} size="sm" variant="success" />
+          </div>
+        ) : null}
+        {fullSyncResult && !fullSyncBusy ? (
+          <DomeCallout
+            tone={fullSyncResult.embeddingFailed > 0 ? 'warning' : 'success'}
+            icon={CheckCircle2}
+          >
+            {t('settings.indexing.full_sync_done')}
+            {fullSyncResult.totalResources > 0 && fullSyncResult.embeddingFailed > 0
+              ? ` ${t('settings.indexing.full_sync_summary_errors', { emb: fullSyncResult.embeddingFailed })}`
+              : null}
+          </DomeCallout>
+        ) : null}
+        <DomeButton
+          type="button"
+          variant="primary"
+          size="md"
+          disabled={libraryBusy}
+          onClick={() => void onFullSync()}
+          leftIcon={
+            fullSyncBusy ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+            ) : (
+              <Layers className="size-4" aria-hidden />
+            )
+          }
+        >
+          {fullSyncBusy ? t('settings.indexing.full_sync_running') : t('settings.indexing.full_sync_btn')}
+        </DomeButton>
+      </DomeCard>
+    </div>
+  );
+}
+
+function EmbeddingsStatusBlock({
+  embedStatus,
+  embedProgress,
+  embedReindexBusy,
+  t,
+}: {
+  embedStatus: SemanticIndexingStatusPayload;
+  embedProgress: { done: number; total: number } | null;
+  embedReindexBusy: boolean;
+  t: TranslateFn;
+}) {
+  return (
+    <div className="mt-4 space-y-3">
+      {embedStatus.modelVersion ? (
+        <p className="text-[11px]" style={{ color: 'var(--dome-text-muted)' }}>
+          <span className="font-medium" style={{ color: 'var(--dome-text-secondary)' }}>
+            {t('settings.ai.embeddings.status.model_active')}:
+          </span>{' '}
+          <code className="text-[10px] px-1 py-0.5 rounded" style={{ background: 'var(--dome-surface)' }}>
+            {embedStatus.modelVersion}
+          </code>
+          {embedStatus.dimensions != null ? (
+            <span className="ml-2">
+              ({embedStatus.dimensions} {t('settings.ai.embeddings.status.dimensions').toLowerCase()})
+            </span>
+          ) : null}
+        </p>
+      ) : null}
+
+      {embedStatus.indexableTotal === 0 ? (
+        <DomeCallout tone="info" icon={Sparkles}>
+          {t('settings.embeddings.empty_library')}
+        </DomeCallout>
+      ) : (
+        <>
+          <div className="settings-stat-grid settings-stat-grid--4">
+            {[
+              { label: t('settings.embeddings.total'), value: embedStatus.indexableTotal, color: DOME_GREEN },
+              {
+                label: t('settings.embeddings.indexed'),
+                value: embedStatus.indexedResourceCount,
+                color: DOME_GREEN,
+              },
+              {
+                label: t('settings.embeddings.pending'),
+                value: embedStatus.pendingCount,
+                color: embedStatus.pendingCount > 0 ? 'var(--warning)' : DOME_GREEN,
+              },
+              { label: t('settings.embeddings.chunks'), value: embedStatus.chunksTotal, color: DOME_GREEN },
+            ].map(({ label, value, color }) => (
+              <DomeCard key={label} className="p-4">
+                <p className="text-2xl font-bold" style={{ color }}>
+                  {value}
+                </p>
+                <p className="text-xs mt-0.5" style={{ color: 'var(--dome-text-muted)' }}>
+                  {label}
+                </p>
+              </DomeCard>
+            ))}
+          </div>
+
+          {embedStatus.allIndexed ? (
+            <div
+              className="flex items-center gap-2 px-4 py-2 rounded-lg text-xs w-fit"
+              style={{
+                backgroundColor: 'var(--dome-surface)',
+                border: '1px solid var(--dome-border)',
+                color: 'var(--dome-text-muted)',
+              }}
+            >
+              <CheckCircle2 className="size-3.5 shrink-0" style={{ color: DOME_GREEN }} />
+              {t('settings.embeddings.all_indexed')}
+            </div>
+          ) : (
+            <DomeCallout tone="warning" icon={Sparkles}>
+              {t('settings.embeddings.pending_label', { count: embedStatus.pendingCount })}
+            </DomeCallout>
+          )}
+        </>
+      )}
+
+      {embedProgress && embedProgress.total > 0 && embedReindexBusy ? (
+        <p className="text-xs" style={{ color: 'var(--dome-text-muted)' }}>
+          {t('settings.embeddings.progress', {
+            done: embedProgress.done,
+            total: embedProgress.total,
+          })}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function EmbeddingsSection({
+  embedStatus,
+  embedLoading,
+  embedError,
+  embedProgress,
+  embedReindexBusy,
+  libraryBusy,
+  onRefresh,
+  onReindexAll,
+  t,
+}: {
+  embedStatus: SemanticIndexingStatusPayload | null;
+  embedLoading: boolean;
+  embedError: string | null;
+  embedProgress: { done: number; total: number } | null;
+  embedReindexBusy: boolean;
+  libraryBusy: boolean;
+  onRefresh: () => void;
+  onReindexAll: () => Promise<void>;
+  t: TranslateFn;
+}) {
+  return (
+    <div className="pt-2 border-t" style={{ borderColor: 'var(--dome-border)' }}>
+      <DomeSubpageHeader className={"!border-0 p-0 bg-transparent mt-2"}>
+        <DomeSubpageHeader.Title>{t('settings.embeddings.section_title')}</DomeSubpageHeader.Title>
+        <DomeSubpageHeader.Subtitle>{t('settings.embeddings.section_hint')}</DomeSubpageHeader.Subtitle>
+      </DomeSubpageHeader>
+
+      {embedStatus && embedStatus.configured === false && !embedLoading ? (
+        <DomeCallout tone="warning" className="mt-3">
+          {t('settings.ai.embeddings.status.not_configured')}
+        </DomeCallout>
+      ) : null}
+
+      {embedLoading ? (
+        <p className="text-xs mt-3 flex items-center gap-2" style={{ color: 'var(--dome-text-muted)' }}>
+          <Loader2 className="size-3.5 animate-spin shrink-0" aria-hidden />
+          {t('settings.embeddings.loading')}
+        </p>
+      ) : null}
+
+      {embedError ? <DomeCallout tone="error" className="mt-3">{embedError}</DomeCallout> : null}
+
+      {embedStatus && !embedLoading ? (
+        <EmbeddingsStatusBlock
+          embedStatus={embedStatus}
+          embedProgress={embedProgress}
+          embedReindexBusy={embedReindexBusy}
+          t={t}
+        />
+      ) : null}
+
+      {!embedLoading ? (
+        <div className="flex flex-wrap gap-2 mt-4">
+          <DomeButton
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onRefresh}
+            disabled={libraryBusy}
+            leftIcon={<RefreshCw className="size-3.5" aria-hidden />}
+          >
+            {t('settings.embeddings.refresh')}
+          </DomeButton>
+          <DomeButton
+            type="button"
+            variant="primary"
+            size="sm"
+            onClick={() => void onReindexAll()}
+            disabled={libraryBusy}
+            leftIcon={
+              embedReindexBusy ? (
+                <Loader2 className="size-3.5 animate-spin" aria-hidden />
+              ) : (
+                <Sparkles className="size-3.5" aria-hidden />
+              )
+            }
+          >
+            {embedReindexBusy ? t('settings.embeddings.reindexing') : t('settings.embeddings.reindex')}
+          </DomeButton>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function IndexingSettings() {
+  const { t } = useTranslation();
+  const [pausePolling, setPausePolling] = useState(false);
+
+  const {
+    embedStatus,
+    embedLoading,
+    setEmbedLoading,
+    embedError,
+    setEmbedError,
+    embedProgress,
+    setEmbedProgress,
+    loadEmbedStatus,
+  } = useEmbeddingStatus(pausePolling);
+
+  const { fullSyncBusy, fullSyncProgress, fullSyncResult, lastError, handleFullSync } = useFullSync(
+    loadEmbedStatus,
+    t,
+  );
+
+  const { embedReindexBusy, handleSemanticReindexAll } = useSemanticReindex({
+    loadEmbedStatus,
+    setEmbedError,
+    setEmbedProgress,
+    t,
+  });
+
   const libraryBusy = fullSyncBusy || embedReindexBusy;
+
+  // Pause the 8s status poll while a bulk operation runs (matches the
+  // original `!embedReindexBusy && !fullSyncBusy` polling guard).
+  useEffect(() => {
+    setPausePolling(libraryBusy);
+  }, [libraryBusy]);
+
+  const handleRefresh = () => {
+    setEmbedLoading(true);
+    void loadEmbedStatus();
+  };
 
   return (
     <SettingsPanel>
       <DomeSubpageHeader className={"!border-0 p-0 bg-transparent"}>
-  <DomeSubpageHeader.Title>{t('settings.indexing.title')}</DomeSubpageHeader.Title>
-  <DomeSubpageHeader.Subtitle>{t('settings.indexing.subtitle')}</DomeSubpageHeader.Subtitle>
-</DomeSubpageHeader>
+        <DomeSubpageHeader.Title>{t('settings.indexing.title')}</DomeSubpageHeader.Title>
+        <DomeSubpageHeader.Subtitle>{t('settings.indexing.subtitle')}</DomeSubpageHeader.Subtitle>
+      </DomeSubpageHeader>
 
       {/* Full library index (cloud vision transcription + Nomic embeddings) */}
-      <div>
-        <DomeSectionLabel className="mb-3 font-bold uppercase tracking-widest opacity-60 text-[var(--dome-text-muted)]">
-          {t('settings.indexing.full_sync_section')}
-        </DomeSectionLabel>
-        <DomeCard className="p-4 space-y-3">
-          <div>
-            <p className="text-sm font-semibold" style={{ color: 'var(--dome-text)' }}>
-              {t('settings.indexing.full_sync_title')}
-            </p>
-            <p className="text-xs mt-1 leading-relaxed" style={{ color: 'var(--dome-text-muted)' }}>
-              {t('settings.indexing.full_sync_hint')}
-            </p>
-          </div>
-          {fullSyncProgress &&
-          fullSyncProgress.phase !== 'finished' &&
-          fullSyncProgress.resourcesTotal > 0 ? (
-            <div className="space-y-2">
-              <div className="flex items-center justify-between gap-2 text-xs">
-                <span className="truncate" style={{ color: 'var(--dome-text-muted)' }}>
-                  {fullSyncProgress.phase === 'embeddings'
-                    ? t('settings.indexing.full_sync_phase_embeddings')
-                    : '…'}
-                  {fullSyncProgress.title
-                    ? ` · ${t('settings.indexing.full_sync_progress_res', {
-                        current: fullSyncProgress.resourceIndex,
-                        total: fullSyncProgress.resourcesTotal,
-                        title: fullSyncProgress.title,
-                      })}`
-                    : null}
-                </span>
-                <span className="shrink-0 font-medium" style={{ color: DOME_GREEN }}>
-                  {fullSyncPercent}%
-                </span>
-              </div>
-              <DomeProgressBar value={fullSyncPercent} max={100} size="sm" variant="success" />
-            </div>
-          ) : null}
-          {fullSyncResult && !fullSyncBusy ? (
-            <DomeCallout
-              tone={fullSyncResult.embeddingFailed > 0 ? 'warning' : 'success'}
-              icon={CheckCircle2}
-            >
-              {t('settings.indexing.full_sync_done')}
-              {fullSyncResult.totalResources > 0 && fullSyncResult.embeddingFailed > 0
-                ? ` ${t('settings.indexing.full_sync_summary_errors', { emb: fullSyncResult.embeddingFailed })}`
-                : null}
-            </DomeCallout>
-          ) : null}
-          <DomeButton
-            type="button"
-            variant="primary"
-            size="md"
-            disabled={libraryBusy}
-            onClick={() => void handleFullSync()}
-            leftIcon={
-              fullSyncBusy ? (
-                <Loader2 className="size-4 animate-spin" aria-hidden />
-              ) : (
-                <Layers className="size-4" aria-hidden />
-              )
-            }
-          >
-            {fullSyncBusy ? t('settings.indexing.full_sync_running') : t('settings.indexing.full_sync_btn')}
-          </DomeButton>
-        </DomeCard>
-      </div>
+      <FullSyncSection
+        fullSyncBusy={fullSyncBusy}
+        fullSyncProgress={fullSyncProgress}
+        fullSyncResult={fullSyncResult}
+        libraryBusy={libraryBusy}
+        onFullSync={handleFullSync}
+        t={t}
+      />
 
       <DomeSectionLabel className="font-bold uppercase tracking-widest opacity-60 text-[var(--dome-text-muted)]">
         {t('settings.indexing.section_separate')}
       </DomeSectionLabel>
 
-      <div className="pt-2 border-t" style={{ borderColor: 'var(--dome-border)' }}>
-        <DomeSubpageHeader className={"!border-0 p-0 bg-transparent mt-2"}>
-  <DomeSubpageHeader.Title>{t('settings.embeddings.section_title')}</DomeSubpageHeader.Title>
-  <DomeSubpageHeader.Subtitle>{t('settings.embeddings.section_hint')}</DomeSubpageHeader.Subtitle>
-</DomeSubpageHeader>
-
-        {embedStatus && embedStatus.configured === false && !embedLoading ? (
-          <DomeCallout tone="warning" className="mt-3">
-            {t('settings.ai.embeddings.status.not_configured')}
-          </DomeCallout>
-        ) : null}
-
-        {embedLoading ? (
-          <p className="text-xs mt-3 flex items-center gap-2" style={{ color: 'var(--dome-text-muted)' }}>
-            <Loader2 className="size-3.5 animate-spin shrink-0" aria-hidden />
-            {t('settings.embeddings.loading')}
-          </p>
-        ) : null}
-
-        {embedError ? <DomeCallout tone="error" className="mt-3">{embedError}</DomeCallout> : null}
-
-        {embedStatus && !embedLoading ? (
-          <div className="mt-4 space-y-3">
-            {embedStatus.modelVersion ? (
-              <p className="text-[11px]" style={{ color: 'var(--dome-text-muted)' }}>
-                <span className="font-medium" style={{ color: 'var(--dome-text-secondary)' }}>
-                  {t('settings.ai.embeddings.status.model_active')}:
-                </span>{' '}
-                <code className="text-[10px] px-1 py-0.5 rounded" style={{ background: 'var(--dome-surface)' }}>
-                  {embedStatus.modelVersion}
-                </code>
-                {embedStatus.dimensions != null ? (
-                  <span className="ml-2">
-                    ({embedStatus.dimensions} {t('settings.ai.embeddings.status.dimensions').toLowerCase()})
-                  </span>
-                ) : null}
-              </p>
-            ) : null}
-
-            {embedStatus.indexableTotal === 0 ? (
-              <DomeCallout tone="info" icon={Sparkles}>
-                {t('settings.embeddings.empty_library')}
-              </DomeCallout>
-            ) : (
-              <>
-                <div className="settings-stat-grid settings-stat-grid--4">
-                  {[
-                    { label: t('settings.embeddings.total'), value: embedStatus.indexableTotal, color: DOME_GREEN },
-                    {
-                      label: t('settings.embeddings.indexed'),
-                      value: embedStatus.indexedResourceCount,
-                      color: DOME_GREEN,
-                    },
-                    {
-                      label: t('settings.embeddings.pending'),
-                      value: embedStatus.pendingCount,
-                      color: embedStatus.pendingCount > 0 ? 'var(--warning)' : DOME_GREEN,
-                    },
-                    { label: t('settings.embeddings.chunks'), value: embedStatus.chunksTotal, color: DOME_GREEN },
-                  ].map(({ label, value, color }) => (
-                    <DomeCard key={label} className="p-4">
-                      <p className="text-2xl font-bold" style={{ color }}>
-                        {value}
-                      </p>
-                      <p className="text-xs mt-0.5" style={{ color: 'var(--dome-text-muted)' }}>
-                        {label}
-                      </p>
-                    </DomeCard>
-                  ))}
-                </div>
-
-                {embedStatus.allIndexed ? (
-                  <div
-                    className="flex items-center gap-2 px-4 py-2 rounded-lg text-xs w-fit"
-                    style={{
-                      backgroundColor: 'var(--dome-surface)',
-                      border: '1px solid var(--dome-border)',
-                      color: 'var(--dome-text-muted)',
-                    }}
-                  >
-                    <CheckCircle2 className="size-3.5 shrink-0" style={{ color: DOME_GREEN }} />
-                    {t('settings.embeddings.all_indexed')}
-                  </div>
-                ) : (
-                  <DomeCallout tone="warning" icon={Sparkles}>
-                    {t('settings.embeddings.pending_label', { count: embedStatus.pendingCount })}
-                  </DomeCallout>
-                )}
-              </>
-            )}
-
-            {embedProgress && embedProgress.total > 0 && embedReindexBusy ? (
-              <p className="text-xs" style={{ color: 'var(--dome-text-muted)' }}>
-                {t('settings.embeddings.progress', {
-                  done: embedProgress.done,
-                  total: embedProgress.total,
-                })}
-              </p>
-            ) : null}
-          </div>
-        ) : null}
-
-        {!embedLoading ? (
-          <div className="flex flex-wrap gap-2 mt-4">
-            <DomeButton
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                setEmbedLoading(true);
-                void loadEmbedStatus();
-              }}
-              disabled={libraryBusy}
-              leftIcon={<RefreshCw className="size-3.5" aria-hidden />}
-            >
-              {t('settings.embeddings.refresh')}
-            </DomeButton>
-            <DomeButton
-              type="button"
-              variant="primary"
-              size="sm"
-              onClick={() => void handleSemanticReindexAll()}
-              disabled={libraryBusy}
-              leftIcon={
-                embedReindexBusy ? (
-                  <Loader2 className="size-3.5 animate-spin" aria-hidden />
-                ) : (
-                  <Sparkles className="size-3.5" aria-hidden />
-                )
-              }
-            >
-              {embedReindexBusy ? t('settings.embeddings.reindexing') : t('settings.embeddings.reindex')}
-            </DomeButton>
-          </div>
-        ) : null}
-      </div>
+      <EmbeddingsSection
+        embedStatus={embedStatus}
+        embedLoading={embedLoading}
+        embedError={embedError}
+        embedProgress={embedProgress}
+        embedReindexBusy={embedReindexBusy}
+        libraryBusy={libraryBusy}
+        onRefresh={handleRefresh}
+        onReindexAll={handleSemanticReindexAll}
+        t={t}
+      />
 
       {lastError ? <DomeCallout tone="error">{lastError}</DomeCallout> : null}
     </SettingsPanel>

--- a/app/components/shell/folder-tab/FolderCard.tsx
+++ b/app/components/shell/folder-tab/FolderCard.tsx
@@ -9,7 +9,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { Resource } from '@/lib/hooks/useResources';
 import DomeResourceIcon from '@/components/ui/DomeResourceIcon';
-import { useResourceVisualPreview } from '@/lib/hooks/useResourceVisualPreview';
+import { useResourceVisualPreview, type ResourceVisualPreview } from '@/lib/hooks/useResourceVisualPreview';
 import { DOME_IFRAME_STORAGE_SHIM_SCRIPT } from '@/lib/chat/artifactStorageShim';
 import { useArtifactFrameSrc } from '@/lib/chat/artifactFrameUrl';
 import { getFolderColor, TYPE_LABELS, FOLDER_COLOR_DEFAULT } from './folderTabShared';
@@ -176,26 +176,7 @@ function highlightSnippet(text: string, query: string): ReactNode {
   return parts.length > 0 ? parts : text;
 }
 
-function FolderCardImpl({
-  item,
-  isFolder,
-  isLast,
-  onOpen,
-  onDelete,
-  onRename,
-  onChangeColor,
-  onMoveToProject,
-  onMoveToFolder,
-  onOpenInSplit,
-  onOpenInWindow,
-  onNewSubfolder,
-  onToggleSelect,
-  selected,
-  showSelectionChrome,
-  searchQuery,
-  searchFocused,
-  cardRef,
-}: {
+interface FolderCardProps {
   item: Resource;
   isFolder: boolean;
   isLast: boolean;
@@ -214,41 +195,41 @@ function FolderCardImpl({
   searchQuery?: string;
   searchFocused?: boolean;
   cardRef?: React.Ref<HTMLDivElement>;
-}) {
-  const { t } = useTranslation();
-  const [hovered, setHovered] = useState(false);
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(null);
-  const [renaming, setRenaming] = useState(false);
-  const [renameValue, setRenameValue] = useState(item.title ?? '');
-  const [colorPickerPos, setColorPickerPos] = useState<{ top: number; left: number } | null>(null);
-  const menuBtnRef = useRef<HTMLButtonElement>(null);
-  const renameRef = useRef<HTMLInputElement>(null);
+}
 
-  useEffect(() => {
-    if (!menuOpen) return;
-    const close = () => setMenuOpen(false);
-    document.addEventListener('mousedown', close);
-    return () => document.removeEventListener('mousedown', close);
-  }, [menuOpen]);
+type TranslateFn = ReturnType<typeof useTranslation>['t'];
 
-  const startRenaming = () => {
-    setRenaming(true);
-    setRenameValue(item.title ?? '');
-    requestAnimationFrame(() => renameRef.current?.focus());
-  };
+/** All render-ready values derived from the resource + lazy visual preview. */
+interface CardPresentation {
+  folderColor: string | undefined;
+  typeColor: string;
+  typeLabel: string;
+  timeAgo: string;
+  coverImage: string | null;
+  isPdfCover: boolean;
+  artifactTemplate: string | null;
+  snippet: string;
+  coverShowsSnippet: boolean;
+  noteMarkdown: string | null;
+  displayTitle: string;
+  isMediaCard: boolean;
+  isDocCard: boolean;
+  isVideoCard: boolean;
+}
 
+function deriveCardPresentation(
+  item: Resource,
+  isFolder: boolean,
+  visual: ResourceVisualPreview,
+  searchQuery: string | undefined,
+  t: TranslateFn,
+): CardPresentation {
   const folderColor = isFolder ? getFolderColor(item) : undefined;
   const typeColor = isFolder ? (folderColor ?? 'var(--dome-accent)') : 'var(--dome-text-muted)';
   const typeLabel = isFolder ? t('folder.typeFolder', 'Carpeta') : (TYPE_LABELS[item.type] ?? item.type);
   const timeAgo = item.updated_at
     ? formatDistanceToNow(new Date(item.updated_at), { addSuffix: true })
     : '—';
-
-  // Lazy content preview (PDF first page, artifact mini-visual, image thumbnail
-  // or text snippet) — the lightweight list payload omits content/thumbnails,
-  // so they are fetched per-card on demand via this hook.
-  const { preview: visual, ref: previewRef } = useResourceVisualPreview(isFolder ? null : item);
 
   const eagerThumbnail = isFolder ? null : pickThumbnail(item);
   const lazyImage = !isFolder
@@ -278,13 +259,426 @@ function FolderCardImpl({
     : null;
 
   const displayTitle = item.title || t('folder.untitled');
-  const isFolderCard = isFolder;
 
   // Format-aware card shape: media keeps the asset's own aspect ratio,
   // documents render as a portrait "page", folders are compact tiles.
   const isMediaCard = !isFolder && (item.type === 'image' || item.type === 'video');
   const isDocCard = !isFolder && !isMediaCard && (item.type === 'pdf' || coverShowsSnippet);
   const isVideoCard = !isFolder && item.type === 'video';
+
+  return {
+    folderColor,
+    typeColor,
+    typeLabel,
+    timeAgo,
+    coverImage,
+    isPdfCover,
+    artifactTemplate,
+    snippet,
+    coverShowsSnippet,
+    noteMarkdown,
+    displayTitle,
+    isMediaCard,
+    isDocCard,
+    isVideoCard,
+  };
+}
+
+function buildCardClass(
+  p: CardPresentation,
+  flags: { isFolderCard: boolean; searchFocused?: boolean; selected: boolean; menuOpen: boolean; isLast: boolean },
+): string {
+  return [
+    'dome-fs-card',
+    flags.isFolderCard ? 'dome-fs-card--folder' : '',
+    p.isMediaCard ? 'dome-fs-card--media' : '',
+    p.isDocCard ? 'dome-fs-card--doc' : '',
+    p.artifactTemplate ? 'dome-fs-card--artifact-card' : '',
+    flags.searchFocused ? 'dome-fs-card--focused' : '',
+    flags.selected ? 'dome-fs-card--selected' : '',
+    flags.menuOpen ? 'dome-fs-card--menu-open' : '',
+    flags.isLast ? 'dome-fs-card--last' : '',
+  ].filter(Boolean).join(' ');
+}
+
+/** Cover preview by priority: folder icon → artifact → image → Markdown → snippet → fallback icon. */
+function CoverPreviewContent({
+  item,
+  isFolderCard,
+  p,
+  visual,
+  searchQuery,
+}: {
+  item: Resource;
+  isFolderCard: boolean;
+  p: CardPresentation;
+  visual: ResourceVisualPreview;
+  searchQuery?: string;
+}) {
+  if (isFolderCard) {
+    return (
+      <Folder
+        className="dome-fs-card__cover-icon"
+        style={{ color: p.typeColor }}
+        strokeWidth={1.25}
+      />
+    );
+  }
+  if (p.artifactTemplate) {
+    return <ArtifactThumb template={p.artifactTemplate} data={visual.artifact?.data ?? null} />;
+  }
+  if (p.coverImage) {
+    // Real <img> so the asset's intrinsic aspect ratio drives the card
+    // height (masonry layout); PDF pages pin to the top like a document.
+    return (
+      <img
+        src={p.coverImage}
+        alt=""
+        className={`dome-fs-card__cover-img${p.isPdfCover ? ' dome-fs-card__cover-img--page' : ''}`}
+        draggable={false}
+        loading="lazy"
+      />
+    );
+  }
+  if (p.noteMarkdown) {
+    return <NoteMarkdownThumb markdown={p.noteMarkdown} />;
+  }
+  if (p.coverShowsSnippet) {
+    return (
+      <p className="dome-fs-card__cover-snippet">
+        {searchQuery ? highlightSnippet(p.snippet, searchQuery) : p.snippet}
+      </p>
+    );
+  }
+  if (visual.loading) {
+    return (
+      <div className="dome-fs-card__cover-fallback" style={{ color: p.typeColor }} aria-hidden>
+        <DomeResourceIcon type={item.type} name={item.title} size={28} strokeWidth={1.25} />
+      </div>
+    );
+  }
+  return (
+    <div className="dome-fs-card__cover-fallback" style={{ color: p.typeColor }}>
+      {item.type === 'note' || item.type === 'notebook' ? (
+        <FileText className="size-7" strokeWidth={1.25} />
+      ) : (
+        <DomeResourceIcon type={item.type} name={item.title} size={28} strokeWidth={1.25} />
+      )}
+    </div>
+  );
+}
+
+function CardCover({
+  item,
+  isFolderCard,
+  p,
+  visual,
+  searchQuery,
+  showSelectionChrome,
+  selected,
+  renaming,
+  hovered,
+  menuOpen,
+  previewRef,
+  menuBtnRef,
+  onActivate,
+  onToggleSelect,
+  onShowMenu,
+  onToggleMenu,
+  t,
+}: {
+  item: Resource;
+  isFolderCard: boolean;
+  p: CardPresentation;
+  visual: ResourceVisualPreview;
+  searchQuery?: string;
+  showSelectionChrome: boolean;
+  selected: boolean;
+  renaming: boolean;
+  hovered: boolean;
+  menuOpen: boolean;
+  previewRef: (node: Element | null) => void;
+  menuBtnRef: React.RefObject<HTMLButtonElement>;
+  onActivate: (e: React.MouseEvent) => void;
+  onToggleSelect: (e: React.MouseEvent) => void;
+  onShowMenu: (pos: { top: number; right: number }) => void;
+  onToggleMenu: () => void;
+  t: TranslateFn;
+}) {
+  return (
+    // Cover is a mouse-only convenience target; the body below is the
+    // keyboard-accessible button (role=button + tabIndex + onKeyDown).
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+    <div
+      ref={previewRef as unknown as React.Ref<HTMLDivElement>}
+      className={`dome-fs-card__cover cursor-pointer${p.artifactTemplate ? ' dome-fs-card__cover--artifact' : ''}`}
+      onClick={onActivate}
+      style={isFolderCard
+        ? { background: `color-mix(in srgb, ${p.typeColor} 12%, var(--dome-surface))` }
+        : undefined}
+    >
+      {showSelectionChrome ? (
+        <span className="dome-fs-card__select">
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => {}}
+            onClick={(e) => { e.stopPropagation(); onToggleSelect(e); }}
+            className="dome-fs-tree-row__checkbox rounded border"
+            aria-label={t('selection.deselect')}
+          />
+        </span>
+      ) : null}
+
+      <CoverPreviewContent
+        item={item}
+        isFolderCard={isFolderCard}
+        p={p}
+        visual={visual}
+        searchQuery={searchQuery}
+      />
+
+      {p.isVideoCard ? (
+        <span className="dome-fs-card__play-badge" aria-hidden>
+          <Play className="size-4" fill="currentColor" strokeWidth={0} />
+        </span>
+      ) : null}
+
+      {(hovered || menuOpen) && !renaming ? (
+        <button
+          ref={menuBtnRef}
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            if (!menuOpen && menuBtnRef.current) {
+              const rect = menuBtnRef.current.getBoundingClientRect();
+              onShowMenu({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+            }
+            onToggleMenu();
+          }}
+          className="dome-fs-card__menu-btn"
+          aria-label={t('folder.rowActions', 'Acciones')}
+          title={t('folder.rowActions', 'Acciones')}
+        >
+          <MoreVertical className="size-3.5" />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function CardBody({
+  renaming,
+  renameRef,
+  renameValue,
+  onRenameValueChange,
+  onCommitRename,
+  onCancelRename,
+  onActivate,
+  isFolderCard,
+  p,
+  searchQuery,
+  t,
+}: {
+  renaming: boolean;
+  renameRef: React.RefObject<HTMLInputElement>;
+  renameValue: string;
+  onRenameValueChange: (value: string) => void;
+  onCommitRename: () => void;
+  onCancelRename: () => void;
+  onActivate: (e: React.MouseEvent) => void;
+  isFolderCard: boolean;
+  p: CardPresentation;
+  searchQuery?: string;
+  t: TranslateFn;
+}) {
+  if (renaming) {
+    return (
+      <div className="dome-fs-card__body">
+        <div className="dome-fs-card__rename">
+          <input
+            ref={renameRef}
+            type="text"
+            value={renameValue}
+            onChange={(e) => onRenameValueChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') onCommitRename();
+              if (e.key === 'Escape') onCancelRename();
+            }}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={t('ui.rename', 'Rename')}
+            className="dome-fs-tree-row__rename-input"
+          />
+          <button type="button" onClick={(e) => { e.stopPropagation(); onCommitRename(); }} className="dome-fs-tree-row__rename-btn dome-fs-tree-row__rename-btn--confirm">
+            <Check className="size-3.5" />
+          </button>
+          <button type="button" onClick={(e) => { e.stopPropagation(); onCancelRename(); }} className="dome-fs-tree-row__rename-btn dome-fs-tree-row__rename-btn--cancel">
+            <X className="size-3.5" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className="dome-fs-card__body"
+      onClick={onActivate}
+      aria-label={p.displayTitle}
+    >
+      <h3 className="dome-fs-card__title" title={p.displayTitle}>
+        {searchQuery ? highlightSnippet(p.displayTitle, searchQuery) : p.displayTitle}
+      </h3>
+
+      {!isFolderCard && p.snippet && !p.coverShowsSnippet && !p.artifactTemplate ? (
+        <p className="dome-fs-card__snippet">
+          {searchQuery ? highlightSnippet(p.snippet, searchQuery) : p.snippet}
+        </p>
+      ) : null}
+
+      <div className="dome-fs-card__meta">
+        <span className="dome-fs-card__type-badge" title={p.typeLabel}>{p.typeLabel}</span>
+        <span className="dome-fs-card__modified">{p.timeAgo}</span>
+      </div>
+    </button>
+  );
+}
+
+function CardMenuLayers({
+  item,
+  isFolderCard,
+  folderColor,
+  menuOpen,
+  menuPos,
+  onDismissMenu,
+  startRenaming,
+  openColorPicker,
+  colorPickerPos,
+  onCloseColorPicker,
+  actions,
+}: {
+  item: Resource;
+  isFolderCard: boolean;
+  folderColor: string | undefined;
+  menuOpen: boolean;
+  menuPos: { top: number; right: number } | null;
+  onDismissMenu: () => void;
+  startRenaming: () => void;
+  openColorPicker: () => void;
+  colorPickerPos: { top: number; left: number } | null;
+  onCloseColorPicker: () => void;
+  actions: Pick<
+    FolderCardProps,
+    | 'onDelete'
+    | 'onChangeColor'
+    | 'onMoveToProject'
+    | 'onMoveToFolder'
+    | 'onOpenInSplit'
+    | 'onOpenInWindow'
+    | 'onNewSubfolder'
+  >;
+}) {
+  return (
+    <>
+      {/* Rendered via portal to `document.body`: the card is a containing block
+          for fixed-position descendants (it has `container-type` + `overflow:
+          hidden` + a hover `transform`), which would otherwise clip and
+          mis-position this menu. */}
+      {menuOpen && menuPos && typeof document !== 'undefined'
+        ? createPortal(
+            <div
+              role="menu"
+              tabIndex={-1}
+              className="dome-folder-view__row-menu"
+              style={{ top: menuPos.top, right: menuPos.right }}
+              onMouseDown={(e) => e.stopPropagation()}
+            >
+              <ResourceContextMenuItems
+                resource={item}
+                options={{
+                  isFolder: isFolderCard,
+                  isNote: item.type === 'note',
+                  canOpenInSplit: Boolean(actions.onOpenInSplit),
+                }}
+                actions={{
+                  onRename: startRenaming,
+                  onOpenInSplit: actions.onOpenInSplit,
+                  onOpenInWindow: actions.onOpenInWindow,
+                  onChangeColor: isFolderCard && actions.onChangeColor ? openColorPicker : undefined,
+                  onMoveToFolder: actions.onMoveToFolder,
+                  onMoveToProject: actions.onMoveToProject,
+                  onNewSubfolder: isFolderCard ? actions.onNewSubfolder : undefined,
+                  onDelete: actions.onDelete,
+                }}
+                onDismiss={onDismissMenu}
+              />
+            </div>,
+            document.body,
+          )
+        : null}
+
+      {colorPickerPos && actions.onChangeColor ? (
+        <ColorPickerPopover
+          pos={colorPickerPos}
+          currentColor={folderColor?.startsWith('#') ? folderColor : FOLDER_COLOR_DEFAULT}
+          onSave={actions.onChangeColor}
+          onClose={onCloseColorPicker}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function FolderCardImpl({
+  item,
+  isFolder,
+  isLast,
+  onOpen,
+  onDelete,
+  onRename,
+  onChangeColor,
+  onMoveToProject,
+  onMoveToFolder,
+  onOpenInSplit,
+  onOpenInWindow,
+  onNewSubfolder,
+  onToggleSelect,
+  selected,
+  showSelectionChrome,
+  searchQuery,
+  searchFocused,
+  cardRef,
+}: FolderCardProps) {
+  const { t } = useTranslation();
+  const [hovered, setHovered] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(null);
+  const [renaming, setRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState(item.title ?? '');
+  const [colorPickerPos, setColorPickerPos] = useState<{ top: number; left: number } | null>(null);
+  const menuBtnRef = useRef<HTMLButtonElement>(null);
+  const renameRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const close = () => setMenuOpen(false);
+    document.addEventListener('mousedown', close);
+    return () => document.removeEventListener('mousedown', close);
+  }, [menuOpen]);
+
+  const startRenaming = () => {
+    setRenaming(true);
+    setRenameValue(item.title ?? '');
+    requestAnimationFrame(() => renameRef.current?.focus());
+  };
+
+  // Lazy content preview (PDF first page, artifact mini-visual, image thumbnail
+  // or text snippet) — the lightweight list payload omits content/thumbnails,
+  // so they are fetched per-card on demand via this hook.
+  const { preview: visual, ref: previewRef } = useResourceVisualPreview(isFolder ? null : item);
+
+  const isFolderCard = isFolder;
+  const p = deriveCardPresentation(item, isFolder, visual, searchQuery, t);
 
   const commitRename = () => {
     const trimmed = renameValue.trim();
@@ -317,17 +711,7 @@ function FolderCardImpl({
     setColorPickerPos({ top, left });
   };
 
-  const cardClass = [
-    'dome-fs-card',
-    isFolderCard ? 'dome-fs-card--folder' : '',
-    isMediaCard ? 'dome-fs-card--media' : '',
-    isDocCard ? 'dome-fs-card--doc' : '',
-    artifactTemplate ? 'dome-fs-card--artifact-card' : '',
-    searchFocused ? 'dome-fs-card--focused' : '',
-    selected ? 'dome-fs-card--selected' : '',
-    menuOpen ? 'dome-fs-card--menu-open' : '',
-    isLast ? 'dome-fs-card--last' : '',
-  ].filter(Boolean).join(' ');
+  const cardClass = buildCardClass(p, { isFolderCard, searchFocused, selected, menuOpen, isLast });
 
   return (
     <div
@@ -342,188 +726,61 @@ function FolderCardImpl({
         setMenuOpen(true);
       }}
     >
-      {/* Cover is a mouse-only convenience target; the body below is the
-          keyboard-accessible button (role=button + tabIndex + onKeyDown). */}
-      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
-      <div
-        ref={previewRef as unknown as React.Ref<HTMLDivElement>}
-        className={`dome-fs-card__cover cursor-pointer${artifactTemplate ? ' dome-fs-card__cover--artifact' : ''}`}
-        onClick={handleCardActivate}
-        style={isFolderCard
-          ? { background: `color-mix(in srgb, ${typeColor} 12%, var(--dome-surface))` }
-          : undefined}
-      >
-        {showSelectionChrome ? (
-          <span className="dome-fs-card__select">
-            <input
-              type="checkbox"
-              checked={selected}
-              onChange={() => {}}
-              onClick={(e) => { e.stopPropagation(); onToggleSelect(e); }}
-              className="dome-fs-tree-row__checkbox rounded border"
-              aria-label={t('selection.deselect')}
-            />
-          </span>
-        ) : null}
+      <CardCover
+        item={item}
+        isFolderCard={isFolderCard}
+        p={p}
+        visual={visual}
+        searchQuery={searchQuery}
+        showSelectionChrome={showSelectionChrome}
+        selected={selected}
+        renaming={renaming}
+        hovered={hovered}
+        menuOpen={menuOpen}
+        previewRef={previewRef}
+        menuBtnRef={menuBtnRef}
+        onActivate={handleCardActivate}
+        onToggleSelect={onToggleSelect}
+        onShowMenu={setMenuPos}
+        onToggleMenu={() => setMenuOpen((v) => !v)}
+        t={t}
+      />
 
-        {isFolderCard ? (
-          <Folder
-            className="dome-fs-card__cover-icon"
-            style={{ color: typeColor }}
-            strokeWidth={1.25}
-          />
-        ) : artifactTemplate ? (
-          <ArtifactThumb template={artifactTemplate} data={visual.artifact?.data ?? null} />
-        ) : coverImage ? (
-          // Real <img> so the asset's intrinsic aspect ratio drives the card
-          // height (masonry layout); PDF pages pin to the top like a document.
-          <img
-            src={coverImage}
-            alt=""
-            className={`dome-fs-card__cover-img${isPdfCover ? ' dome-fs-card__cover-img--page' : ''}`}
-            draggable={false}
-            loading="lazy"
-          />
-        ) : noteMarkdown ? (
-          <NoteMarkdownThumb markdown={noteMarkdown} />
-        ) : coverShowsSnippet ? (
-          <p className="dome-fs-card__cover-snippet">
-            {searchQuery ? highlightSnippet(snippet, searchQuery) : snippet}
-          </p>
-        ) : visual.loading ? (
-          <div className="dome-fs-card__cover-fallback" style={{ color: typeColor }} aria-hidden>
-            <DomeResourceIcon type={item.type} name={item.title} size={28} strokeWidth={1.25} />
-          </div>
-        ) : (
-          <div className="dome-fs-card__cover-fallback" style={{ color: typeColor }}>
-            {item.type === 'note' || item.type === 'notebook' ? (
-              <FileText className="size-7" strokeWidth={1.25} />
-            ) : (
-              <DomeResourceIcon type={item.type} name={item.title} size={28} strokeWidth={1.25} />
-            )}
-          </div>
-        )}
+      <CardBody
+        renaming={renaming}
+        renameRef={renameRef}
+        renameValue={renameValue}
+        onRenameValueChange={setRenameValue}
+        onCommitRename={commitRename}
+        onCancelRename={() => setRenaming(false)}
+        onActivate={handleCardActivate}
+        isFolderCard={isFolderCard}
+        p={p}
+        searchQuery={searchQuery}
+        t={t}
+      />
 
-        {isVideoCard ? (
-          <span className="dome-fs-card__play-badge" aria-hidden>
-            <Play className="size-4" fill="currentColor" strokeWidth={0} />
-          </span>
-        ) : null}
-
-        {(hovered || menuOpen) && !renaming ? (
-          <button
-            ref={menuBtnRef}
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              if (!menuOpen && menuBtnRef.current) {
-                const rect = menuBtnRef.current.getBoundingClientRect();
-                setMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
-              }
-              setMenuOpen((v) => !v);
-            }}
-            className="dome-fs-card__menu-btn"
-            aria-label={t('folder.rowActions', 'Acciones')}
-            title={t('folder.rowActions', 'Acciones')}
-          >
-            <MoreVertical className="size-3.5" />
-          </button>
-        ) : null}
-      </div>
-
-      {renaming ? (
-        <div className="dome-fs-card__body">
-          <div className="dome-fs-card__rename">
-            <input
-              ref={renameRef}
-              type="text"
-              value={renameValue}
-              onChange={(e) => setRenameValue(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') commitRename();
-                if (e.key === 'Escape') setRenaming(false);
-              }}
-              onClick={(e) => e.stopPropagation()}
-              aria-label={t('ui.rename', 'Rename')}
-              className="dome-fs-tree-row__rename-input"
-            />
-            <button type="button" onClick={(e) => { e.stopPropagation(); commitRename(); }} className="dome-fs-tree-row__rename-btn dome-fs-tree-row__rename-btn--confirm">
-              <Check className="size-3.5" />
-            </button>
-            <button type="button" onClick={(e) => { e.stopPropagation(); setRenaming(false); }} className="dome-fs-tree-row__rename-btn dome-fs-tree-row__rename-btn--cancel">
-              <X className="size-3.5" />
-            </button>
-          </div>
-        </div>
-      ) : (
-        <button
-          type="button"
-          className="dome-fs-card__body"
-          onClick={handleCardActivate}
-          aria-label={displayTitle}
-        >
-          <h3 className="dome-fs-card__title" title={displayTitle}>
-            {searchQuery ? highlightSnippet(displayTitle, searchQuery) : displayTitle}
-          </h3>
-
-          {!isFolderCard && snippet && !coverShowsSnippet && !artifactTemplate ? (
-            <p className="dome-fs-card__snippet">
-              {searchQuery ? highlightSnippet(snippet, searchQuery) : snippet}
-            </p>
-          ) : null}
-
-          <div className="dome-fs-card__meta">
-            <span className="dome-fs-card__type-badge" title={typeLabel}>{typeLabel}</span>
-            <span className="dome-fs-card__modified">{timeAgo}</span>
-          </div>
-        </button>
-      )}
-
-      {/* Rendered via portal to `document.body`: the card is a containing block
-          for fixed-position descendants (it has `container-type` + `overflow:
-          hidden` + a hover `transform`), which would otherwise clip and
-          mis-position this menu. */}
-      {menuOpen && menuPos && typeof document !== 'undefined'
-        ? createPortal(
-            <div
-              role="menu"
-              tabIndex={-1}
-              className="dome-folder-view__row-menu"
-              style={{ top: menuPos.top, right: menuPos.right }}
-              onMouseDown={(e) => e.stopPropagation()}
-            >
-              <ResourceContextMenuItems
-                resource={item}
-                options={{
-                  isFolder: isFolderCard,
-                  isNote: item.type === 'note',
-                  canOpenInSplit: Boolean(onOpenInSplit),
-                }}
-                actions={{
-                  onRename: startRenaming,
-                  onOpenInSplit,
-                  onOpenInWindow,
-                  onChangeColor: isFolderCard && onChangeColor ? openColorPicker : undefined,
-                  onMoveToFolder,
-                  onMoveToProject,
-                  onNewSubfolder: isFolderCard ? onNewSubfolder : undefined,
-                  onDelete,
-                }}
-                onDismiss={() => setMenuOpen(false)}
-              />
-            </div>,
-            document.body,
-          )
-        : null}
-
-      {colorPickerPos && onChangeColor ? (
-        <ColorPickerPopover
-          pos={colorPickerPos}
-          currentColor={folderColor?.startsWith('#') ? folderColor : FOLDER_COLOR_DEFAULT}
-          onSave={onChangeColor}
-          onClose={() => setColorPickerPos(null)}
-        />
-      ) : null}
+      <CardMenuLayers
+        item={item}
+        isFolderCard={isFolderCard}
+        folderColor={p.folderColor}
+        menuOpen={menuOpen}
+        menuPos={menuPos}
+        onDismissMenu={() => setMenuOpen(false)}
+        startRenaming={startRenaming}
+        openColorPicker={openColorPicker}
+        colorPickerPos={colorPickerPos}
+        onCloseColorPicker={() => setColorPickerPos(null)}
+        actions={{
+          onDelete,
+          onChangeColor,
+          onMoveToProject,
+          onMoveToFolder,
+          onOpenInSplit,
+          onOpenInWindow,
+          onNewSubfolder,
+        }}
+      />
     </div>
   );
 }

--- a/app/lib/hooks/useDashboardData.ts
+++ b/app/lib/hooks/useDashboardData.ts
@@ -127,6 +127,321 @@ const EMPTY_GAMIFICATION: HomeGamification = {
 
 const BACKGROUND_RELOAD_DEBOUNCE_MS = 800;
 
+type TranslateFn = (key: string, opts?: Record<string, unknown>) => string;
+
+interface DashboardResource {
+  id: string;
+  title: string;
+  type: string;
+  project_id: string;
+  created_at?: number;
+  updated_at: number;
+  metadata?: string | Record<string, unknown>;
+}
+
+interface DashboardChatSession {
+  id: string;
+  resource_id: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface DashboardTimeWindows {
+  nowMs: number;
+  startToday: number;
+  endToday: number;
+  weekStartMs: number;
+  prevWeekStartMs: number;
+}
+
+/** Shared accumulator for streak days and per-day activity counts. */
+interface ActivityTally {
+  activityDays: Set<string>;
+  dayCountMap: Record<string, number>;
+}
+
+function makeTimeWindows(nowMs: number): DashboardTimeWindows {
+  const startToday = startOfLocalDayMs(nowMs);
+  return {
+    nowMs,
+    startToday,
+    endToday: startToday + 86400000,
+    weekStartMs: nowMs - 7 * 86400000,
+    prevWeekStartMs: nowMs - 14 * 86400000,
+  };
+}
+
+function bumpDay(tally: ActivityTally, key: string): void {
+  if (!key) return;
+  tally.dayCountMap[key] = (tally.dayCountMap[key] ?? 0) + 1;
+}
+
+function okArray<T>(res: { success?: boolean; data?: unknown } | null | undefined): T[] {
+  return res?.success && Array.isArray(res.data) ? (res.data as T[]) : [];
+}
+
+async function fetchStudioRows(
+  scopedPid: string,
+): Promise<{ rows: Array<{ created_at?: number; updated_at?: number }>; count: number }> {
+  if (!window.electron?.db?.studio?.getByProject) return { rows: [], count: 0 };
+  const studioResult = await window.electron.db.studio.getByProject(scopedPid).catch(() => null);
+  const rows = okArray<{ created_at?: number; updated_at?: number }>(studioResult);
+  return { rows, count: rows.length };
+}
+
+async function countDueFlashcards(decks: Array<{ id: string }>): Promise<number> {
+  if (!window.electron?.db?.flashcards?.getStats || decks.length === 0) return 0;
+  const deckStats = await Promise.all(
+    decks.map((deck) =>
+      window.electron.db.flashcards.getStats(deck.id).catch(() => null),
+    ),
+  );
+  return deckStats.reduce((sum, r) => {
+    if (!r?.success || !r.data) return sum;
+    return sum + Number(r.data.due_cards || 0) + Number(r.data.new_cards || 0);
+  }, 0);
+}
+
+function tallyStudioRows(
+  studioRows: Array<{ created_at?: number; updated_at?: number }>,
+  tally: ActivityTally,
+  weekStartMs: number,
+): number {
+  let studioCreatedThisWeek = 0;
+  for (const row of studioRows) {
+    const cMs = toEpochMs(row.created_at ?? row.updated_at);
+    const uMs = toEpochMs(row.updated_at ?? row.created_at);
+    tally.activityDays.add(localDayKey(cMs));
+    if (uMs !== cMs) tally.activityDays.add(localDayKey(uMs));
+    bumpDay(tally, localDayKey(cMs));
+    if (localDayKey(uMs) !== localDayKey(cMs)) bumpDay(tally, localDayKey(uMs));
+    if (cMs >= weekStartMs) studioCreatedThisWeek++;
+  }
+  return studioCreatedThisWeek;
+}
+
+async function tallyFlashcardSessions(
+  decks: Array<{ id: string }>,
+  tally: ActivityTally,
+  weekStartMs: number,
+): Promise<number> {
+  if (!window.electron?.db?.flashcards?.getSessions || decks.length === 0) return 0;
+  const sessionResults = await Promise.all(
+    decks.map((deck) =>
+      window.electron.db.flashcards.getSessions(deck.id, 120).catch(() => null),
+    ),
+  );
+  let cardsStudiedThisWeek = 0;
+  for (const result of sessionResults) {
+    const sessions =
+      result?.success && Array.isArray(result.data) ? result.data : [];
+    for (const session of sessions) {
+      const st = toEpochMs(session.started_at);
+      tally.activityDays.add(localDayKey(st));
+      bumpDay(tally, localDayKey(st));
+      if (st >= weekStartMs) {
+        cardsStudiedThisWeek += Number(session.cards_studied ?? 0);
+      }
+    }
+  }
+  return cardsStudiedThisWeek;
+}
+
+function tallyResources(
+  resources: DashboardResource[],
+  tally: ActivityTally,
+  tw: DashboardTimeWindows,
+) {
+  let weeklyResourcesCreated = 0;
+  let weeklyResourceTouches = 0;
+  let resourcesCreatedToday = 0;
+  let resourcesEditedToday = 0;
+  let resourcesCreatedThisWeek = 0;
+  let prevWeeklyResourcesCreated = 0;
+  let prevWeeklyResourceTouches = 0;
+  for (const r of resources) {
+    const cMs = toEpochMs(r.created_at ?? r.updated_at);
+    const uMs = toEpochMs(r.updated_at);
+    tally.activityDays.add(localDayKey(cMs));
+    tally.activityDays.add(localDayKey(uMs));
+    bumpDay(tally, localDayKey(cMs));
+    const uk = localDayKey(uMs);
+    if (uk !== localDayKey(cMs)) bumpDay(tally, uk);
+    else if (uMs > cMs + 1000) bumpDay(tally, uk);
+    if (cMs >= tw.weekStartMs) weeklyResourcesCreated++;
+    if (uMs >= tw.weekStartMs) weeklyResourceTouches++;
+    if (cMs >= tw.startToday && cMs < tw.endToday) resourcesCreatedToday++;
+    if (uMs >= tw.startToday && uMs < tw.endToday && uMs > cMs + 30 * 1000) resourcesEditedToday++;
+    if (cMs >= tw.weekStartMs) resourcesCreatedThisWeek++;
+    else if (cMs >= tw.prevWeekStartMs && cMs < tw.weekStartMs) prevWeeklyResourcesCreated++;
+    if (uMs >= tw.prevWeekStartMs && uMs < tw.weekStartMs) prevWeeklyResourceTouches++;
+  }
+  return {
+    weeklyResourcesCreated,
+    weeklyResourceTouches,
+    resourcesCreatedToday,
+    resourcesEditedToday,
+    resourcesCreatedThisWeek,
+    prevWeeklyResourcesCreated,
+    prevWeeklyResourceTouches,
+  };
+}
+
+function tallyChats(
+  chats: DashboardChatSession[],
+  tally: ActivityTally,
+  tw: DashboardTimeWindows,
+) {
+  let chatsToday = 0;
+  let weeklyChatSessions = 0;
+  let chatsThisWeek = 0;
+  let prevWeeklyChatSessions = 0;
+  for (const s of chats) {
+    const ca = toEpochMs(s.created_at);
+    const ua = toEpochMs(s.updated_at ?? s.created_at);
+    tally.activityDays.add(localDayKey(ca));
+    tally.activityDays.add(localDayKey(ua));
+    bumpDay(tally, localDayKey(ca));
+    const uak = localDayKey(ua);
+    if (uak !== localDayKey(ca)) bumpDay(tally, uak);
+    const maxTs = Math.max(ca, ua);
+    if (maxTs >= tw.weekStartMs) weeklyChatSessions++;
+    if (ua >= tw.startToday && ua < tw.endToday) chatsToday++;
+    if (maxTs >= tw.weekStartMs) chatsThisWeek++;
+    else if (maxTs >= tw.prevWeekStartMs && maxTs < tw.weekStartMs) prevWeeklyChatSessions++;
+  }
+  return { chatsToday, weeklyChatSessions, chatsThisWeek, prevWeeklyChatSessions };
+}
+
+function tallyRuns(
+  runs: PersistentRun[],
+  tally: ActivityTally,
+  tw: DashboardTimeWindows,
+) {
+  let runsCompletedToday = 0;
+  let weeklyRunsCompleted = 0;
+  let prevWeeklyRunsCompleted = 0;
+  let runsStartedThisWeek = 0;
+  for (const run of runs) {
+    const startedAt = toEpochMs(run.startedAt);
+    const finished = toEpochMs(run.finishedAt ?? run.updatedAt);
+    const updatedAt = toEpochMs(run.updatedAt);
+    tally.activityDays.add(localDayKey(startedAt));
+    tally.activityDays.add(localDayKey(updatedAt));
+    if (run.finishedAt) tally.activityDays.add(localDayKey(finished));
+    bumpDay(tally, localDayKey(startedAt));
+    if (run.finishedAt) bumpDay(tally, localDayKey(finished));
+    if (startedAt >= tw.weekStartMs) runsStartedThisWeek++;
+    if (run.status === 'completed') {
+      if (finished >= tw.weekStartMs) weeklyRunsCompleted++;
+      if (finished >= tw.startToday && finished < tw.endToday) runsCompletedToday++;
+      if (finished >= tw.prevWeekStartMs && finished < tw.weekStartMs) prevWeeklyRunsCompleted++;
+    }
+  }
+  return { runsCompletedToday, weeklyRunsCompleted, prevWeeklyRunsCompleted, runsStartedThisWeek };
+}
+
+function buildPendingToday(args: {
+  dueFlashcards: number;
+  eventsRaw: DashboardUpcomingEvent[];
+  runs: PersistentRun[];
+  tw: DashboardTimeWindows;
+  t: TranslateFn;
+}): PendingTodayItem[] {
+  const { dueFlashcards, eventsRaw, runs, tw, t } = args;
+  const pending: PendingTodayItem[] = [];
+  if (dueFlashcards > 0) {
+    const tagInfo = { tag: t('dashboard.tag_study'), tagKind: 'warn' as PendingTagKind };
+    pending.push({
+      id: 'pending-flashcards',
+      kind: 'flashcards',
+      title: t('dashboard.pending_flashcards', { count: dueFlashcards }),
+      subtitle: t('dashboard.pending_flashcards_sub'),
+      timestamp: tw.nowMs,
+      ...formatPendingTime(tw.nowMs),
+      ...tagInfo,
+    });
+  }
+  for (const ev of eventsRaw) {
+    const st = toEpochMs(ev.start_at);
+    if (st >= tw.startToday && st < tw.endToday + 86400000) {
+      const { time, ampm } = formatPendingTime(st);
+      const tagInfo = pendingTagForEvent(st, tw.nowMs, t);
+      pending.push({
+        id: `pending-cal-${ev.id}`,
+        kind: 'calendar',
+        title: ev.title || t('dashboard.pending_event'),
+        subtitle: t('dashboard.pending_calendar_sub'),
+        refId: ev.id,
+        timestamp: st,
+        timeLabel: time,
+        ampm,
+        ...tagInfo,
+      });
+    }
+  }
+  for (const run of runs) {
+    if (run.status === 'running' || run.status === 'waiting_approval' || run.status === 'queued') {
+      const updatedAt = toEpochMs(run.updatedAt);
+      const { time, ampm } = formatPendingTime(updatedAt);
+      const tagInfo = pendingTagForRun(run.status, t);
+      pending.push({
+        id: `pending-run-${run.id}`,
+        kind: 'run',
+        title: run.title || t('dashboard.pending_run'),
+        subtitle: t('dashboard.pending_run_sub'),
+        refId: run.id,
+        timestamp: updatedAt,
+        timeLabel: time,
+        ampm,
+        ...tagInfo,
+      });
+    }
+  }
+  pending.sort((a, b) => a.timestamp - b.timestamp);
+  return pending;
+}
+
+function buildActivityFeed(
+  resources: DashboardResource[],
+  chats: DashboardChatSession[],
+  nowMs: number,
+  t: TranslateFn,
+): ActivityItem[] {
+  const resourcesById = new Map(resources.map((r) => [r.id, r]));
+  const sevenDaysAgoMs = nowMs - 7 * 86400000;
+  const resourceActivity: ActivityItem[] = resources
+    .filter((r) => toEpochMs(r.updated_at) >= sevenDaysAgoMs)
+    .sort((a, b) => toEpochMs(b.updated_at) - toEpochMs(a.updated_at))
+    .slice(0, 8)
+    .map((r) => ({
+      id: `resource-${r.id}`,
+      kind: 'resource' as ActivityKind,
+      title: r.title || 'Untitled',
+      subtitle: r.type,
+      timestamp: toEpochMs(r.updated_at),
+      resourceId: r.id,
+      resourceType: r.type,
+    }));
+
+  const chatActivity: ActivityItem[] = chats.slice(0, 8).map((s) => {
+    const linked = s.resource_id ? resourcesById.get(s.resource_id) : undefined;
+    const sessionTitle = 'title' in s && typeof s.title === 'string' ? s.title.trim() : '';
+    return {
+      id: `chat-${s.id}`,
+      kind: 'chat' as ActivityKind,
+      title: sessionTitle || linked?.title || t('dashboard.activity_chat_default'),
+      timestamp: toEpochMs(s.updated_at ?? s.created_at),
+      sessionId: s.id,
+    };
+  });
+
+  return [...resourceActivity, ...chatActivity]
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .slice(0, 12);
+}
+
+
 export function useDashboardData(projectId: string | null = null): DashboardData {
   const { i18n } = useTranslation();
   const [stats, setStats] = useState<DashboardStats>(EMPTY_STATS);
@@ -155,53 +470,18 @@ export function useDashboardData(projectId: string | null = null): DashboardData
         listRuns({ limit: 80, projectId: scopedPid }).catch(() => [] as PersistentRun[]),
       ]);
 
-      const allResourcesRaw: Array<{
-        id: string;
-        title: string;
-        type: string;
-        project_id: string;
-        created_at?: number;
-        updated_at: number;
-        metadata?: string | Record<string, unknown>;
-      }> =
-        resourcesResult?.success && Array.isArray(resourcesResult.data)
-          ? resourcesResult.data
-          : [];
-      const allResources = allResourcesRaw.filter((resource) => resource.project_id === scopedPid);
+      const allResources = okArray<DashboardResource>(resourcesResult).filter(
+        (resource) => resource.project_id === scopedPid,
+      );
 
-      let studioCount = 0;
-      let studioCreatedThisWeek = 0;
-      const studioRows: Array<{ created_at?: number; updated_at?: number }> = [];
-      if (window.electron?.db?.studio?.getByProject) {
-        const studioResult = await window.electron.db.studio.getByProject(scopedPid).catch(() => null);
-        if (studioResult?.success && Array.isArray(studioResult.data)) {
-          studioRows.push(...studioResult.data);
-          studioCount = studioResult.data.length;
-        }
-      }
+      const { rows: studioRows, count: studioCount } = await fetchStudioRows(scopedPid);
 
-      const decksRaw: Array<{ id: string; project_id?: string | null }> =
-        decksResult?.success && Array.isArray(decksResult.data) ? decksResult.data : [];
-      const decks = decksRaw.filter((deck) => deck.project_id === scopedPid);
-      let dueFlashcards = 0;
-      if (window.electron?.db?.flashcards?.getStats && decks.length > 0) {
-        const deckStats = await Promise.all(
-          decks.map((deck) =>
-            window.electron.db.flashcards.getStats(deck.id).catch(() => null),
-          ),
-        );
-        dueFlashcards = deckStats.reduce((sum, r) => {
-          if (!r?.success || !r.data) return sum;
-          return sum + Number(r.data.due_cards || 0) + Number(r.data.new_cards || 0);
-        }, 0);
-      }
+      const decks = okArray<{ id: string; project_id?: string | null }>(decksResult).filter(
+        (deck) => deck.project_id === scopedPid,
+      );
+      const dueFlashcards = await countDueFlashcards(decks);
 
-      const eventsRaw: Array<{
-        id: string;
-        title: string;
-        start_at: number;
-        calendar_color?: string;
-      }> =
+      const eventsRaw: DashboardUpcomingEvent[] =
         eventsResult?.success && Array.isArray(eventsResult.events) ? eventsResult.events : [];
 
       if (seq !== loadSeqRef.current) return;
@@ -215,206 +495,47 @@ export function useDashboardData(projectId: string | null = null): DashboardData
         })),
       );
 
-      const chats = chatsResult.success && Array.isArray(chatsResult.data) ? chatsResult.data : [];
+      const chats = okArray<DashboardChatSession>(chatsResult);
       const runsSafe = Array.isArray(runsResult) ? runsResult : [];
       setRuns(runsSafe.slice(0, 8));
 
       const activeRuns = countActiveRuns(runsSafe);
-      const nowMs = Date.now();
-      const startToday = startOfLocalDayMs(nowMs);
-      const endToday = startToday + 86400000;
-      const weekStartMs = nowMs - 7 * 86400000;
-      const prevWeekStartMs = nowMs - 14 * 86400000;
+      const tw = makeTimeWindows(Date.now());
+      const tally: ActivityTally = { activityDays: new Set<string>(), dayCountMap: {} };
 
-      const activityDays = new Set<string>();
-      const dayCountMap: Record<string, number> = {};
-      const bumpDay = (key: string) => {
-        if (!key) return;
-        dayCountMap[key] = (dayCountMap[key] ?? 0) + 1;
-      };
-
-      let weeklyResourcesCreated = 0;
-      let weeklyResourceTouches = 0;
-      let resourcesCreatedToday = 0;
-      let resourcesEditedToday = 0;
-      let resourcesCreatedThisWeek = 0;
-      let prevWeeklyResourcesCreated = 0;
-      let prevWeeklyResourceTouches = 0;
-      let cardsStudiedThisWeek = 0;
-
-      for (const row of studioRows) {
-        const cMs = toEpochMs(row.created_at ?? row.updated_at);
-        const uMs = toEpochMs(row.updated_at ?? row.created_at);
-        activityDays.add(localDayKey(cMs));
-        if (uMs !== cMs) activityDays.add(localDayKey(uMs));
-        bumpDay(localDayKey(cMs));
-        if (localDayKey(uMs) !== localDayKey(cMs)) bumpDay(localDayKey(uMs));
-        if (cMs >= weekStartMs) studioCreatedThisWeek++;
-      }
-
-      if (window.electron?.db?.flashcards?.getSessions && decks.length > 0) {
-        const sessionResults = await Promise.all(
-          decks.map((deck) =>
-            window.electron.db.flashcards.getSessions(deck.id, 120).catch(() => null),
-          ),
-        );
-        for (const result of sessionResults) {
-          const sessions =
-            result?.success && Array.isArray(result.data) ? result.data : [];
-          for (const session of sessions) {
-            const st = toEpochMs(session.started_at);
-            activityDays.add(localDayKey(st));
-            bumpDay(localDayKey(st));
-            if (st >= weekStartMs) {
-              cardsStudiedThisWeek += Number(session.cards_studied ?? 0);
-            }
-          }
-        }
-      }
-
-      for (const r of allResources) {
-        const cMs = toEpochMs(r.created_at ?? r.updated_at);
-        const uMs = toEpochMs(r.updated_at);
-        activityDays.add(localDayKey(cMs));
-        activityDays.add(localDayKey(uMs));
-        bumpDay(localDayKey(cMs));
-        const uk = localDayKey(uMs);
-        if (uk !== localDayKey(cMs)) bumpDay(uk);
-        else if (uMs > cMs + 1000) bumpDay(uk);
-        if (cMs >= weekStartMs) weeklyResourcesCreated++;
-        if (uMs >= weekStartMs) weeklyResourceTouches++;
-        if (cMs >= startToday && cMs < endToday) resourcesCreatedToday++;
-        if (uMs >= startToday && uMs < endToday && uMs > cMs + 30 * 1000) resourcesEditedToday++;
-        if (cMs >= weekStartMs) resourcesCreatedThisWeek++;
-        else if (cMs >= prevWeekStartMs && cMs < weekStartMs) prevWeeklyResourcesCreated++;
-        if (uMs >= prevWeekStartMs && uMs < weekStartMs) prevWeeklyResourceTouches++;
-      }
-
-      let chatsToday = 0;
-      let weeklyChatSessions = 0;
-      let chatsThisWeek = 0;
-      let prevWeeklyChatSessions = 0;
-      for (const s of chats) {
-        const ca = toEpochMs(s.created_at);
-        const ua = toEpochMs(s.updated_at ?? s.created_at);
-        activityDays.add(localDayKey(ca));
-        activityDays.add(localDayKey(ua));
-        bumpDay(localDayKey(ca));
-        const uak = localDayKey(ua);
-        if (uak !== localDayKey(ca)) bumpDay(uak);
-        const maxTs = Math.max(ca, ua);
-        if (maxTs >= weekStartMs) weeklyChatSessions++;
-        if (ua >= startToday && ua < endToday) chatsToday++;
-        if (maxTs >= weekStartMs) chatsThisWeek++;
-        else if (maxTs >= prevWeekStartMs && maxTs < weekStartMs) prevWeeklyChatSessions++;
-      }
-
-      let runsCompletedToday = 0;
-      let weeklyRunsCompleted = 0;
-      let prevWeeklyRunsCompleted = 0;
-      let runsStartedThisWeek = 0;
-      for (const run of runsSafe) {
-        const startedAt = toEpochMs(run.startedAt);
-        const finished = toEpochMs(run.finishedAt ?? run.updatedAt);
-        const updatedAt = toEpochMs(run.updatedAt);
-        activityDays.add(localDayKey(startedAt));
-        activityDays.add(localDayKey(updatedAt));
-        if (run.finishedAt) activityDays.add(localDayKey(finished));
-        bumpDay(localDayKey(startedAt));
-        if (run.finishedAt) bumpDay(localDayKey(finished));
-        if (startedAt >= weekStartMs) runsStartedThisWeek++;
-        if (run.status === 'completed') {
-          if (finished >= weekStartMs) weeklyRunsCompleted++;
-          if (finished >= startToday && finished < endToday) runsCompletedToday++;
-          if (finished >= prevWeekStartMs && finished < weekStartMs) prevWeeklyRunsCompleted++;
-        }
-      }
+      const studioCreatedThisWeek = tallyStudioRows(studioRows, tally, tw.weekStartMs);
+      const cardsStudiedThisWeek = await tallyFlashcardSessions(decks, tally, tw.weekStartMs);
+      const resourceTotals = tallyResources(allResources, tally, tw);
+      const chatTotals = tallyChats(chats, tally, tw);
+      const runTotals = tallyRuns(runsSafe, tally, tw);
 
       const dailyGoals = buildDailyGoals({
-        resourcesCreatedToday,
-        resourcesEditedToday,
-        chatsToday,
-        runsCompletedToday,
+        resourcesCreatedToday: resourceTotals.resourcesCreatedToday,
+        resourcesEditedToday: resourceTotals.resourcesEditedToday,
+        chatsToday: chatTotals.chatsToday,
+        runsCompletedToday: runTotals.runsCompletedToday,
         activeRuns,
         t,
       });
 
       const dailyGoalProgress = dailyGoals.filter((g) => g.done).length;
 
-      const streakDays = computeStreak(activityDays);
-      const momentumPercent = computeMomentumPercent({
-        weeklyCreated: weeklyResourcesCreated,
-        weeklyTouches: weeklyResourceTouches,
-        weeklyChats: weeklyChatSessions,
-        weeklyRuns: weeklyRunsCompleted,
+      const streakDays = computeStreak(tally.activityDays);
+      const currentWeekEnergy = {
+        weeklyCreated: resourceTotals.weeklyResourcesCreated,
+        weeklyTouches: resourceTotals.weeklyResourceTouches,
+        weeklyChats: chatTotals.weeklyChatSessions,
+        weeklyRuns: runTotals.weeklyRunsCompleted,
+      };
+      const momentumPercent = computeMomentumPercent(currentWeekEnergy);
+      const weeklyEnergyDelta = computeWeeklyEnergyDelta(currentWeekEnergy, {
+        weeklyCreated: resourceTotals.prevWeeklyResourcesCreated,
+        weeklyTouches: resourceTotals.prevWeeklyResourceTouches,
+        weeklyChats: chatTotals.prevWeeklyChatSessions,
+        weeklyRuns: runTotals.prevWeeklyRunsCompleted,
       });
-      const weeklyEnergyDelta = computeWeeklyEnergyDelta(
-        {
-          weeklyCreated: weeklyResourcesCreated,
-          weeklyTouches: weeklyResourceTouches,
-          weeklyChats: weeklyChatSessions,
-          weeklyRuns: weeklyRunsCompleted,
-        },
-        {
-          weeklyCreated: prevWeeklyResourcesCreated,
-          weeklyTouches: prevWeeklyResourceTouches,
-          weeklyChats: prevWeeklyChatSessions,
-          weeklyRuns: prevWeeklyRunsCompleted,
-        },
-      );
 
-      const pending: PendingTodayItem[] = [];
-      if (dueFlashcards > 0) {
-        const tagInfo = { tag: t('dashboard.tag_study'), tagKind: 'warn' as PendingTagKind };
-        pending.push({
-          id: 'pending-flashcards',
-          kind: 'flashcards',
-          title: t('dashboard.pending_flashcards', { count: dueFlashcards }),
-          subtitle: t('dashboard.pending_flashcards_sub'),
-          timestamp: nowMs,
-          ...formatPendingTime(nowMs),
-          ...tagInfo,
-        });
-      }
-      for (const ev of eventsRaw) {
-        const st = toEpochMs(ev.start_at);
-        if (st >= startToday && st < endToday + 86400000) {
-          const { time, ampm } = formatPendingTime(st);
-          const tagInfo = pendingTagForEvent(st, nowMs, t);
-          pending.push({
-            id: `pending-cal-${ev.id}`,
-            kind: 'calendar',
-            title: ev.title || t('dashboard.pending_event'),
-            subtitle: t('dashboard.pending_calendar_sub'),
-            refId: ev.id,
-            timestamp: st,
-            timeLabel: time,
-            ampm,
-            ...tagInfo,
-          });
-        }
-      }
-      for (const run of runsSafe) {
-        if (run.status === 'running' || run.status === 'waiting_approval' || run.status === 'queued') {
-          const updatedAt = toEpochMs(run.updatedAt);
-          const { time, ampm } = formatPendingTime(updatedAt);
-          const tagInfo = pendingTagForRun(run.status, t);
-          pending.push({
-            id: `pending-run-${run.id}`,
-            kind: 'run',
-            title: run.title || t('dashboard.pending_run'),
-            subtitle: t('dashboard.pending_run_sub'),
-            refId: run.id,
-            timestamp: updatedAt,
-            timeLabel: time,
-            ampm,
-            ...tagInfo,
-          });
-        }
-      }
-
-      pending.sort((a, b) => a.timestamp - b.timestamp);
-      const pendingTodayCount = pending.length;
+      const pending = buildPendingToday({ dueFlashcards, eventsRaw, runs: runsSafe, tw, t });
 
       setGamification({
         streakDays,
@@ -423,11 +544,11 @@ export function useDashboardData(projectId: string | null = null): DashboardData
         dailyGoalTarget: 3,
         dailyGoalProgress,
         dailyGoals,
-        weeklyResourcesCreated,
-        weeklyResourceTouches,
-        weeklyChatSessions,
-        weeklyRunsCompleted,
-        pendingTodayCount,
+        weeklyResourcesCreated: resourceTotals.weeklyResourcesCreated,
+        weeklyResourceTouches: resourceTotals.weeklyResourceTouches,
+        weeklyChatSessions: chatTotals.weeklyChatSessions,
+        weeklyRunsCompleted: runTotals.weeklyRunsCompleted,
+        pendingTodayCount: pending.length,
       });
 
       setStats({
@@ -440,47 +561,16 @@ export function useDashboardData(projectId: string | null = null): DashboardData
       });
 
       setStatsDeltas({
-        resources: resourcesCreatedThisWeek,
-        chats: chatsThisWeek,
+        resources: resourceTotals.resourcesCreatedThisWeek,
+        chats: chatTotals.chatsThisWeek,
         dueCards: cardsStudiedThisWeek,
         studioDocs: studioCreatedThisWeek,
-        activeRuns: runsStartedThisWeek,
+        activeRuns: runTotals.runsStartedThisWeek,
       });
 
-      setActivityDayCounts(dayCountMap);
+      setActivityDayCounts(tally.dayCountMap);
 
-      const resourcesById = new Map(allResources.map((r) => [r.id, r]));
-      const sevenDaysAgoMs = nowMs - 7 * 86400000;
-      const resourceActivity: ActivityItem[] = allResources
-        .filter((r) => toEpochMs(r.updated_at) >= sevenDaysAgoMs)
-        .sort((a, b) => toEpochMs(b.updated_at) - toEpochMs(a.updated_at))
-        .slice(0, 8)
-        .map((r) => ({
-          id: `resource-${r.id}`,
-          kind: 'resource' as ActivityKind,
-          title: r.title || 'Untitled',
-          subtitle: r.type,
-          timestamp: toEpochMs(r.updated_at),
-          resourceId: r.id,
-          resourceType: r.type,
-        }));
-
-      const chatActivity: ActivityItem[] = chats.slice(0, 8).map((s) => {
-        const linked = s.resource_id ? resourcesById.get(s.resource_id) : undefined;
-        const sessionTitle = 'title' in s && typeof s.title === 'string' ? s.title.trim() : '';
-        return {
-          id: `chat-${s.id}`,
-          kind: 'chat' as ActivityKind,
-          title: sessionTitle || linked?.title || t('dashboard.activity_chat_default'),
-          timestamp: toEpochMs(s.updated_at ?? s.created_at),
-          sessionId: s.id,
-        };
-      });
-
-      const merged = [...resourceActivity, ...chatActivity]
-        .sort((a, b) => b.timestamp - a.timestamp)
-        .slice(0, 12);
-      setActivity(merged);
+      setActivity(buildActivityFeed(allResources, chats, tw.nowMs, t));
 
       setPendingToday(pending.slice(0, 8));
     } catch (error) {

--- a/docs/architecture/ipc-channels.md
+++ b/docs/architecture/ipc-channels.md
@@ -1,7 +1,7 @@
 # Canales IPC (autogenerado)
 
 > **No edites a mano.** Regenera con `pnpm run generate:ipc-inventory`.
-> Última generación: 2026-07-06T18:32:06.681Z
+> Última generación: 2026-07-10T08:03:55.191Z
 
 Canales detectados vía `ipcMain.handle` / `ipcMain.on` en `electron/ipc/**/*.cjs`.
 
@@ -200,25 +200,25 @@ Canales detectados vía `ipcMain.handle` / `ipcMain.on` en `electron/ipc/**/*.cj
 | `db:projects:getDeletionImpact` | `electron/ipc/data/database.cjs:327` |
 | `db:projects:getVaultRoot` | `electron/ipc/data/database.cjs:316` |
 | `db:projects:setVaultRoot` | `electron/ipc/data/database.cjs:297` |
-| `db:resources:bulkDelete` | `electron/ipc/data/database.cjs:2091` |
+| `db:resources:bulkDelete` | `electron/ipc/data/database.cjs:2069` |
 | `db:resources:create` | `electron/ipc/data/database.cjs:352` |
-| `db:resources:delete` | `electron/ipc/data/database.cjs:1914` |
+| `db:resources:delete` | `electron/ipc/data/database.cjs:1892` |
 | `db:resources:ensureUrl` | `electron/ipc/data/database.cjs:427` |
-| `db:resources:getAll` | `electron/ipc/data/database.cjs:1882` |
+| `db:resources:getAll` | `electron/ipc/data/database.cjs:1860` |
 | `db:resources:getBacklinks` | `electron/ipc/data/database.cjs:765` |
-| `db:resources:getByFolder` | `electron/ipc/data/database.cjs:1931` |
+| `db:resources:getByFolder` | `electron/ipc/data/database.cjs:1909` |
 | `db:resources:getById` | `electron/ipc/data/database.cjs:412` |
 | `db:resources:getByProject` | `electron/ipc/data/database.cjs:400` |
-| `db:resources:getRoot` | `electron/ipc/data/database.cjs:1944` |
-| `db:resources:listLight` | `electron/ipc/data/database.cjs:1895` |
-| `db:resources:moveToFolder` | `electron/ipc/data/database.cjs:2027` |
-| `db:resources:moveToProject` | `electron/ipc/data/database.cjs:1960` |
-| `db:resources:removeFromFolder` | `electron/ipc/data/database.cjs:2067` |
+| `db:resources:getRoot` | `electron/ipc/data/database.cjs:1922` |
+| `db:resources:listLight` | `electron/ipc/data/database.cjs:1873` |
+| `db:resources:moveToFolder` | `electron/ipc/data/database.cjs:2005` |
+| `db:resources:moveToProject` | `electron/ipc/data/database.cjs:1938` |
+| `db:resources:removeFromFolder` | `electron/ipc/data/database.cjs:2045` |
 | `db:resources:search` | `electron/ipc/data/database.cjs:688` |
 | `db:resources:searchForMention` | `electron/ipc/data/database.cjs:740` |
 | `db:resources:update` | `electron/ipc/data/database.cjs:509` |
 | `db:resources:uploadFile` | `electron/ipc/data/database.cjs:778` |
-| `db:search:unified` | `electron/ipc/data/database.cjs:1683` |
+| `db:search:unified` | `electron/ipc/data/database.cjs:1793` |
 | `db:semantic:confirm` | `electron/ipc/ai/semantic.cjs:108` |
 | `db:semantic:createManual` | `electron/ipc/ai/semantic.cjs:147` |
 | `db:semantic:delete` | `electron/ipc/ai/semantic.cjs:121` |

--- a/electron/core/db/migrations.cjs
+++ b/electron/core/db/migrations.cjs
@@ -2,13 +2,15 @@
 /**
  * SQLite migrations (05/T03 fase b — extracted verbatim from database.cjs).
  *
- * Frozen history: each `if (version < N)` block is applied in order by
- * `applyMigrations(db, version)`. New installs get the final schema directly
- * (see schema setup in database.cjs); existing installs run the runner.
- * Backup/restore atomicity is handled by the caller (runMigrations).
+ * Frozen history: each `migrationN(db, version)` function guards itself with
+ * `if (version < N)` (or a runtime schema check) and is applied in order by
+ * `applyMigrations(db, version)` via MIGRATION_STEPS. New installs get the
+ * final schema directly (see schema setup in database.cjs); existing installs
+ * run the runner. Backup/restore atomicity is handled by the caller
+ * (runMigrations).
  *
- * Add a new migration by appending an `if (version < N+1)` block at the end
- * that bumps `schema_version` to the new value.
+ * Add a new migration by defining a `migrationN+1` function that bumps
+ * `schema_version` to the new value and appending it to MIGRATION_STEPS.
  */
 
 const crypto = require('crypto');
@@ -54,11 +56,15 @@ function extractLegacyMcpServers(raw) {
   return [];
 }
 
+// Each migrationN() below was extracted verbatim from the original monolithic
+// applyMigrations body. Every function keeps its own `if (version < N)` /
+// runtime-check guard, so calling them unconditionally in order is exactly
+// equivalent to the previous sequential `if (version < N)` blocks.
 // `invalidateQueries` lives in database.cjs (it clears the prepared-statement
-// cache). It is passed in by the caller; default to a no-op so migrations never
-// throw a ReferenceError if invoked without it.
-function applyMigrations(db, version, invalidateQueries = () => {}) {
-  // Migration 1: Add internal file storage columns to resources
+// cache); default to a no-op so migrations never throw a ReferenceError.
+
+// Migration 1: Add internal file storage columns to resources
+function migration1(db, version) {
   if (version < 1) {
     console.log('[DB] Running migration 1: Add internal file storage columns');
 
@@ -99,9 +105,11 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
 
     console.log('[DB] Migration 1 complete');
   }
+}
 
-  // Migration 2: Update resources table CHECK constraint to include 'folder' type
-  // ALWAYS check if migration is needed by testing the actual constraint
+// Migration 2: Update resources table CHECK constraint to include 'folder' type
+// ALWAYS check if migration is needed by testing the actual constraint
+function migration2(db, version) {
   let needsFolderConstraintUpdate = false;
 
   try {
@@ -230,9 +238,11 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       ON CONFLICT(key) DO UPDATE SET value = '2', updated_at = excluded.updated_at
     `).run(Date.now());
   }
+}
 
-  // Migration 3: Add folder_id column for folder containment
-  // Check if folder_id column exists (it may have been added by migration 2)
+// Migration 3: Add folder_id column for folder containment
+// Check if folder_id column exists (it may have been added by migration 2)
+function migration3(db, version) {
   const tableInfoM3 = db.prepare('PRAGMA table_info(resources)').all();
   const existingColumnsM3 = new Set(tableInfoM3.map((col) => col.name));
 
@@ -258,8 +268,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       ON CONFLICT(key) DO UPDATE SET value = '3', updated_at = excluded.updated_at
     `).run(Date.now());
   }
+}
 
-  // Migration 4: Add tables for auth profiles and Many memory
+// Migration 4: Add tables for auth profiles and Many memory
+function migration4(db, version) {
   if (version < 4) {
     console.log('[DB] Running migration 4: Add auth_profiles and martin_memory tables');
 
@@ -308,8 +320,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       ON CONFLICT(key) DO UPDATE SET value = '4', updated_at = excluded.updated_at
     `).run(Date.now());
   }
+}
 
-  // Migration 5: Add knowledge graph tables (nodes and edges)
+// Migration 5: Add knowledge graph tables (nodes and edges)
+function migration5(db, version) {
   if (version < 5) {
     console.log('[DB] Running migration 5: Add knowledge graph tables');
 
@@ -395,8 +409,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       ON CONFLICT(key) DO UPDATE SET value = '5', updated_at = excluded.updated_at
     `).run(Date.now());
   }
+}
 
-  // Migration 6: Add flashcard tables for spaced repetition study
+// Migration 6: Add flashcard tables for spaced repetition study
+function migration6(db, version) {
   if (version < 6) {
     console.log('[DB] Running migration 6: Add flashcard tables');
 
@@ -472,8 +488,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       ON CONFLICT(key) DO UPDATE SET value = '6', updated_at = excluded.updated_at
     `).run(Date.now());
   }
+}
 
-  // Migration 7: Add studio_outputs table
+// Migration 7: Add studio_outputs table
+function migration7(db, version) {
   if (version < 7) {
     console.log('[DB] Running migration 7: Add studio_outputs table');
 
@@ -508,8 +526,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       ON CONFLICT(key) DO UPDATE SET value = '7', updated_at = excluded.updated_at
     `).run(Date.now());
   }
+}
 
-  // Migration 8: Studio-Flashcards unification (deck_id, resource_id, studio_output_id)
+// Migration 8: Studio-Flashcards unification (deck_id, resource_id, studio_output_id)
+function migration8(db, version) {
   if (version < 8) {
     console.log('[DB] Running migration 8: Studio-Flashcards unification');
 
@@ -546,8 +566,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       ON CONFLICT(key) DO UPDATE SET value = '8', updated_at = excluded.updated_at
     `).run(Date.now());
   }
+}
 
-  // Migration 9: Add 'notebook' to resources type constraint
+// Migration 9: Add 'notebook' to resources type constraint
+function migration9(db, version) {
   let needsNotebookConstraint = false;
   try {
     const testStmt = db.prepare(`
@@ -639,8 +661,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       ON CONFLICT(key) DO UPDATE SET value = '9', updated_at = excluded.updated_at
     `).run(Date.now());
   }
+}
 
-  // Migration 10: Add 'excel' to resources type constraint
+// Migration 10: Add 'excel' to resources type constraint
+function migration10(db) {
   let needsExcelConstraint = false;
   try {
     const testStmt = db.prepare(`
@@ -735,8 +759,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       `).run(Date.now());
     }
   }
+}
 
-  // Migration 11: Add 'ppt' to resources type constraint
+// Migration 11: Add 'ppt' to resources type constraint
+function migration11(db) {
   let needsPptConstraint = false;
   try {
     const testStmt = db.prepare(`
@@ -831,9 +857,11 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       `).run(Date.now());
     }
   }
+}
 
-  // Migration 12: Add calendar tables
-  // Also run if schema_version was incorrectly set or tables have wrong schema (e.g. from failed partial migration)
+// Migration 12: Add calendar tables
+// Also run if schema_version was incorrectly set or tables have wrong schema (e.g. from failed partial migration)
+function migration12(db, version) {
   const calendarSchemaValid = (() => {
     try {
       db.prepare('SELECT 1 FROM calendar_accounts LIMIT 1').get();
@@ -964,8 +992,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
-  // Migration 14: Schema cleanup — drop dead tables, fix FKs, remove unused columns
+// Migration 14: Schema cleanup — drop dead tables, fix FKs, remove unused columns
+function migration14(db, version) {
   if (version < 14) {
     console.log('[DB] Running migration 14: Schema cleanup');
 
@@ -1058,8 +1088,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       // Non-fatal: log but don't throw so app still starts
     }
   }
+}
 
-  // Migration 15: Chat sessions, messages, and traces for AI chat traceability
+// Migration 15: Chat sessions, messages, and traces for AI chat traceability
+function migration15(db, version) {
   if (version < 15) {
     console.log('[DB] Running migration 15 - chat sessions and traces');
     try {
@@ -1130,7 +1162,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 15 error:', error.message);
     }
   }
+}
 
+function migration16(db, version) {
   if (version < 16) {
     console.log('[DB] Running migration 16 - enrich chat sessions metadata');
     try {
@@ -1159,7 +1193,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 16 failed:', error);
     }
   }
+}
 
+function migration17(db, version) {
   if (version < 17) {
     console.log('[DB] Running migration 17 - automation definitions and persistent runs');
     try {
@@ -1255,8 +1291,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 17 failed:', error);
     }
   }
+}
 
-  // Migration 18: Resource images from Docling cloud conversion
+// Migration 18: Resource images from Docling cloud conversion
+function migration18(db, version) {
   if (version < 18) {
     try {
       db.exec(`
@@ -1286,7 +1324,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 18 failed:', error);
     }
   }
+}
 
+function migration19(db, version) {
   if (version < 19) {
     try {
       const now = Date.now();
@@ -1595,7 +1635,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 19 failed:', error);
     }
   }
+}
 
+function migration20(db, version, invalidateQueries) {
   if (version < 20) {
     try {
       const now = Date.now();
@@ -1652,9 +1694,11 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 20 failed:', error);
     }
   }
+}
 
-  // Migration 21: repair many_agents.favorite if schema_version reached 20 without the column
-  // (e.g. partial/failed migration 20 or older builds that bumped version early)
+// Migration 21: repair many_agents.favorite if schema_version reached 20 without the column
+// (e.g. partial/failed migration 20 or older builds that bumped version early)
+function migration21(db, version, invalidateQueries) {
   if (version < 21) {
     try {
       const now = Date.now();
@@ -1674,9 +1718,11 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 21 failed:', error);
     }
   }
+}
 
-  // Migration 22: repair folder_id / workflow folder schema if version advanced without migration 20
-  // (e.g. only migration 21 ran, or partial DB state)
+// Migration 22: repair folder_id / workflow folder schema if version advanced without migration 20
+// (e.g. only migration 21 ran, or partial DB state)
+function migration22(db, version, invalidateQueries) {
   if (version < 22) {
     try {
       const now = Date.now();
@@ -1735,8 +1781,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 22 failed:', error);
     }
   }
+}
 
-  // Migration 23: project scope for agents, workflows, chat, automations, runs, folders, executions
+// Migration 23: project scope for agents, workflows, chat, automations, runs, folders, executions
+function migration23(db, version, invalidateQueries) {
   if (version < 23) {
     try {
       const now = Date.now();
@@ -1859,8 +1907,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 23 failed:', error);
     }
   }
+}
 
-  // Migration 24: semantic_relations + note_embeddings replace resource_links
+// Migration 24: semantic_relations + note_embeddings replace resource_links
+function migration24(db, version, invalidateQueries) {
   if (version < 24) {
     try {
       const now = Date.now();
@@ -1954,8 +2004,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 24 failed:', error);
     }
   }
+}
 
-  // Migration 25: resource_chunks (Nomic 768-d), drop legacy note_embeddings, reset auto semantic edges
+// Migration 25: resource_chunks (Nomic 768-d), drop legacy note_embeddings, reset auto semantic edges
+function migration25(db, version, invalidateQueries) {
   if (version < 25) {
     try {
       const now = Date.now();
@@ -2002,8 +2054,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 25 failed:', error);
     }
   }
+}
 
-  // Migration 26: remove PageIndex / Docling tables; Gemma PDF transcripts + page_number on chunks
+// Migration 26: remove PageIndex / Docling tables; Gemma PDF transcripts + page_number on chunks
+function migration26(db, version, invalidateQueries) {
   if (version < 26) {
     try {
       const now = Date.now();
@@ -2052,8 +2106,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 26 failed:', error);
     }
   }
+}
 
-  // Migration 27: transcription sessions & chunks (clean-slate redesign)
+// Migration 27: transcription sessions & chunks (clean-slate redesign)
+function migration27(db, version, invalidateQueries) {
   if (version < 27) {
     console.log('[DB] Running migration 27 - transcription sessions & chunks');
     try {
@@ -2213,7 +2269,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       }
     }
   }
+}
 
+function migration29(db, version, invalidateQueries) {
   if (version < 29) {
     console.log('[DB] Running migration 29 - artifact_runtime_data + automation_artifact_bindings');
     try {
@@ -2290,8 +2348,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 29 failed:', error);
     }
   }
+}
 
-  // Migration 30: Reclassify mis-typed document resources (xlsx→excel, pptx→ppt)
+// Migration 30: Reclassify mis-typed document resources (xlsx→excel, pptx→ppt)
+function migration30(db, version, invalidateQueries) {
   if (version < 30) {
     console.log('[DB] Running migration 30 - reclassify xlsx/pptx resources');
     try {
@@ -2332,8 +2392,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 30 failed:', error);
     }
   }
+}
 
-  // Migration 31: Drop WhatsApp tables (integration removed)
+// Migration 31: Drop WhatsApp tables (integration removed)
+function migration31(db, version, invalidateQueries) {
   if (version < 31) {
     console.log('[DB] Running migration 31 - drop WhatsApp tables');
     try {
@@ -2362,8 +2424,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 31 failed:', error);
     }
   }
+}
 
-  // Migration 32: Local state for Dome cloud sync (Provider + Supabase)
+// Migration 32: Local state for Dome cloud sync (Provider + Supabase)
+function migration32(db, version, invalidateQueries) {
   if (version < 32) {
     console.log('[DB] Running migration 32 - dome_cloud_sync');
     try {
@@ -2388,8 +2452,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 32 failed:', error);
     }
   }
+}
 
-  // Migration 33: Add last_push_at to dome_cloud_sync for delta sync
+// Migration 33: Add last_push_at to dome_cloud_sync for delta sync
+function migration33(db, version, invalidateQueries) {
   if (version < 33) {
     console.log('[DB] Running migration 33 - dome_cloud_sync last_push_at');
     try {
@@ -2410,8 +2476,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 33 failed:', error);
     }
   }
+}
 
-  // Migration 34: agent_store table for the agent runtime BaseStore cross-thread memory
+// Migration 34: agent_store table for the agent runtime BaseStore cross-thread memory
+function migration34(db, version, invalidateQueries) {
   if (version < 34) {
     console.log('[DB] Running migration 34 - agent_store table');
     try {
@@ -2438,8 +2506,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 34 failed:', error);
     }
   }
+}
 
-  // Migration 35: many_agent_versions — snapshot history for agent definitions
+// Migration 35: many_agent_versions — snapshot history for agent definitions
+function migration35(db, version, invalidateQueries) {
   if (version < 35) {
     console.log('[DB] Running migration 35 - many_agent_versions table');
     try {
@@ -2474,8 +2544,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 35 failed:', error);
     }
   }
+}
 
-  // Migration 36: artifact feeders + extend automation target_type for feeder
+// Migration 36: artifact feeders + extend automation target_type for feeder
+function migration36(db, version, invalidateQueries) {
   if (version < 36) {
     console.log('[DB] Running migration 36 - artifact feeders');
     try {
@@ -2585,8 +2657,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 36 failed:', error);
     }
   }
+}
 
-  // Migration 37: quiz run history for Learn deck overview
+// Migration 37: quiz run history for Learn deck overview
+function migration37(db, version, invalidateQueries) {
   if (version < 37) {
     console.log('[DB] Running migration 37 - quiz_runs');
     try {
@@ -2620,8 +2694,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 37 failed:', error);
     }
   }
+}
 
-  // Migration 38: FSRS spaced-repetition fields on flashcards (replaces SM-2)
+// Migration 38: FSRS spaced-repetition fields on flashcards (replaces SM-2)
+function migration38(db, version, invalidateQueries) {
   if (version < 38) {
     console.log('[DB] Running migration 38 - FSRS flashcard fields');
     try {
@@ -2671,8 +2747,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 38 failed:', error);
     }
   }
+}
 
-  // Migration 39: keep flashcard_decks.card_count accurate via triggers
+// Migration 39: keep flashcard_decks.card_count accurate via triggers
+function migration39(db, version) {
   if (version < 39) {
     console.log('[DB] Running migration 39 - card_count triggers');
     try {
@@ -2715,8 +2793,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 39 failed:', error);
     }
   }
+}
 
-  // Migration 40: unified study_events table (flash + quiz) and missing FKs
+// Migration 40: unified study_events table (flash + quiz) and missing FKs
+function migration40(db, version, invalidateQueries) {
   if (version < 40) {
     console.log('[DB] Running migration 40 - study_events + FKs');
     try {
@@ -2842,8 +2922,10 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 40 failed:', error);
     }
   }
+}
 
-  // Migration 41: KPI cache so getKpis/getStreak don't rescan 365 days each call
+// Migration 41: KPI cache so getKpis/getStreak don't rescan 365 days each call
+function migration41(db, version) {
   if (version < 41) {
     console.log('[DB] Running migration 41 - learn_kpis_cache');
     try {
@@ -2865,11 +2947,13 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 41 failed:', error);
     }
   }
+}
 
-  // Migration 42: per-provider API keys/base URLs — copy the legacy shared
-  // ai_api_key / ai_base_url into the active provider's slots (encrypted value
-  // is copied verbatim; same safeStorage encryption). Legacy keys stay as a
-  // read fallback for the active provider only.
+// Migration 42: per-provider API keys/base URLs — copy the legacy shared
+// ai_api_key / ai_base_url into the active provider's slots (encrypted value
+// is copied verbatim; same safeStorage encryption). Legacy keys stay as a
+// read fallback for the active provider only.
+function migration42(db, version) {
   if (version < 42) {
     console.log('[DB] Running migration 42 - per-provider AI credentials');
     try {
@@ -2897,7 +2981,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 42 failed:', error);
     }
   }
+}
 
+function migration43(db, version) {
   if (version < 43) {
     console.log('[DB] Running migration 43 - GitHub project sync tables');
     try {
@@ -3043,7 +3129,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration44(db, version) {
   if (version < 44) {
     console.log('[DB] Running migration 44 - GitHub milestone closed_at');
     try {
@@ -3062,7 +3150,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration45(db, version) {
   if (version < 45) {
     console.log('[DB] Running migration 45 - email accounts (himalaya)');
     try {
@@ -3099,7 +3189,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration46(db, version) {
   if (version < 46) {
     console.log('[DB] Running migration 46 - notes markdown vault (vault_path)');
     try {
@@ -3126,7 +3218,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration47(db, version) {
   if (version < 47) {
     console.log('[DB] Running migration 47 - notes vault source-of-truth (content_text/hash + FTS)');
     try {
@@ -3225,7 +3319,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration48(db, version) {
   if (version < 48) {
     console.log('[DB] Running migration 48 - per-project vault root + project-relative vault_path');
     try {
@@ -3258,7 +3354,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration49(db, version) {
   if (version < 49) {
     console.log('[DB] Running migration 49 - move binaries into the vault');
     try {
@@ -3339,10 +3437,12 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
-  // Migration 51: store release markdown body so the calendar event can render it
-  // without re-hitting the GitHub API. Older sync runs left body out entirely,
-  // which is why the release modal currently shows the tag URL as plain text.
+// Migration 51: store release markdown body so the calendar event can render it
+// without re-hitting the GitHub API. Older sync runs left body out entirely,
+// which is why the release modal currently shows the tag URL as plain text.
+function migration51(db, version) {
   if (version < 51) {
     console.log('[DB] Running migration 51 - github_releases.body');
     try {
@@ -3361,16 +3461,18 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
-  // Migration 50: snap GitHub all-day events to local midnight.
-  // Earlier versions of the GitHub→calendar bridge stored `start_at` and
-  // `end_at` from the raw GitHub timestamps (e.g. `published_at: 18:30 UTC`),
-  // so the all-day event was painted as a 24-hour bar that started mid-day and
-  // the month-view renderer (which collapses only `end == startOfNextDay` back
-  // to a single cell) ended up showing the same release across two days. Fixing
-  // the bridge alone is not enough for events already in the database — this
-  // migration retroactively snaps every `source = 'github'`, `all_day = 1`
-  // event to local midnight and resets `end_at = start_at + 24h`.
+// Migration 50: snap GitHub all-day events to local midnight.
+// Earlier versions of the GitHub→calendar bridge stored `start_at` and
+// `end_at` from the raw GitHub timestamps (e.g. `published_at: 18:30 UTC`),
+// so the all-day event was painted as a 24-hour bar that started mid-day and
+// the month-view renderer (which collapses only `end == startOfNextDay` back
+// to a single cell) ended up showing the same release across two days. Fixing
+// the bridge alone is not enough for events already in the database — this
+// migration retroactively snaps every `source = 'github'`, `all_day = 1`
+// event to local midnight and resets `end_at = start_at + 24h`.
+function migration50(db, version) {
   if (version < 50) {
     console.log('[DB] Running migration 50 - snap GitHub all-day events to midnight');
     try {
@@ -3407,13 +3509,15 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
-  // Migration 52: Pipelines — unified Kanban model on top of the existing run
-  // engine. Adds four tables (pipelines, pipeline_stages, pipeline_items,
-  // pipeline_sources). Purely additive: no DROP/ALTER on existing tables, so it
-  // is reversible by restoring the pre-migration backup. Items reference the
-  // existing automation_runs / calendar_events / many_agents / canvas_workflows
-  // rows rather than duplicating them.
+// Migration 52: Pipelines — unified Kanban model on top of the existing run
+// engine. Adds four tables (pipelines, pipeline_stages, pipeline_items,
+// pipeline_sources). Purely additive: no DROP/ALTER on existing tables, so it
+// is reversible by restoring the pre-migration backup. Items reference the
+// existing automation_runs / calendar_events / many_agents / canvas_workflows
+// rows rather than duplicating them.
+function migration52(db, version) {
   if (version < 52) {
     console.log('[DB] Running migration 52 - pipelines');
     try {
@@ -3527,7 +3631,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration53(db, version) {
   if (version < 53) {
     try {
       db.exec(`
@@ -3558,7 +3664,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration54(db, version) {
   if (version < 54) {
     console.log('[DB] Running migration 54 - email account action permissions');
     try {
@@ -3583,7 +3691,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration55(db, version) {
   if (version < 55) {
     console.log('[DB] Running migration 55 - folder vault_path backfill (vault = source of truth)');
     try {
@@ -3648,7 +3758,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration56(db, version) {
   if (version < 56) {
     console.log('[DB] Running migration 56 - scope calendar/email accounts to vault (project_id)');
     try {
@@ -3673,7 +3785,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration57(db, version) {
   if (version < 57) {
     console.log('[DB] Running migration 57 - scope GitHub repos to vault (project_id)');
     try {
@@ -3853,7 +3967,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration58(db, version) {
   if (version < 58) {
     console.log('[DB] Running migration 58 - artifact vault HTML mirror backfill');
     try {
@@ -3876,7 +3992,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration59(db, version) {
   if (version < 59) {
     console.log('[DB] Running migration 59 - social hub (accounts, posts, metrics)');
     try {
@@ -3955,7 +4073,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration60(db, version) {
   if (version < 60) {
     console.log('[DB] Running migration 60 - social account metrics + AI reports');
     try {
@@ -4001,7 +4121,9 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       throw error;
     }
   }
+}
 
+function migration61(db, version) {
   if (version < 61) {
     console.log('[DB] Running migration 61 - social account kind (member vs organization pages)');
     try {
@@ -4020,6 +4142,78 @@ function applyMigrations(db, version, invalidateQueries = () => {}) {
       console.error('[DB] Migration 61 failed:', error);
       throw error;
     }
+  }
+}
+
+// Ordered migration steps. Order is execution order — do not sort by number
+// (51 intentionally runs before 50, matching the original frozen history).
+// Add a new migration by appending a `migrationN` function above and
+// registering it at the end of this list.
+const MIGRATION_STEPS = [
+  migration1,
+  migration2,
+  migration3,
+  migration4,
+  migration5,
+  migration6,
+  migration7,
+  migration8,
+  migration9,
+  migration10,
+  migration11,
+  migration12,
+  migration14,
+  migration15,
+  migration16,
+  migration17,
+  migration18,
+  migration19,
+  migration20,
+  migration21,
+  migration22,
+  migration23,
+  migration24,
+  migration25,
+  migration26,
+  migration27,
+  migration29,
+  migration30,
+  migration31,
+  migration32,
+  migration33,
+  migration34,
+  migration35,
+  migration36,
+  migration37,
+  migration38,
+  migration39,
+  migration40,
+  migration41,
+  migration42,
+  migration43,
+  migration44,
+  migration45,
+  migration46,
+  migration47,
+  migration48,
+  migration49,
+  migration51,
+  migration50,
+  migration52,
+  migration53,
+  migration54,
+  migration55,
+  migration56,
+  migration57,
+  migration58,
+  migration59,
+  migration60,
+  migration61,
+];
+
+function applyMigrations(db, version, invalidateQueries = () => {}) {
+  for (const step of MIGRATION_STEPS) {
+    step(db, version, invalidateQueries);
   }
 }
 

--- a/electron/ipc/data/database.cjs
+++ b/electron/ipc/data/database.cjs
@@ -1680,6 +1680,116 @@ function register({ ipcMain, windowManager, database, fileStorage, validateSende
     };
   };
 
+  // Sanitize query for FTS5 — quote each term to prevent special chars
+  // (like /, -, etc.) from being interpreted as FTS5 operators
+  const sanitizeFtsQuery = (query) => query
+    .replace(/[^\w\s\u00C0-\u024F\u1E00-\u1EFF]/g, ' ')  // Replace special chars with spaces
+    .split(/\s+/)
+    .filter((term) => term.length > 0)
+    .map((term) => `"${term}"`)
+    .join(' ');
+
+  const extractSearchTerms = (query) => query
+    .replace(/[^\w\s\u00C0-\u024F\u1E00-\u1EFF]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+
+  // Enrich resources: add parent resources for interactions that matched
+  // but whose resource did not match in FTS (e.g. match only in annotation)
+  const enrichResourcesFromInteractions = (queries, resourceResults, interactionResults) => {
+    const resourceIds = new Set(resourceResults.map((r) => r.id));
+    for (const interaction of interactionResults) {
+      const rid = interaction.resource_id;
+      if (rid && !resourceIds.has(rid)) {
+        const resource = queries.getResourceById.get(rid);
+        if (resource) {
+          resourceResults.push(resource);
+          resourceIds.add(rid);
+        }
+      }
+    }
+  };
+
+  // Search studio outputs (study materials) by title/content
+  const searchStudioOutputs = (rawTerms) => {
+    if (rawTerms.length === 0) return [];
+    try {
+      const db = database.getDB();
+      const placeholders = rawTerms.map(() => '(title LIKE ? OR content LIKE ?)').join(' OR ');
+      const params = rawTerms.flatMap((t) => [`%${t}%`, `%${t}%`]);
+      const stmt = db.prepare(
+        `SELECT * FROM studio_outputs WHERE ${placeholders} ORDER BY updated_at DESC LIMIT 15`
+      );
+      return stmt.all(...params) || [];
+    } catch (studioErr) {
+      console.warn('[DB] Studio search failed:', studioErr);
+      return [];
+    }
+  };
+
+  // FTS-only search of resources + interactions, with interaction enrichment.
+  // Used by the corruption-repair retry paths.
+  const runFtsUnifiedSearch = (sanitizedQuery) => {
+    const queries = database.getQueries();
+    const resourceResults = queries.searchResources.all(sanitizedQuery);
+    const interactionResults = queries.searchInteractions.all(sanitizedQuery);
+    enrichResourcesFromInteractions(queries, resourceResults, interactionResults);
+    return { resourceResults, interactionResults };
+  };
+
+  // Corruption fallback for db:search:unified — repair the FTS tables and
+  // retry (up to two repair cycles), preserving the original error handling.
+  const retryUnifiedSearchAfterRepair = (error, sanitizedQuery, rawTerms, scopeProjectId) => {
+    const handled = database.handleCorruptionError(error);
+    if (!handled) {
+      return { success: false, error: error.message };
+    }
+    // Retry the operation after repair
+    // Queries are automatically invalidated by handleCorruptionError
+    try {
+      const { resourceResults, interactionResults } = runFtsUnifiedSearch(sanitizedQuery);
+      const studioResults = searchStudioOutputs(rawTerms);
+      return {
+        success: true,
+        data: scopeUnifiedData(
+          {
+            resources: resourceResults,
+            interactions: interactionResults,
+            studioOutputs: studioResults,
+          },
+          scopeProjectId,
+        ),
+      };
+    } catch (retryError) {
+      console.error('[DB] Error retrying unified search after repair:', retryError);
+      // If it's still corrupt, try one more repair cycle
+      if (retryError.code === 'SQLITE_CORRUPT' || retryError.code === 'SQLITE_CORRUPT_VTAB') {
+        console.warn('[DB] Corruption persists in unified search, attempting more aggressive repair...');
+        database.invalidateQueries();
+        const repairedAgain = database.repairFTSTables();
+        if (repairedAgain) {
+          try {
+            const { resourceResults, interactionResults } = runFtsUnifiedSearch(sanitizedQuery);
+            return {
+              success: true,
+              data: scopeUnifiedData(
+                {
+                  resources: resourceResults,
+                  interactions: interactionResults,
+                },
+                scopeProjectId,
+              ),
+            };
+          } catch (finalError) {
+            console.error('[DB] Error after second repair attempt:', finalError);
+            return { success: false, error: finalError.message };
+          }
+        }
+      }
+      return { success: false, error: retryError.message };
+    }
+  };
+
   ipcMain.handle('db:search:unified', async (event, query, projectId) => {
     // Validate and sanitize query BEFORE the try block so retry catch blocks can use it
     validateSender(event, windowManager);
@@ -1691,15 +1801,7 @@ function register({ ipcMain, windowManager, database, fileStorage, validateSende
       return { success: false, error: 'Query too long. Maximum 1000 characters' };
     }
 
-    // Sanitize query for FTS5 — quote each term to prevent special chars
-    // (like /, -, etc.) from being interpreted as FTS5 operators
-    const sanitizedQuery = query
-      .replace(/[^\w\s\u00C0-\u024F\u1E00-\u1EFF]/g, ' ')  // Replace special chars with spaces
-      .split(/\s+/)
-      .filter(term => term.length > 0)
-      .map(term => `"${term}"`)
-      .join(' ');
-
+    const sanitizedQuery = sanitizeFtsQuery(query);
     if (!sanitizedQuery) {
       return {
         success: true,
@@ -1707,13 +1809,10 @@ function register({ ipcMain, windowManager, database, fileStorage, validateSende
       };
     }
 
+    const rawTerms = extractSearchTerms(query);
+
     try {
       const queries = database.getQueries();
-
-      const rawTerms = query
-        .replace(/[^\w\s\u00C0-\u024F\u1E00-\u1EFF]/g, ' ')
-        .split(/\s+/)
-        .filter((t) => t.length > 0);
       const lanceQuery = rawTerms.join(' ');
 
       /** @type {any[]} */
@@ -1736,35 +1835,9 @@ function register({ ipcMain, windowManager, database, fileStorage, validateSende
       // Search interactions
       const interactionResults = queries.searchInteractions.all(sanitizedQuery);
 
-      // Enrich resources: add parent resources for interactions that matched
-      // but whose resource did not match in FTS (e.g. match only in annotation)
-      const resourceIds = new Set(resourceResults.map((r) => r.id));
-      for (const interaction of interactionResults) {
-        const rid = interaction.resource_id;
-        if (rid && !resourceIds.has(rid)) {
-          const resource = queries.getResourceById.get(rid);
-          if (resource) {
-            resourceResults.push(resource);
-            resourceIds.add(rid);
-          }
-        }
-      }
+      enrichResourcesFromInteractions(queries, resourceResults, interactionResults);
 
-      // Search studio outputs (study materials) by title/content
-      let studioResults = [];
-      if (rawTerms.length > 0) {
-        try {
-          const db = database.getDB();
-          const placeholders = rawTerms.map(() => '(title LIKE ? OR content LIKE ?)').join(' OR ');
-          const params = rawTerms.flatMap((t) => [`%${t}%`, `%${t}%`]);
-          const stmt = db.prepare(
-            `SELECT * FROM studio_outputs WHERE ${placeholders} ORDER BY updated_at DESC LIMIT 15`
-          );
-          studioResults = stmt.all(...params) || [];
-        } catch (studioErr) {
-          console.warn('[DB] Studio search failed:', studioErr);
-        }
-      }
+      const studioResults = searchStudioOutputs(rawTerms);
 
       return {
         success: true,
@@ -1779,102 +1852,7 @@ function register({ ipcMain, windowManager, database, fileStorage, validateSende
       };
     } catch (error) {
       console.error('[DB] Error in unified search:', error);
-
-      // Try to handle corruption errors
-      const handled = database.handleCorruptionError(error);
-      if (handled) {
-        // Retry the operation after repair
-        // Queries are automatically invalidated by handleCorruptionError
-        try {
-          const queries = database.getQueries();
-          const resourceResults = queries.searchResources.all(sanitizedQuery);
-          const interactionResults = queries.searchInteractions.all(sanitizedQuery);
-
-          const resourceIds = new Set(resourceResults.map((r) => r.id));
-          for (const interaction of interactionResults) {
-            const rid = interaction.resource_id;
-            if (rid && !resourceIds.has(rid)) {
-              const resource = queries.getResourceById.get(rid);
-              if (resource) {
-                resourceResults.push(resource);
-                resourceIds.add(rid);
-              }
-            }
-          }
-
-          const rawTerms = query.replace(/[^\w\s\u00C0-\u024F\u1E00-\u1EFF]/g, ' ').split(/\s+/).filter((t) => t.length > 0);
-          let studioResults = [];
-          if (rawTerms.length > 0) {
-            try {
-              const db = database.getDB();
-              const placeholders = rawTerms.map(() => '(title LIKE ? OR content LIKE ?)').join(' OR ');
-              const params = rawTerms.flatMap((t) => [`%${t}%`, `%${t}%`]);
-              const stmt = db.prepare(
-                `SELECT * FROM studio_outputs WHERE ${placeholders} ORDER BY updated_at DESC LIMIT 15`
-              );
-              studioResults = stmt.all(...params) || [];
-            } catch {
-              /* ignore */
-            }
-          }
-
-          return {
-            success: true,
-            data: scopeUnifiedData(
-              {
-                resources: resourceResults,
-                interactions: interactionResults,
-                studioOutputs: studioResults,
-              },
-              scopeProjectId,
-            ),
-          };
-        } catch (retryError) {
-          console.error('[DB] Error retrying unified search after repair:', retryError);
-          // If it's still corrupt, try one more repair cycle
-          if (retryError.code === 'SQLITE_CORRUPT' || retryError.code === 'SQLITE_CORRUPT_VTAB') {
-            console.warn('[DB] Corruption persists in unified search, attempting more aggressive repair...');
-            database.invalidateQueries();
-            const repairedAgain = database.repairFTSTables();
-            if (repairedAgain) {
-              try {
-                const queries = database.getQueries();
-                const resourceResults = queries.searchResources.all(sanitizedQuery);
-                const interactionResults = queries.searchInteractions.all(sanitizedQuery);
-
-                const resourceIds = new Set(resourceResults.map((r) => r.id));
-                for (const interaction of interactionResults) {
-                  const rid = interaction.resource_id;
-                  if (rid && !resourceIds.has(rid)) {
-                    const resource = queries.getResourceById.get(rid);
-                    if (resource) {
-                      resourceResults.push(resource);
-                      resourceIds.add(rid);
-                    }
-                  }
-                }
-
-                return {
-                  success: true,
-                  data: scopeUnifiedData(
-                    {
-                      resources: resourceResults,
-                      interactions: interactionResults,
-                    },
-                    scopeProjectId,
-                  ),
-                };
-              } catch (finalError) {
-                console.error('[DB] Error after second repair attempt:', finalError);
-                return { success: false, error: finalError.message };
-              }
-            }
-          }
-          return { success: false, error: retryError.message };
-        }
-      }
-
-      return { success: false, error: error.message };
+      return retryUnifiedSearchAfterRepair(error, sanitizedQuery, rawTerms, scopeProjectId);
     }
   });
 

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -3,7 +3,17 @@
  */
 
 import { type Content, FinishReason, FunctionCallingConfigMode, type Part } from "@google/genai";
-import type { Context, ImageContent, Model, StopReason, TextContent, Tool } from "../types.js";
+import type {
+	AssistantMessage,
+	Context,
+	ImageContent,
+	Message,
+	Model,
+	StopReason,
+	TextContent,
+	Tool,
+	ToolResultMessage,
+} from "../types.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -85,6 +95,155 @@ function supportsMultimodalFunctionResponse(modelId: string): boolean {
 	return true;
 }
 
+/** Returns null when the message converts to no parts and must be skipped. */
+function convertUserContent(msg: Extract<Message, { role: "user" }>): Content | null {
+	if (typeof msg.content === "string") {
+		return {
+			role: "user",
+			parts: [{ text: sanitizeSurrogates(msg.content) }],
+		};
+	}
+	const parts: Part[] = msg.content.map((item) => {
+		if (item.type === "text") {
+			return { text: sanitizeSurrogates(item.text) };
+		} else {
+			return {
+				inlineData: {
+					mimeType: item.mimeType,
+					data: item.data,
+				},
+			};
+		}
+	});
+	if (parts.length === 0) return null;
+	return { role: "user", parts };
+}
+
+/** Returns null for blocks that convert to no part (empty text/thinking). */
+function convertAssistantPart(
+	block: AssistantMessage["content"][number],
+	isSameProviderAndModel: boolean,
+	modelId: string,
+): Part | null {
+	if (block.type === "text") {
+		// Skip empty text blocks
+		if (!block.text || block.text.trim() === "") return null;
+		const thoughtSignature = resolveThoughtSignature(isSameProviderAndModel, block.textSignature);
+		return {
+			text: sanitizeSurrogates(block.text),
+			...(thoughtSignature && { thoughtSignature }),
+		};
+	}
+	if (block.type === "thinking") {
+		// Skip empty thinking blocks
+		if (!block.thinking || block.thinking.trim() === "") return null;
+		// Only keep as thinking block if same provider AND same model
+		// Otherwise convert to plain text (no tags to avoid model mimicking them)
+		if (isSameProviderAndModel) {
+			const thoughtSignature = resolveThoughtSignature(isSameProviderAndModel, block.thinkingSignature);
+			return {
+				thought: true,
+				text: sanitizeSurrogates(block.thinking),
+				...(thoughtSignature && { thoughtSignature }),
+			};
+		}
+		return {
+			text: sanitizeSurrogates(block.thinking),
+		};
+	}
+	if (block.type === "toolCall") {
+		const thoughtSignature = resolveThoughtSignature(isSameProviderAndModel, block.thoughtSignature);
+		return {
+			functionCall: {
+				name: block.name,
+				args: block.arguments ?? {},
+				...(requiresToolCallId(modelId) ? { id: block.id } : {}),
+			},
+			...(thoughtSignature && { thoughtSignature }),
+		};
+	}
+	return null;
+}
+
+/** Returns null when the message converts to no parts and must be skipped. */
+function convertAssistantContent<T extends GoogleApiType>(msg: AssistantMessage, model: Model<T>): Content | null {
+	// Check if message is from same provider and model - only then keep thinking blocks
+	const isSameProviderAndModel = msg.provider === model.provider && msg.model === model.id;
+	const parts: Part[] = [];
+	for (const block of msg.content) {
+		const part = convertAssistantPart(block, isSameProviderAndModel, model.id);
+		if (part) parts.push(part);
+	}
+	if (parts.length === 0) return null;
+	return { role: "model", parts };
+}
+
+/**
+ * Append a toolResult message, merging consecutive function responses into a
+ * single user turn (required by the Cloud Code Assist API) and emitting a
+ * separate user image turn for models without multimodal function responses.
+ */
+function appendToolResultContent<T extends GoogleApiType>(
+	contents: Content[],
+	msg: ToolResultMessage,
+	model: Model<T>,
+): void {
+	// Extract text and image content
+	const textContent = msg.content.filter((c): c is TextContent => c.type === "text");
+	const textResult = textContent.map((c) => c.text).join("\n");
+	const imageContent = model.input.includes("image")
+		? msg.content.filter((c): c is ImageContent => c.type === "image")
+		: [];
+
+	const hasText = textResult.length > 0;
+	const hasImages = imageContent.length > 0;
+
+	// Gemini 3+ models support multimodal function responses with images nested inside
+	// functionResponse.parts. Claude and other non-Gemini models behind Cloud Code Assist /
+	// Gemini < 3 still needs a separate user image turn.
+	const modelSupportsMultimodalFunctionResponse = supportsMultimodalFunctionResponse(model.id);
+
+	// Use "output" key for success, "error" key for errors as per SDK documentation
+	const responseValue = hasText ? sanitizeSurrogates(textResult) : hasImages ? "(see attached image)" : "";
+
+	const imageParts: Part[] = imageContent.map((imageBlock) => ({
+		inlineData: {
+			mimeType: imageBlock.mimeType,
+			data: imageBlock.data,
+		},
+	}));
+
+	const includeId = requiresToolCallId(model.id);
+	const functionResponsePart: Part = {
+		functionResponse: {
+			name: msg.toolName,
+			response: msg.isError ? { error: responseValue } : { output: responseValue },
+			...(hasImages && modelSupportsMultimodalFunctionResponse && { parts: imageParts }),
+			...(includeId ? { id: msg.toolCallId } : {}),
+		},
+	};
+
+	// Cloud Code Assist API requires all function responses to be in a single user turn.
+	// Check if the last content is already a user turn with function responses and merge.
+	const lastContent = contents[contents.length - 1];
+	if (lastContent?.role === "user" && lastContent.parts?.some((p) => p.functionResponse)) {
+		lastContent.parts.push(functionResponsePart);
+	} else {
+		contents.push({
+			role: "user",
+			parts: [functionResponsePart],
+		});
+	}
+
+	// For Gemini < 3, add images in a separate user message
+	if (hasImages && !modelSupportsMultimodalFunctionResponse) {
+		contents.push({
+			role: "user",
+			parts: [{ text: "Tool result image:" }, ...imageParts],
+		});
+	}
+}
+
 /**
  * Convert internal messages to Gemini Content[] format.
  */
@@ -99,135 +258,13 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 
 	for (const msg of transformedMessages) {
 		if (msg.role === "user") {
-			if (typeof msg.content === "string") {
-				contents.push({
-					role: "user",
-					parts: [{ text: sanitizeSurrogates(msg.content) }],
-				});
-			} else {
-				const parts: Part[] = msg.content.map((item) => {
-					if (item.type === "text") {
-						return { text: sanitizeSurrogates(item.text) };
-					} else {
-						return {
-							inlineData: {
-								mimeType: item.mimeType,
-								data: item.data,
-							},
-						};
-					}
-				});
-				if (parts.length === 0) continue;
-				contents.push({
-					role: "user",
-					parts,
-				});
-			}
+			const content = convertUserContent(msg);
+			if (content) contents.push(content);
 		} else if (msg.role === "assistant") {
-			const parts: Part[] = [];
-			// Check if message is from same provider and model - only then keep thinking blocks
-			const isSameProviderAndModel = msg.provider === model.provider && msg.model === model.id;
-
-			for (const block of msg.content) {
-				if (block.type === "text") {
-					// Skip empty text blocks
-					if (!block.text || block.text.trim() === "") continue;
-					const thoughtSignature = resolveThoughtSignature(isSameProviderAndModel, block.textSignature);
-					parts.push({
-						text: sanitizeSurrogates(block.text),
-						...(thoughtSignature && { thoughtSignature }),
-					});
-				} else if (block.type === "thinking") {
-					// Skip empty thinking blocks
-					if (!block.thinking || block.thinking.trim() === "") continue;
-					// Only keep as thinking block if same provider AND same model
-					// Otherwise convert to plain text (no tags to avoid model mimicking them)
-					if (isSameProviderAndModel) {
-						const thoughtSignature = resolveThoughtSignature(isSameProviderAndModel, block.thinkingSignature);
-						parts.push({
-							thought: true,
-							text: sanitizeSurrogates(block.thinking),
-							...(thoughtSignature && { thoughtSignature }),
-						});
-					} else {
-						parts.push({
-							text: sanitizeSurrogates(block.thinking),
-						});
-					}
-				} else if (block.type === "toolCall") {
-					const thoughtSignature = resolveThoughtSignature(isSameProviderAndModel, block.thoughtSignature);
-					const part: Part = {
-						functionCall: {
-							name: block.name,
-							args: block.arguments ?? {},
-							...(requiresToolCallId(model.id) ? { id: block.id } : {}),
-						},
-						...(thoughtSignature && { thoughtSignature }),
-					};
-					parts.push(part);
-				}
-			}
-
-			if (parts.length === 0) continue;
-			contents.push({
-				role: "model",
-				parts,
-			});
+			const content = convertAssistantContent(msg, model);
+			if (content) contents.push(content);
 		} else if (msg.role === "toolResult") {
-			// Extract text and image content
-			const textContent = msg.content.filter((c): c is TextContent => c.type === "text");
-			const textResult = textContent.map((c) => c.text).join("\n");
-			const imageContent = model.input.includes("image")
-				? msg.content.filter((c): c is ImageContent => c.type === "image")
-				: [];
-
-			const hasText = textResult.length > 0;
-			const hasImages = imageContent.length > 0;
-
-			// Gemini 3+ models support multimodal function responses with images nested inside
-			// functionResponse.parts. Claude and other non-Gemini models behind Cloud Code Assist /
-			// Gemini < 3 still needs a separate user image turn.
-			const modelSupportsMultimodalFunctionResponse = supportsMultimodalFunctionResponse(model.id);
-
-			// Use "output" key for success, "error" key for errors as per SDK documentation
-			const responseValue = hasText ? sanitizeSurrogates(textResult) : hasImages ? "(see attached image)" : "";
-
-			const imageParts: Part[] = imageContent.map((imageBlock) => ({
-				inlineData: {
-					mimeType: imageBlock.mimeType,
-					data: imageBlock.data,
-				},
-			}));
-
-			const includeId = requiresToolCallId(model.id);
-			const functionResponsePart: Part = {
-				functionResponse: {
-					name: msg.toolName,
-					response: msg.isError ? { error: responseValue } : { output: responseValue },
-					...(hasImages && modelSupportsMultimodalFunctionResponse && { parts: imageParts }),
-					...(includeId ? { id: msg.toolCallId } : {}),
-				},
-			};
-
-			// Cloud Code Assist API requires all function responses to be in a single user turn.
-			// Check if the last content is already a user turn with function responses and merge.
-			const lastContent = contents[contents.length - 1];
-			if (lastContent?.role === "user" && lastContent.parts?.some((p) => p.functionResponse)) {
-				lastContent.parts.push(functionResponsePart);
-			} else {
-				contents.push({
-					role: "user",
-					parts: [functionResponsePart],
-				});
-			}
-
-			// For Gemini < 3, add images in a separate user message
-			if (hasImages && !modelSupportsMultimodalFunctionResponse) {
-				contents.push({
-					role: "user",
-					parts: [{ text: "Tool result image:" }, ...imageParts],
-				});
-			}
+			appendToolResultContent(contents, msg, model);
 		}
 	}
 

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -266,37 +266,179 @@ function buildChatPayload(
 	return payload;
 }
 
+/**
+ * Tracks the currently open text/thinking block, emitting start/delta/end
+ * events as the stream alternates between block types.
+ */
+function createBlockTracker(output: AssistantMessage, stream: AssistantMessageEventStream) {
+	let currentBlock: TextContent | ThinkingContent | null = null;
+	const blockIndex = () => output.content.length - 1;
+
+	const finishCurrentBlock = () => {
+		if (!currentBlock) return;
+		if (currentBlock.type === "text") {
+			stream.push({
+				type: "text_end",
+				contentIndex: blockIndex(),
+				content: currentBlock.text,
+				partial: output,
+			});
+		} else {
+			stream.push({
+				type: "thinking_end",
+				contentIndex: blockIndex(),
+				content: currentBlock.thinking,
+				partial: output,
+			});
+		}
+		currentBlock = null;
+	};
+
+	const appendText = (textDelta: string) => {
+		if (!currentBlock || currentBlock.type !== "text") {
+			finishCurrentBlock();
+			currentBlock = { type: "text", text: "" };
+			output.content.push(currentBlock);
+			stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+		}
+		currentBlock.text += textDelta;
+		stream.push({
+			type: "text_delta",
+			contentIndex: blockIndex(),
+			delta: textDelta,
+			partial: output,
+		});
+	};
+
+	const appendThinking = (thinkingDelta: string) => {
+		if (!currentBlock || currentBlock.type !== "thinking") {
+			finishCurrentBlock();
+			currentBlock = { type: "thinking", thinking: "" };
+			output.content.push(currentBlock);
+			stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+		}
+		currentBlock.thinking += thinkingDelta;
+		stream.push({
+			type: "thinking_delta",
+			contentIndex: blockIndex(),
+			delta: thinkingDelta,
+			partial: output,
+		});
+	};
+
+	return { appendText, appendThinking, finishCurrentBlock };
+}
+
+type BlockTracker = ReturnType<typeof createBlockTracker>;
+
+function handleChatContentDelta(
+	deltaContent: string | Array<{ type: string; [key: string]: unknown }>,
+	tracker: BlockTracker,
+): void {
+	const contentItems = typeof deltaContent === "string" ? [deltaContent] : deltaContent;
+	for (const item of contentItems) {
+		if (typeof item === "string") {
+			tracker.appendText(sanitizeSurrogates(item));
+			continue;
+		}
+
+		if (item.type === "thinking") {
+			const deltaText = (item.thinking as Array<Record<string, unknown>>)
+				.map((part) => ("text" in part ? (part.text as string) : ""))
+				.filter((text) => text.length > 0)
+				.join("");
+			const thinkingDelta = sanitizeSurrogates(deltaText);
+			if (!thinkingDelta) continue;
+			tracker.appendThinking(thinkingDelta);
+			continue;
+		}
+
+		if (item.type === "text") {
+			tracker.appendText(sanitizeSurrogates(item.text as string));
+		}
+	}
+}
+
+function handleChatToolCallDelta(
+	toolCall: NonNullable<CompletionEvent["data"]["choices"][number]["delta"]["toolCalls"]>[number],
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	toolBlocksByKey: Map<string, number>,
+	tracker: BlockTracker,
+): void {
+	tracker.finishCurrentBlock();
+	const callId =
+		toolCall.id && toolCall.id !== "null"
+			? toolCall.id
+			: deriveMistralToolCallId(`toolcall:${toolCall.index ?? 0}`, 0);
+	const key = `${callId}:${toolCall.index || 0}`;
+	const existingIndex = toolBlocksByKey.get(key);
+	let block: (ToolCall & { partialArgs?: string }) | undefined;
+
+	if (existingIndex !== undefined) {
+		const existing = output.content[existingIndex];
+		if (existing?.type === "toolCall") {
+			block = existing as ToolCall & { partialArgs?: string };
+		}
+	}
+
+	if (!block) {
+		block = {
+			type: "toolCall",
+			id: callId,
+			name: toolCall.function.name,
+			arguments: {},
+			partialArgs: "",
+		};
+		output.content.push(block);
+		toolBlocksByKey.set(key, output.content.length - 1);
+		stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
+	}
+
+	const argsDelta =
+		typeof toolCall.function.arguments === "string"
+			? toolCall.function.arguments
+			: JSON.stringify(toolCall.function.arguments || {});
+	block.partialArgs = (block.partialArgs || "") + argsDelta;
+	block.arguments = parseStreamingJson<Record<string, unknown>>(block.partialArgs);
+	stream.push({
+		type: "toolcall_delta",
+		contentIndex: toolBlocksByKey.get(key)!,
+		delta: argsDelta,
+		partial: output,
+	});
+}
+
+function finalizeChatToolCallBlocks(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	toolBlocksByKey: Map<string, number>,
+): void {
+	for (const index of toolBlocksByKey.values()) {
+		const block = output.content[index];
+		if (block.type !== "toolCall") continue;
+		const toolBlock = block as ToolCall & { partialArgs?: string };
+		toolBlock.arguments = parseStreamingJson<Record<string, unknown>>(toolBlock.partialArgs);
+		// Finalize in-place and strip the scratch buffer so replay only
+		// carries parsed arguments.
+		delete toolBlock.partialArgs;
+		stream.push({
+			type: "toolcall_end",
+			contentIndex: index,
+			toolCall: toolBlock,
+			partial: output,
+		});
+	}
+}
+
 async function consumeChatStream(
 	model: Model<"mistral-conversations">,
 	output: AssistantMessage,
 	stream: AssistantMessageEventStream,
 	mistralStream: AsyncIterable<CompletionEvent>,
 ): Promise<void> {
-	let currentBlock: TextContent | ThinkingContent | null = null;
-	const blocks = output.content;
-	const blockIndex = () => blocks.length - 1;
 	const toolBlocksByKey = new Map<string, number>();
-
-	const finishCurrentBlock = (block?: typeof currentBlock) => {
-		if (!block) return;
-		if (block.type === "text") {
-			stream.push({
-				type: "text_end",
-				contentIndex: blockIndex(),
-				content: block.text,
-				partial: output,
-			});
-			return;
-		}
-		if (block.type === "thinking") {
-			stream.push({
-				type: "thinking_end",
-				contentIndex: blockIndex(),
-				content: block.thinking,
-				partial: output,
-			});
-		}
-	};
+	const tracker = createBlockTracker(output, stream);
 
 	for await (const event of mistralStream) {
 		const chunk = event.data;
@@ -322,133 +464,16 @@ async function consumeChatStream(
 
 		const delta = choice.delta;
 		if (delta.content !== null && delta.content !== undefined) {
-			const contentItems = typeof delta.content === "string" ? [delta.content] : delta.content;
-			for (const item of contentItems) {
-				if (typeof item === "string") {
-					const textDelta = sanitizeSurrogates(item);
-					if (!currentBlock || currentBlock.type !== "text") {
-						finishCurrentBlock(currentBlock);
-						currentBlock = { type: "text", text: "" };
-						output.content.push(currentBlock);
-						stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
-					}
-					currentBlock.text += textDelta;
-					stream.push({
-						type: "text_delta",
-						contentIndex: blockIndex(),
-						delta: textDelta,
-						partial: output,
-					});
-					continue;
-				}
-
-				if (item.type === "thinking") {
-					const deltaText = item.thinking
-						.map((part) => ("text" in part ? part.text : ""))
-						.filter((text) => text.length > 0)
-						.join("");
-					const thinkingDelta = sanitizeSurrogates(deltaText);
-					if (!thinkingDelta) continue;
-					if (!currentBlock || currentBlock.type !== "thinking") {
-						finishCurrentBlock(currentBlock);
-						currentBlock = { type: "thinking", thinking: "" };
-						output.content.push(currentBlock);
-						stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
-					}
-					currentBlock.thinking += thinkingDelta;
-					stream.push({
-						type: "thinking_delta",
-						contentIndex: blockIndex(),
-						delta: thinkingDelta,
-						partial: output,
-					});
-					continue;
-				}
-
-				if (item.type === "text") {
-					const textDelta = sanitizeSurrogates(item.text);
-					if (!currentBlock || currentBlock.type !== "text") {
-						finishCurrentBlock(currentBlock);
-						currentBlock = { type: "text", text: "" };
-						output.content.push(currentBlock);
-						stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
-					}
-					currentBlock.text += textDelta;
-					stream.push({
-						type: "text_delta",
-						contentIndex: blockIndex(),
-						delta: textDelta,
-						partial: output,
-					});
-				}
-			}
+			handleChatContentDelta(delta.content as Parameters<typeof handleChatContentDelta>[0], tracker);
 		}
 
-		const toolCalls = delta.toolCalls || [];
-		for (const toolCall of toolCalls) {
-			if (currentBlock) {
-				finishCurrentBlock(currentBlock);
-				currentBlock = null;
-			}
-			const callId =
-				toolCall.id && toolCall.id !== "null"
-					? toolCall.id
-					: deriveMistralToolCallId(`toolcall:${toolCall.index ?? 0}`, 0);
-			const key = `${callId}:${toolCall.index || 0}`;
-			const existingIndex = toolBlocksByKey.get(key);
-			let block: (ToolCall & { partialArgs?: string }) | undefined;
-
-			if (existingIndex !== undefined) {
-				const existing = output.content[existingIndex];
-				if (existing?.type === "toolCall") {
-					block = existing as ToolCall & { partialArgs?: string };
-				}
-			}
-
-			if (!block) {
-				block = {
-					type: "toolCall",
-					id: callId,
-					name: toolCall.function.name,
-					arguments: {},
-					partialArgs: "",
-				};
-				output.content.push(block);
-				toolBlocksByKey.set(key, output.content.length - 1);
-				stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
-			}
-
-			const argsDelta =
-				typeof toolCall.function.arguments === "string"
-					? toolCall.function.arguments
-					: JSON.stringify(toolCall.function.arguments || {});
-			block.partialArgs = (block.partialArgs || "") + argsDelta;
-			block.arguments = parseStreamingJson<Record<string, unknown>>(block.partialArgs);
-			stream.push({
-				type: "toolcall_delta",
-				contentIndex: toolBlocksByKey.get(key)!,
-				delta: argsDelta,
-				partial: output,
-			});
+		for (const toolCall of delta.toolCalls || []) {
+			handleChatToolCallDelta(toolCall, output, stream, toolBlocksByKey, tracker);
 		}
 	}
 
-	finishCurrentBlock(currentBlock);
-	for (const index of toolBlocksByKey.values()) {
-		const block = output.content[index];
-		if (block.type !== "toolCall") continue;
-		const toolBlock = block as ToolCall & { partialArgs?: string };
-		toolBlock.arguments = parseStreamingJson<Record<string, unknown>>(toolBlock.partialArgs);
-		// Finalize in-place and strip the scratch buffer so replay only
-		// carries parsed arguments.
-		delete toolBlock.partialArgs;
-		stream.push({
-			type: "toolcall_end",
-			contentIndex: index,
-			toolCall: toolBlock,
-			partial: output,
-		});
-	}
+	tracker.finishCurrentBlock();
+	finalizeChatToolCallBlocks(output, stream, toolBlocksByKey);
 }
 
 function toFunctionTools(tools: Tool[]): Array<FunctionTool & { type: "function" }> {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -563,62 +563,103 @@ function buildParams(
 		params.tool_choice = options.toolChoice;
 	}
 
-	if (compat.thinkingFormat === "zai" && model.reasoning) {
-		(params as any).enable_thinking = !!options?.reasoningEffort;
-	} else if (compat.thinkingFormat === "qwen" && model.reasoning) {
-		(params as any).enable_thinking = !!options?.reasoningEffort;
-	} else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
-		(params as any).chat_template_kwargs = {
-			enable_thinking: !!options?.reasoningEffort,
-			preserve_thinking: true,
-		};
-	} else if (compat.thinkingFormat === "deepseek" && model.reasoning) {
-		(params as any).thinking = { type: options?.reasoningEffort ? "enabled" : "disabled" };
-		if (options?.reasoningEffort && compat.supportsReasoningEffort) {
-			(params as any).reasoning_effort =
-				model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort;
-		}
-	} else if (compat.thinkingFormat === "openrouter" && model.reasoning) {
-		// OpenRouter normalizes reasoning across providers via a nested reasoning object.
-		const openRouterParams = params as typeof params & { reasoning?: { effort?: string } };
-		if (options?.reasoningEffort) {
-			openRouterParams.reasoning = {
-				effort: model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort,
+	applyReasoningParams(params, model, compat, options);
+	applyProviderRoutingParams(params, model);
+
+	return params;
+}
+
+/**
+ * Map options.reasoningEffort onto the provider-specific thinking/reasoning
+ * params. Each named thinkingFormat handles the request fully, except
+ * "ant-ling" without a reasoningEffort, which (like unknown formats) falls
+ * back to the generic OpenAI-style reasoning_effort handling.
+ */
+function applyReasoningParams(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	model: Model<"openai-completions">,
+	compat: ResolvedOpenAICompletionsCompat,
+	options?: OpenAICompletionsOptions,
+): void {
+	if (!model.reasoning) return;
+	const requestedEffort = options?.reasoningEffort;
+	const mappedEffort = requestedEffort ? (model.thinkingLevelMap?.[requestedEffort] ?? requestedEffort) : undefined;
+
+	switch (compat.thinkingFormat) {
+		case "zai":
+		case "qwen":
+			(params as any).enable_thinking = !!requestedEffort;
+			return;
+		case "qwen-chat-template":
+			(params as any).chat_template_kwargs = {
+				enable_thinking: !!requestedEffort,
+				preserve_thinking: true,
 			};
-		} else if (model.thinkingLevelMap?.off !== null) {
-			openRouterParams.reasoning = { effort: model.thinkingLevelMap?.off ?? "none" };
+			return;
+		case "deepseek":
+			(params as any).thinking = { type: requestedEffort ? "enabled" : "disabled" };
+			if (requestedEffort && compat.supportsReasoningEffort) {
+				(params as any).reasoning_effort = mappedEffort;
+			}
+			return;
+		case "openrouter": {
+			// OpenRouter normalizes reasoning across providers via a nested reasoning object.
+			const openRouterParams = params as typeof params & { reasoning?: { effort?: string } };
+			if (requestedEffort) {
+				openRouterParams.reasoning = { effort: mappedEffort };
+			} else if (model.thinkingLevelMap?.off !== null) {
+				openRouterParams.reasoning = { effort: model.thinkingLevelMap?.off ?? "none" };
+			}
+			return;
 		}
-	} else if (compat.thinkingFormat === "ant-ling" && model.reasoning && options?.reasoningEffort) {
-		const effort = model.thinkingLevelMap?.[options.reasoningEffort];
-		if (typeof effort === "string") {
-			(params as typeof params & { reasoning?: { effort: string } }).reasoning = { effort };
+		case "ant-ling": {
+			if (!requestedEffort) break; // falls back to generic reasoning_effort handling
+			const effort = model.thinkingLevelMap?.[requestedEffort];
+			if (typeof effort === "string") {
+				(params as typeof params & { reasoning?: { effort: string } }).reasoning = { effort };
+			}
+			return;
 		}
-	} else if (compat.thinkingFormat === "together" && model.reasoning) {
-		const togetherParams = params as Omit<typeof params, "reasoning_effort"> & {
-			reasoning?: { enabled: boolean };
-			reasoning_effort?: string;
-		};
-		togetherParams.reasoning = { enabled: !!options?.reasoningEffort };
-		if (options?.reasoningEffort && compat.supportsReasoningEffort) {
-			togetherParams.reasoning_effort = model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort;
+		case "together": {
+			const togetherParams = params as Omit<typeof params, "reasoning_effort"> & {
+				reasoning?: { enabled: boolean };
+				reasoning_effort?: string;
+			};
+			togetherParams.reasoning = { enabled: !!requestedEffort };
+			if (requestedEffort && compat.supportsReasoningEffort) {
+				togetherParams.reasoning_effort = mappedEffort;
+			}
+			return;
 		}
-	} else if (compat.thinkingFormat === "string-thinking" && model.reasoning) {
-		const stringThinkingParams = params as typeof params & { thinking?: string };
-		if (options?.reasoningEffort) {
-			stringThinkingParams.thinking = model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort;
-		} else if (model.thinkingLevelMap?.off !== null) {
-			stringThinkingParams.thinking = model.thinkingLevelMap?.off ?? "none";
+		case "string-thinking": {
+			const stringThinkingParams = params as typeof params & { thinking?: string };
+			if (requestedEffort) {
+				stringThinkingParams.thinking = mappedEffort;
+			} else if (model.thinkingLevelMap?.off !== null) {
+				stringThinkingParams.thinking = model.thinkingLevelMap?.off ?? "none";
+			}
+			return;
 		}
-	} else if (options?.reasoningEffort && model.reasoning && compat.supportsReasoningEffort) {
-		// OpenAI-style reasoning_effort
-		(params as any).reasoning_effort = model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort;
-	} else if (!options?.reasoningEffort && model.reasoning && compat.supportsReasoningEffort) {
+		default:
+			break;
+	}
+
+	// Generic OpenAI-style reasoning_effort
+	if (!compat.supportsReasoningEffort) return;
+	if (requestedEffort) {
+		(params as any).reasoning_effort = mappedEffort;
+	} else {
 		const offValue = model.thinkingLevelMap?.off;
 		if (typeof offValue === "string") {
 			(params as any).reasoning_effort = offValue;
 		}
 	}
+}
 
+function applyProviderRoutingParams(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	model: Model<"openai-completions">,
+): void {
 	// OpenRouter provider routing preferences
 	if (model.compat?.openRouterRouting) {
 		(params as any).provider = model.compat.openRouterRouting;
@@ -634,8 +675,6 @@ function buildParams(
 			(params as any).providerOptions = { gateway: gatewayOptions };
 		}
 	}
-
-	return params;
 }
 
 function getCompatCacheControl(
@@ -753,6 +792,246 @@ function addCacheControlToTextContent(
 	return false;
 }
 
+function normalizeToolCallId(id: string, model: Model<"openai-completions">): string {
+	// Handle pipe-separated IDs from OpenAI Responses API
+	// Format: {call_id}|{id} where {id} can be 400+ chars with special chars (+, /, =)
+	// These come from providers like github-copilot, openai-codex, opencode
+	// Extract just the call_id part and normalize it
+	if (id.includes("|")) {
+		const [callId] = id.split("|");
+		// Sanitize to allowed chars and truncate to 40 chars (OpenAI limit)
+		return callId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 40);
+	}
+
+	if (model.provider === "openai") return id.length > 40 ? id.slice(0, 40) : id;
+	return id;
+}
+
+/** Returns null when the message converts to empty content and must be skipped. */
+function convertUserMessage(msg: Extract<Message, { role: "user" }>): ChatCompletionMessageParam | null {
+	if (typeof msg.content === "string") {
+		return {
+			role: "user",
+			content: sanitizeSurrogates(msg.content),
+		};
+	}
+	const content: ChatCompletionContentPart[] = msg.content.map((item): ChatCompletionContentPart => {
+		if (item.type === "text") {
+			return {
+				type: "text",
+				text: sanitizeSurrogates(item.text),
+			} satisfies ChatCompletionContentPartText;
+		} else {
+			return {
+				type: "image_url",
+				image_url: {
+					url: `data:${item.mimeType};base64,${item.data}`,
+				},
+			} satisfies ChatCompletionContentPartImage;
+		}
+	});
+	if (content.length === 0) return null;
+	return { role: "user", content };
+}
+
+function applyAssistantThinkingBlocks(
+	assistantMsg: ChatCompletionAssistantMessageParam,
+	msg: AssistantMessage,
+	assistantTextParts: ChatCompletionContentPartText[],
+	assistantText: string,
+	model: Model<"openai-completions">,
+	compat: ResolvedOpenAICompletionsCompat,
+): void {
+	const nonEmptyThinkingBlocks = msg.content
+		.filter(isThinkingContentBlock)
+		.filter((block) => block.thinking.trim().length > 0);
+	if (nonEmptyThinkingBlocks.length > 0) {
+		if (compat.requiresThinkingAsText) {
+			// Convert thinking blocks to plain text (no tags to avoid model mimicking them)
+			const thinkingText = nonEmptyThinkingBlocks
+				.map((block) => sanitizeSurrogates(block.thinking))
+				.join("\n\n");
+			assistantMsg.content = [{ type: "text", text: thinkingText }, ...assistantTextParts];
+		} else {
+			// Always send assistant content as a plain string (OpenAI Chat Completions
+			// API standard format). Sending as an array of {type:"text", text:"..."}
+			// objects is non-standard and causes some models (e.g. DeepSeek V3.2 via
+			// NVIDIA NIM) to mirror the content-block structure literally in their
+			// output, producing recursive nesting like [{'type':'text','text':'[{...}]'}].
+			if (assistantText.length > 0) {
+				assistantMsg.content = assistantText;
+			}
+
+			// Use the signature from the first thinking block if available (for llama.cpp server + gpt-oss)
+			let signature = nonEmptyThinkingBlocks[0].thinkingSignature;
+			if (model.provider === "opencode-go" && signature === "reasoning") {
+				signature = "reasoning_content";
+			}
+			if (signature && signature.length > 0) {
+				(assistantMsg as any)[signature] = nonEmptyThinkingBlocks.map((block) => block.thinking).join("\n");
+			}
+		}
+	} else if (assistantText.length > 0) {
+		// Always send assistant content as a plain string (OpenAI Chat Completions
+		// API standard format). Sending as an array of {type:"text", text:"..."}
+		// objects is non-standard and causes some models (e.g. DeepSeek V3.2 via
+		// NVIDIA NIM) to mirror the content-block structure literally in their
+		// output, producing recursive nesting like [{'type':'text','text':'[{...}]'}].
+		assistantMsg.content = assistantText;
+	}
+}
+
+function applyAssistantToolCalls(assistantMsg: ChatCompletionAssistantMessageParam, msg: AssistantMessage): void {
+	const toolCalls = msg.content.filter(isToolCallBlock);
+	if (toolCalls.length === 0) return;
+	assistantMsg.tool_calls = toolCalls.map((tc) => ({
+		id: tc.id,
+		type: "function" as const,
+		function: {
+			name: tc.name,
+			arguments: JSON.stringify(tc.arguments),
+		},
+	}));
+	const reasoningDetails = toolCalls
+		.filter((tc) => tc.thoughtSignature)
+		.map((tc) => {
+			try {
+				return JSON.parse(tc.thoughtSignature!);
+			} catch {
+				return null;
+			}
+		})
+		.filter(Boolean);
+	if (reasoningDetails.length > 0) {
+		(assistantMsg as any).reasoning_details = reasoningDetails;
+	}
+}
+
+/** Returns null when the message has no content and no tool calls and must be skipped. */
+function convertAssistantMessage(
+	msg: AssistantMessage,
+	model: Model<"openai-completions">,
+	compat: ResolvedOpenAICompletionsCompat,
+): ChatCompletionAssistantMessageParam | null {
+	// Some providers don't accept null content, use empty string instead
+	const assistantMsg: ChatCompletionAssistantMessageParam = {
+		role: "assistant",
+		content: compat.requiresAssistantAfterToolResult ? "" : null,
+	};
+
+	const assistantTextParts = msg.content
+		.filter(isTextContentBlock)
+		.filter((block) => block.text.trim().length > 0)
+		.map(
+			(block) =>
+				({
+					type: "text",
+					text: sanitizeSurrogates(block.text),
+				}) satisfies ChatCompletionContentPartText,
+		);
+	const assistantText = assistantTextParts.map((part) => part.text).join("");
+
+	applyAssistantThinkingBlocks(assistantMsg, msg, assistantTextParts, assistantText, model, compat);
+	applyAssistantToolCalls(assistantMsg, msg);
+
+	if (
+		compat.requiresReasoningContentOnAssistantMessages &&
+		model.reasoning &&
+		(assistantMsg as { reasoning_content?: string }).reasoning_content === undefined
+	) {
+		(assistantMsg as { reasoning_content?: string }).reasoning_content = "";
+	}
+	// Skip assistant messages that have no content and no tool calls.
+	// Some providers require "either content or tool_calls, but not none".
+	// Other providers also don't accept empty assistant messages.
+	// This handles aborted assistant responses that got no content.
+	const content = assistantMsg.content;
+	const hasContent =
+		content !== null &&
+		content !== undefined &&
+		(typeof content === "string" ? content.length > 0 : content.length > 0);
+	if (!hasContent && !assistantMsg.tool_calls) {
+		return null;
+	}
+	return assistantMsg;
+}
+
+/**
+ * Convert a run of consecutive toolResult messages starting at startIndex.
+ * Returns the converted messages (tool results plus, when images are present,
+ * an optional synthetic assistant bridge and a user message carrying the
+ * images), the index of the last consumed message, and the effective lastRole.
+ */
+function convertToolResultGroup(
+	transformedMessages: Message[],
+	startIndex: number,
+	model: Model<"openai-completions">,
+	compat: ResolvedOpenAICompletionsCompat,
+): { messages: ChatCompletionMessageParam[]; endIndex: number; lastRole: "user" | "toolResult" } {
+	const messages: ChatCompletionMessageParam[] = [];
+	const imageBlocks: Array<{ type: "image_url"; image_url: { url: string } }> = [];
+	let j = startIndex;
+
+	for (; j < transformedMessages.length && transformedMessages[j].role === "toolResult"; j++) {
+		const toolMsg = transformedMessages[j] as ToolResultMessage;
+
+		// Extract text and image content
+		const textResult = toolMsg.content
+			.filter(isTextContentBlock)
+			.map((block) => block.text)
+			.join("\n");
+		const hasImages = toolMsg.content.some((c) => c.type === "image");
+
+		// Always send tool result with text (or placeholder if only images)
+		const hasText = textResult.length > 0;
+		// Some providers require the 'name' field in tool results
+		const toolResultMsg: ChatCompletionToolMessageParam = {
+			role: "tool",
+			content: sanitizeSurrogates(hasText ? textResult : "(see attached image)"),
+			tool_call_id: toolMsg.toolCallId,
+		};
+		if (compat.requiresToolResultName && toolMsg.toolName) {
+			(toolResultMsg as any).name = toolMsg.toolName;
+		}
+		messages.push(toolResultMsg);
+
+		if (hasImages && model.input.includes("image")) {
+			for (const block of toolMsg.content) {
+				if (isImageContentBlock(block)) {
+					imageBlocks.push({
+						type: "image_url",
+						image_url: {
+							url: `data:${block.mimeType};base64,${block.data}`,
+						},
+					});
+				}
+			}
+		}
+	}
+
+	if (imageBlocks.length === 0) {
+		return { messages, endIndex: j - 1, lastRole: "toolResult" };
+	}
+
+	if (compat.requiresAssistantAfterToolResult) {
+		messages.push({
+			role: "assistant",
+			content: "I have processed the tool results.",
+		});
+	}
+	messages.push({
+		role: "user",
+		content: [
+			{
+				type: "text",
+				text: "Attached image(s) from tool result:",
+			},
+			...imageBlocks,
+		],
+	});
+	return { messages, endIndex: j - 1, lastRole: "user" };
+}
+
 export function convertMessages(
 	model: Model<"openai-completions">,
 	context: Context,
@@ -760,22 +1039,7 @@ export function convertMessages(
 ): ChatCompletionMessageParam[] {
 	const params: ChatCompletionMessageParam[] = [];
 
-	const normalizeToolCallId = (id: string): string => {
-		// Handle pipe-separated IDs from OpenAI Responses API
-		// Format: {call_id}|{id} where {id} can be 400+ chars with special chars (+, /, =)
-		// These come from providers like github-copilot, openai-codex, opencode
-		// Extract just the call_id part and normalize it
-		if (id.includes("|")) {
-			const [callId] = id.split("|");
-			// Sanitize to allowed chars and truncate to 40 chars (OpenAI limit)
-			return callId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 40);
-		}
-
-		if (model.provider === "openai") return id.length > 40 ? id.slice(0, 40) : id;
-		return id;
-	};
-
-	const transformedMessages = transformMessages(context.messages, model, (id) => normalizeToolCallId(id));
+	const transformedMessages = transformMessages(context.messages, model, (id) => normalizeToolCallId(id, model));
 
 	if (context.systemPrompt) {
 		const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
@@ -797,199 +1061,20 @@ export function convertMessages(
 		}
 
 		if (msg.role === "user") {
-			if (typeof msg.content === "string") {
-				params.push({
-					role: "user",
-					content: sanitizeSurrogates(msg.content),
-				});
-			} else {
-				const content: ChatCompletionContentPart[] = msg.content.map((item): ChatCompletionContentPart => {
-					if (item.type === "text") {
-						return {
-							type: "text",
-							text: sanitizeSurrogates(item.text),
-						} satisfies ChatCompletionContentPartText;
-					} else {
-						return {
-							type: "image_url",
-							image_url: {
-								url: `data:${item.mimeType};base64,${item.data}`,
-							},
-						} satisfies ChatCompletionContentPartImage;
-					}
-				});
-				if (content.length === 0) continue;
-				params.push({
-					role: "user",
-					content,
-				});
-			}
+			const userMsg = convertUserMessage(msg);
+			// Skip user messages that convert to empty content (lastRole is intentionally not updated)
+			if (!userMsg) continue;
+			params.push(userMsg);
 		} else if (msg.role === "assistant") {
-			// Some providers don't accept null content, use empty string instead
-			const assistantMsg: ChatCompletionAssistantMessageParam = {
-				role: "assistant",
-				content: compat.requiresAssistantAfterToolResult ? "" : null,
-			};
-
-			const assistantTextParts = msg.content
-				.filter(isTextContentBlock)
-				.filter((block) => block.text.trim().length > 0)
-				.map(
-					(block) =>
-						({
-							type: "text",
-							text: sanitizeSurrogates(block.text),
-						}) satisfies ChatCompletionContentPartText,
-				);
-			const assistantText = assistantTextParts.map((part) => part.text).join("");
-
-			const nonEmptyThinkingBlocks = msg.content
-				.filter(isThinkingContentBlock)
-				.filter((block) => block.thinking.trim().length > 0);
-			if (nonEmptyThinkingBlocks.length > 0) {
-				if (compat.requiresThinkingAsText) {
-					// Convert thinking blocks to plain text (no tags to avoid model mimicking them)
-					const thinkingText = nonEmptyThinkingBlocks
-						.map((block) => sanitizeSurrogates(block.thinking))
-						.join("\n\n");
-					assistantMsg.content = [{ type: "text", text: thinkingText }, ...assistantTextParts];
-				} else {
-					// Always send assistant content as a plain string (OpenAI Chat Completions
-					// API standard format). Sending as an array of {type:"text", text:"..."}
-					// objects is non-standard and causes some models (e.g. DeepSeek V3.2 via
-					// NVIDIA NIM) to mirror the content-block structure literally in their
-					// output, producing recursive nesting like [{'type':'text','text':'[{...}]'}].
-					if (assistantText.length > 0) {
-						assistantMsg.content = assistantText;
-					}
-
-					// Use the signature from the first thinking block if available (for llama.cpp server + gpt-oss)
-					let signature = nonEmptyThinkingBlocks[0].thinkingSignature;
-					if (model.provider === "opencode-go" && signature === "reasoning") {
-						signature = "reasoning_content";
-					}
-					if (signature && signature.length > 0) {
-						(assistantMsg as any)[signature] = nonEmptyThinkingBlocks.map((block) => block.thinking).join("\n");
-					}
-				}
-			} else if (assistantText.length > 0) {
-				// Always send assistant content as a plain string (OpenAI Chat Completions
-				// API standard format). Sending as an array of {type:"text", text:"..."}
-				// objects is non-standard and causes some models (e.g. DeepSeek V3.2 via
-				// NVIDIA NIM) to mirror the content-block structure literally in their
-				// output, producing recursive nesting like [{'type':'text','text':'[{...}]'}].
-				assistantMsg.content = assistantText;
-			}
-
-			const toolCalls = msg.content.filter(isToolCallBlock);
-			if (toolCalls.length > 0) {
-				assistantMsg.tool_calls = toolCalls.map((tc) => ({
-					id: tc.id,
-					type: "function" as const,
-					function: {
-						name: tc.name,
-						arguments: JSON.stringify(tc.arguments),
-					},
-				}));
-				const reasoningDetails = toolCalls
-					.filter((tc) => tc.thoughtSignature)
-					.map((tc) => {
-						try {
-							return JSON.parse(tc.thoughtSignature!);
-						} catch {
-							return null;
-						}
-					})
-					.filter(Boolean);
-				if (reasoningDetails.length > 0) {
-					(assistantMsg as any).reasoning_details = reasoningDetails;
-				}
-			}
-			if (
-				compat.requiresReasoningContentOnAssistantMessages &&
-				model.reasoning &&
-				(assistantMsg as { reasoning_content?: string }).reasoning_content === undefined
-			) {
-				(assistantMsg as { reasoning_content?: string }).reasoning_content = "";
-			}
-			// Skip assistant messages that have no content and no tool calls.
-			// Some providers require "either content or tool_calls, but not none".
-			// Other providers also don't accept empty assistant messages.
-			// This handles aborted assistant responses that got no content.
-			const content = assistantMsg.content;
-			const hasContent =
-				content !== null &&
-				content !== undefined &&
-				(typeof content === "string" ? content.length > 0 : content.length > 0);
-			if (!hasContent && !assistantMsg.tool_calls) {
-				continue;
-			}
+			const assistantMsg = convertAssistantMessage(msg, model, compat);
+			// Skip empty assistant messages (lastRole is intentionally not updated)
+			if (!assistantMsg) continue;
 			params.push(assistantMsg);
 		} else if (msg.role === "toolResult") {
-			const imageBlocks: Array<{ type: "image_url"; image_url: { url: string } }> = [];
-			let j = i;
-
-			for (; j < transformedMessages.length && transformedMessages[j].role === "toolResult"; j++) {
-				const toolMsg = transformedMessages[j] as ToolResultMessage;
-
-				// Extract text and image content
-				const textResult = toolMsg.content
-					.filter(isTextContentBlock)
-					.map((block) => block.text)
-					.join("\n");
-				const hasImages = toolMsg.content.some((c) => c.type === "image");
-
-				// Always send tool result with text (or placeholder if only images)
-				const hasText = textResult.length > 0;
-				// Some providers require the 'name' field in tool results
-				const toolResultMsg: ChatCompletionToolMessageParam = {
-					role: "tool",
-					content: sanitizeSurrogates(hasText ? textResult : "(see attached image)"),
-					tool_call_id: toolMsg.toolCallId,
-				};
-				if (compat.requiresToolResultName && toolMsg.toolName) {
-					(toolResultMsg as any).name = toolMsg.toolName;
-				}
-				params.push(toolResultMsg);
-
-				if (hasImages && model.input.includes("image")) {
-					for (const block of toolMsg.content) {
-						if (isImageContentBlock(block)) {
-							imageBlocks.push({
-								type: "image_url",
-								image_url: {
-									url: `data:${block.mimeType};base64,${block.data}`,
-								},
-							});
-						}
-					}
-				}
-			}
-
-			i = j - 1;
-
-			if (imageBlocks.length > 0) {
-				if (compat.requiresAssistantAfterToolResult) {
-					params.push({
-						role: "assistant",
-						content: "I have processed the tool results.",
-					});
-				}
-
-				params.push({
-					role: "user",
-					content: [
-						{
-							type: "text",
-							text: "Attached image(s) from tool result:",
-						},
-						...imageBlocks,
-					],
-				});
-				lastRole = "user";
-			} else {
-				lastRole = "toolResult";
-			}
+			const group = convertToolResultGroup(transformedMessages, i, model, compat);
+			params.push(...group.messages);
+			i = group.endIndex;
+			lastRole = group.lastRole;
 			continue;
 		}
 


### PR DESCRIPTION
## Summary
- Splits the ten highest cognitive-complexity functions flagged by Sonar into small, single-purpose units without behavior changes: `applyMigrations` (800 → dispatch table of 59 `migrationN()` functions, #714), `db:search:unified` (89, triplicated search logic deduplicated, #745), `useDashboardData` (105, tally helpers, #502), `openai-completions` `convertMessages`/`buildParams` (105/68, #589/#510), `google-shared convertMessages` (76, #493), `mistral consumeChatStream` (73, #587), `FolderCard` (77, #615), `IndexingSettings` (50, #604) and `ManyChatHeader` (46, #654).
- Provider refactors are verified with differential tests against the previous implementation: 359 input combinations (openai-completions), 21 (google-shared) and 5 scripted streams (mistral) produce byte-identical outputs/event sequences; migrations verified line-by-line verbatim plus the existing migration/backup test suites (106/106 pass).
- Regenerates `docs/architecture/ipc-channels.md` (line references shifted after the `database.cjs` refactor) so the `check:ipc-inventory` CI gate passes.

Closes #714, closes #745, closes #502, closes #589, closes #510, closes #493, closes #587, closes #615, closes #604, closes #654.

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [x] Docs / config

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes  
- [x] `pnpm run build` passes
- [ ] i18n keys added in all 4 languages (en, es, fr, pt) if new user-visible strings — N/A (no new user-visible strings)
- [x] No hardcoded colors (CSS variables only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdAqSVGSLJHyZPTbX7bShp