### PR TITLE
fix(sonar): fix S4822/S3923 reliability bugs in app/lib

### DIFF
--- a/app/lib/analytics/sentry.ts
+++ b/app/lib/analytics/sentry.ts
@@ -27,11 +27,9 @@ export function isSentryConfigured(): boolean {
 
 /** Forward span consent to the main process (performance only). */
 function setMainSpanConsent(enabled: boolean): void {
-  try {
-    void window.electron?.invoke?.('sentry:set-consent', enabled);
-  } catch {
+  void window.electron?.invoke?.('sentry:set-consent', enabled)?.catch(() => {
     // ignore — main may not have Sentry configured
-  }
+  });
 }
 
 function ensureRendererInitialized(analyticsEnabled: boolean): void {

--- a/app/lib/chat/toolCatalog.ts
+++ b/app/lib/chat/toolCatalog.ts
@@ -38,7 +38,7 @@ export function isSubagentType(value: string): value is SubagentType {
 export function subagentTypeFromTaskArgs(args: Record<string, unknown> | undefined): string {
   if (!args) return '';
   const raw = String(args.subagent_type ?? args.subagentType ?? args.name ?? '').trim().toLowerCase();
-  return isSubagentType(raw) ? raw : raw;
+  return raw;
 }
 
 export function subagentTypeFromDelegateArgs(args: Record<string, unknown> | undefined): string {

--- a/app/lib/store/useTabStore.ts
+++ b/app/lib/store/useTabStore.ts
@@ -543,15 +543,13 @@ export const useTabStore = create<TabStore>((set, get) => {
       };
       const tabType: TabType = typeMap[resourceType] ?? 'resource';
       get().openTab({ type: tabType, title, resourceId, ...(projectId ? { projectId } : {}) });
-      try {
-        void window.electron?.invoke?.('automations:notifyContext', {
-          tag: 'resource_opened',
-          resourceId,
-          resourceType,
-        });
-      } catch {
+      void window.electron?.invoke?.('automations:notifyContext', {
+        tag: 'resource_opened',
+        resourceId,
+        resourceType,
+      })?.catch(() => {
         /* non-Electron or older build */
-      }
+      });
     },
 
     openResourceInSplit: (resourceId, resourceType, title, tabId, _projectId) => {
@@ -757,7 +755,7 @@ export const useTabStore = create<TabStore>((set, get) => {
         resourceId: location.id,
         title: location.title,
         ...(location.color ? { color: location.color } : {}),
-        ...(projectId ? { projectId } : (tabs[fromIdx].projectId ? {} : {})),
+        ...(projectId ? { projectId } : {}),
       };
       const newTabs = [...tabs];
       newTabs[fromIdx] = updatedTab;

--- a/app/lib/transcription/captureController.ts
+++ b/app/lib/transcription/captureController.ts
@@ -173,7 +173,7 @@ export class CaptureController {
     this.sysVideoSink = null;
     try { this.mic?.recorder.stop(); } catch { /* */ }
     if (this.sessionId) {
-      try { tx.sessionControl({ sessionId: this.sessionId, action: 'cancel' }); } catch { /* */ }
+      void tx.sessionControl({ sessionId: this.sessionId, action: 'cancel' }).catch(() => { /* */ });
     }
     stopStreamTracks(micStream);
     stopStreamTracks(sysStream);

--- a/app/lib/transcription/useAudioLevel.ts
+++ b/app/lib/transcription/useAudioLevel.ts
@@ -66,7 +66,7 @@ export function useAudioLevel(stream: MediaStream | null): number {
     return () => {
       if (animFrameRef.current !== null) cancelAnimationFrame(animFrameRef.current);
       try { source.disconnect(); } catch { /* ignore */ }
-      try { ctx.close(); } catch { /* ignore */ }
+      void ctx.close().catch(() => { /* ignore */ });
       contextRef.current = null;
       analyserRef.current = null;
       sourceRef.current = null;


### PR DESCRIPTION
## Summary
- **S4822**: Reemplaza `try/catch` ineficaz en promesas por `.catch()` en `captureController.ts`, `sentry.ts`, `useAudioLevel.ts` y `useTabStore.ts`.
- **S3923**: Elimina ramas redundantes en ternarios idénticos en `toolCatalog.ts` y `useTabStore.ts`.

## Test plan
- [x] `pnpm run typecheck` (falla preexistente en `DomeMcpSection.tsx`, no relacionada)
- [ ] Verificar que transcripción cancela sesión sin errores no manejados
- [ ] Verificar apertura de recurso notifica contexto de automatización