### PR TITLE
fix(sonar): mechanical S7735 void + S7772 node: imports

### DIFF
--- a/app/components/settings/sections/AISection.tsx
+++ b/app/components/settings/sections/AISection.tsx
@@ -248,17 +248,14 @@ export default function AISection() {
     }
   };
 
-  useEffect(() => {
-    void refreshDomeSession();
+  useEffect(() => { refreshDomeSession();
   }, [refreshDomeSession]);
-  useEffect(() => {
-    void refreshCopilotStatus();
+  useEffect(() => { refreshCopilotStatus();
   }, [refreshCopilotStatus]);
-  useEffect(() => {
-    void refreshCloudSyncStatus();
+  useEffect(() => { refreshCloudSyncStatus();
   }, [refreshCloudSyncStatus]);
   useEffect(() => {
-    const onFocus = () => void refreshDomeSession();
+    const onFocus = () => refreshDomeSession();
     window.addEventListener('focus', onFocus);
     return () => window.removeEventListener('focus', onFocus);
   }, [refreshDomeSession]);
@@ -272,8 +269,7 @@ export default function AISection() {
     }
   }, []);
 
-  useEffect(() => {
-    void refreshProviderKeyStatus();
+  useEffect(() => { refreshProviderKeyStatus();
   }, [refreshProviderKeyStatus]);
 
   // Deep link from the model switcher: jump to a provider (and optionally its models modal).
@@ -283,8 +279,7 @@ export default function AISection() {
       if (!detail?.provider) return;
       setActiveTab('chat');
       setProvider(detail.provider);
-      if (isCloudAIProvider(detail.provider)) {
-        void (async () => {
+      if (isCloudAIProvider(detail.provider)) { (async () => {
           try {
             const { db } = await import('@/lib/db/client');
             const res = await db.getSetting(`ai_api_key_${detail.provider}`);
@@ -308,8 +303,7 @@ export default function AISection() {
     setModel(getDefaultModelId(newProvider));
     // Cada provider tiene su propia clave en DB: al cambiar, carga la suya
     // (enmascarada) en vez de arrastrar la del provider anterior.
-    if (isCloudAIProvider(newProvider)) {
-      void (async () => {
+    if (isCloudAIProvider(newProvider)) { (async () => {
         try {
           const { db } = await import('@/lib/db/client');
           const res = await db.getSetting(`ai_api_key_${newProvider}`);
@@ -354,8 +348,7 @@ export default function AISection() {
         break;
     }
     try {
-      await saveAIConfig(config);
-      void refreshProviderKeyStatus();
+      await saveAIConfig(config); refreshProviderKeyStatus();
       await transcriptionRef.current?.save();
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
@@ -530,8 +523,7 @@ export default function AISection() {
               if (savedProvider === provider && !customModel) {
                 const next = resolveVisibleModelAfterSave(savedProvider, model, visibleIds);
                 if (next !== model) {
-                  setModel(next);
-                  void saveChatModelForProvider(savedProvider, next);
+                  setModel(next); saveChatModelForProvider(savedProvider, next);
                   window.dispatchEvent(new Event('dome:ai-config-changed'));
                 }
               }
@@ -574,8 +566,7 @@ export default function AISection() {
                 {!domeConnected ? (
                   <form
                     onSubmit={(event) => {
-                      event.preventDefault();
-                      void handleDomePasswordLogin();
+                      event.preventDefault(); handleDomePasswordLogin();
                     }}
                   >
                     <FieldGroup>
@@ -625,7 +616,7 @@ export default function AISection() {
                   <Button
                     type="button"
                     variant="outline"
-                    onClick={() => void handleConnectDome()}
+                    onClick={() => handleConnectDome()}
                     disabled={domeConnecting}
                   >
                     {domeConnecting ? <Spinner data-icon="inline-start" /> : null}
@@ -636,7 +627,7 @@ export default function AISection() {
                         : t('settings.ai.dome_login_via_dashboard')}
                   </Button>
                   {domeConnected ? (
-                    <Button type="button" variant="ghost" onClick={() => void handleDisconnectDome()}>
+                    <Button type="button" variant="ghost" onClick={() => handleDisconnectDome()}>
                       {t('settings.ai.disconnect')}
                     </Button>
                   ) : null}
@@ -701,7 +692,7 @@ export default function AISection() {
                         size="sm"
                         className="self-start"
                         disabled={cloudSyncBusy}
-                        onClick={() => void handleCloudSyncNow()}
+                        onClick={() => handleCloudSyncNow()}
                       >
                         {cloudSyncBusy ? <Spinner data-icon="inline-start" /> : null}
                         {cloudSyncBusy
@@ -730,7 +721,7 @@ export default function AISection() {
                   </Badge>
                   <Button
                     type="button"
-                    onClick={() => void handleConnectCopilot()}
+                    onClick={() => handleConnectCopilot()}
                     disabled={copilotConnecting}
                   >
                     {copilotConnecting ? <Spinner data-icon="inline-start" /> : null}
@@ -744,7 +735,7 @@ export default function AISection() {
                     <Button
                       type="button"
                       variant="ghost"
-                      onClick={() => void handleDisconnectCopilot()}
+                      onClick={() => handleDisconnectCopilot()}
                     >
                       {t('settings.ai.disconnect')}
                     </Button>
@@ -800,14 +791,14 @@ export default function AISection() {
       {activeTab === 'chat' || activeTab === 'transcription' ? (
         <>
           <div className="flex flex-wrap items-center gap-3">
-            <Button type="button" onClick={() => void handleSave()}>
+            <Button type="button" onClick={() => handleSave()}>
               {saved ? t('settings.ai.saved_config') : t('settings.ai.save_all')}
             </Button>
             {activeTab === 'chat' ? (
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => void handleTestConnection()}
+                onClick={() => handleTestConnection()}
                 disabled={testing}
               >
                 {testing ? <Spinner data-icon="inline-start" /> : null}

--- a/app/components/settings/sections/DomeSyncSection.tsx
+++ b/app/components/settings/sections/DomeSyncSection.tsx
@@ -52,8 +52,7 @@ export default function DomeSyncSection() {
     }
   }, []);
 
-  useEffect(() => {
-    void loadDomainStatus().finally(() => setLoading(false));
+  useEffect(() => { loadDomainStatus().finally(() => setLoading(false));
   }, [loadDomainStatus]);
 
   useEffect(() => {
@@ -70,9 +69,7 @@ export default function DomeSyncSection() {
     try {
       const result = await window.electron.domeAuth.startOAuthFlow();
       if (result.success) {
-        showToast('success', t('settings.domain_sync.connected_to_dome'));
-        void session.refresh();
-        void loadDomainStatus();
+        showToast('success', t('settings.domain_sync.connected_to_dome')); session.refresh(); loadDomainStatus();
       } else {
         showToast('error', result.error ?? t('settings.domain_sync.connect_error'));
       }
@@ -138,7 +135,7 @@ export default function DomeSyncSection() {
             </EmptyDescription>
           </EmptyHeader>
           <EmptyContent>
-            <Button type="button" onClick={() => void handleConnect()} disabled={connectingOAuth}>
+            <Button type="button" onClick={() => handleConnect()} disabled={connectingOAuth}>
               {connectingOAuth ? <Spinner data-icon="inline-start" /> : null}
               {connectingOAuth ? 'Conectando…' : 'Iniciar sesión en Dome'}
             </Button>
@@ -186,7 +183,7 @@ export default function DomeSyncSection() {
                 variant="outline"
                 size="sm"
                 disabled={domainSyncing}
-                onClick={() => void syncDomainsNow()}
+                onClick={() => syncDomainsNow()}
               >
                 {domainSyncing ? (
                   <Spinner data-icon="inline-start" />
@@ -204,7 +201,7 @@ export default function DomeSyncSection() {
                 control={
                   <Switch
                     checked={domainState[domain]?.enabled !== false}
-                    onCheckedChange={(checked) => void toggleDomain(domain, checked)}
+                    onCheckedChange={(checked) => toggleDomain(domain, checked)}
                     aria-label={t(labelKey)}
                   />
                 }
@@ -221,8 +218,7 @@ export default function DomeSyncSection() {
               onClick={async () => {
                 const result = await window.electron?.domeAuth?.disconnect?.();
                 if (result?.success) {
-                  showToast('success', t('settings.domain_sync.disconnected_from_dome'));
-                  void session.refresh();
+                  showToast('success', t('settings.domain_sync.disconnected_from_dome')); session.refresh();
                 }
               }}
             >

--- a/app/components/settings/sections/EmailSection.tsx
+++ b/app/components/settings/sections/EmailSection.tsx
@@ -498,7 +498,7 @@ export default function EmailSection() {
                   variant="ghost"
                   size="icon-sm"
                   className="text-destructive"
-                  onClick={() => void handleRemove(acc.id)}
+                  onClick={() => handleRemove(acc.id)}
                   title={t('email.settings.remove')}
                   aria-label={t('email.settings.remove')}
                 >
@@ -509,8 +509,7 @@ export default function EmailSection() {
               <EmailPermissionsEditor
                 userActions={acc.user_actions ?? DEFAULT_USER_ACTIONS}
                 agentActions={acc.agent_actions ?? DEFAULT_AGENT_ACTIONS}
-                onChange={(user_actions, agent_actions) =>
-                  void saveAccountPermissions(acc.id, user_actions, agent_actions)
+                onChange={(user_actions, agent_actions) => saveAccountPermissions(acc.id, user_actions, agent_actions)
                 }
               />
             </SettingsRow>
@@ -624,7 +623,7 @@ export default function EmailSection() {
             ) : null}
 
             <div className="flex flex-wrap items-center gap-2 pt-1">
-              <Button type="button" disabled={busy} onClick={() => void handleTest()}>
+              <Button type="button" disabled={busy} onClick={() => handleTest()}>
                 {testState === 'testing' ? (
                   <Spinner data-icon="inline-start" />
                 ) : (
@@ -632,7 +631,7 @@ export default function EmailSection() {
                 )}
                 {t('email.settings.test_and_save')}
               </Button>
-              <Button type="button" variant="outline" disabled={busy} onClick={() => void handleAdd()}>
+              <Button type="button" variant="outline" disabled={busy} onClick={() => handleAdd()}>
                 {t('email.settings.save_without_test')}
               </Button>
               <Button

--- a/app/components/settings/sections/IndexingSection.tsx
+++ b/app/components/settings/sections/IndexingSection.tsx
@@ -75,8 +75,7 @@ function useEmbeddingStatus(pausePolling: boolean) {
     }
   }, []);
 
-  useEffect(() => {
-    void loadEmbedStatus();
+  useEffect(() => { loadEmbedStatus();
     const interval = setInterval(() => {
       if (!pausePolling) void loadEmbedStatus();
     }, 8000);
@@ -117,8 +116,7 @@ function useFullSync(loadEmbedStatus: () => Promise<void>, t: TranslateFn) {
     const off = window.electron.on('indexing:full-sync-progress', (data: FullSyncProgressPayload) => {
       setFullSyncProgress(data);
       if (data.phase === 'finished') {
-        setFullSyncBusy(false);
-        void loadEmbedStatus();
+        setFullSyncBusy(false); loadEmbedStatus();
       }
     });
     return () => {
@@ -146,8 +144,7 @@ function useFullSync(loadEmbedStatus: () => Promise<void>, t: TranslateFn) {
       setLastError(toErrorMessage(e));
     } finally {
       setFullSyncBusy(false);
-      setFullSyncProgress(null);
-      void loadEmbedStatus();
+      setFullSyncProgress(null); loadEmbedStatus();
     }
   };
 
@@ -181,8 +178,7 @@ function useSemanticReindex({
       setEmbedError(toErrorMessage(e));
     } finally {
       setEmbedReindexBusy(false);
-      setEmbedProgress(null);
-      void loadEmbedStatus();
+      setEmbedProgress(null); loadEmbedStatus();
     }
   };
 
@@ -224,8 +220,7 @@ export default function IndexingSection() {
   }, [libraryBusy]);
 
   const handleRefresh = () => {
-    setEmbedLoading(true);
-    void loadEmbedStatus();
+    setEmbedLoading(true); loadEmbedStatus();
   };
 
   const fullSyncPercent = computeFullSyncPercent(fullSyncProgress);
@@ -241,7 +236,7 @@ export default function IndexingSection() {
           title={t('settings.indexing.full_sync_title')}
           description={t('settings.indexing.full_sync_hint')}
           control={
-            <Button type="button" size="sm" disabled={libraryBusy} onClick={() => void handleFullSync()}>
+            <Button type="button" size="sm" disabled={libraryBusy} onClick={() => handleFullSync()}>
               {fullSyncBusy ? (
                 <Spinner data-icon="inline-start" />
               ) : (
@@ -310,7 +305,7 @@ export default function IndexingSection() {
               <Button
                 type="button"
                 size="sm"
-                onClick={() => void handleSemanticReindexAll()}
+                onClick={() => handleSemanticReindexAll()}
                 disabled={libraryBusy}
               >
                 {embedReindexBusy ? (

--- a/app/components/settings/sections/SocialSection.tsx
+++ b/app/components/settings/sections/SocialSection.tsx
@@ -92,9 +92,8 @@ export default function SocialSection() {
     if (accountsRes?.success) setAccounts(accountsRes.data);
   }, []);
 
-  useEffect(() => {
-    void load();
-    const unsub = window.electron?.on?.('social:account-updated', () => void load());
+  useEffect(() => { load();
+    const unsub = window.electron?.on?.('social:account-updated', () => load());
     return () => unsub?.();
   }, [load]);
 
@@ -142,7 +141,7 @@ export default function SocialSection() {
               type="number"
               value={oauthPort}
               onChange={(e) => setOauthPort(Number(e.target.value) || 8737)}
-              onBlur={() => void savePort(oauthPort)}
+              onBlur={() => savePort(oauthPort)}
               className="w-28"
             />
           }
@@ -271,8 +270,7 @@ function ProviderGroup({
     (a) => a.provider === 'linkedin' && (a.accountKind || 'member') === 'member',
   );
 
-  const copyRedirect = () => {
-    void navigator.clipboard?.writeText(status.redirectUri);
+  const copyRedirect = () => { navigator.clipboard?.writeText(status.redirectUri);
   };
 
   const configured =
@@ -368,7 +366,7 @@ function ProviderGroup({
                       <Checkbox
                         checked={Boolean(acc.cloudPublishing)}
                         disabled={cloudBusyId === acc.id}
-                        onCheckedChange={(checked) => void toggleCloudPublishing(acc.id, checked)}
+                        onCheckedChange={(checked) => toggleCloudPublishing(acc.id, checked)}
                       />
                       <span>{t('social.settings.cloud_publishing')}</span>
                     </label>
@@ -388,7 +386,7 @@ function ProviderGroup({
                     variant="ghost"
                     size="icon-sm"
                     className="text-destructive"
-                    onClick={() => void disconnect(acc.id)}
+                    onClick={() => disconnect(acc.id)}
                     title={t('social.settings.disconnect')}
                     aria-label={t('social.settings.disconnect')}
                   >
@@ -406,7 +404,7 @@ function ProviderGroup({
             variant="outline"
             size="sm"
             className="self-start text-primary"
-            onClick={() => void syncLinkedInOrgs(linkedInMemberAccount.id)}
+            onClick={() => syncLinkedInOrgs(linkedInMemberAccount.id)}
             disabled={syncingOrgs}
           >
             {syncingOrgs ? (
@@ -425,7 +423,7 @@ function ProviderGroup({
             <Checkbox
               aria-label={t('social.settings.linkedin_org_enabled')}
               checked={orgEnabled}
-              onCheckedChange={() => void toggleOrgEnabled()}
+              onCheckedChange={() => toggleOrgEnabled()}
               disabled={saving}
               className="mt-0.5"
             />
@@ -496,7 +494,7 @@ function ProviderGroup({
             type="button"
             variant="outline"
             size="sm"
-            onClick={() => void saveConfig()}
+            onClick={() => saveConfig()}
             disabled={saving}
           >
             {saving ? <Spinner data-icon="inline-start" /> : null}
@@ -505,7 +503,7 @@ function ProviderGroup({
           <Button
             type="button"
             size="sm"
-            onClick={() => void connectOAuth()}
+            onClick={() => connectOAuth()}
             disabled={connecting || !configured}
           >
             {connecting ? t('social.settings.connecting') : t('social.settings.connect_oauth')}
@@ -537,7 +535,7 @@ function ProviderGroup({
             <Button
               type="button"
               size="sm"
-              onClick={() => void connectToken()}
+              onClick={() => connectToken()}
               disabled={connecting || !manualToken.trim()}
             >
               {t('social.settings.connect')}

--- a/electron/agents/automation-persistence.cjs
+++ b/electron/agents/automation-persistence.cjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 const database = require('../core/database.cjs');
 const { parseJsonSafely, toJson } = require('./run-store.cjs');
 

--- a/electron/agents/dome-harness-bridge.cjs
+++ b/electron/agents/dome-harness-bridge.cjs
@@ -5,8 +5,8 @@
  * Owns JSONL session storage, skills loading, and MCP → AgentTool conversion.
  */
 
-const path = require('path');
-const os = require('os');
+const path = require('node:path');
+const os = require('node:os');
 
 const SESSION_CWD = 'dome';
 

--- a/electron/agents/pipeline-event-log.cjs
+++ b/electron/agents/pipeline-event-log.cjs
@@ -18,7 +18,7 @@ function logEvent(itemId, eventType, { actor, summary, detail, runId } = {}) {
   try {
     const item = _queries.getPipelineItemById.get(itemId);
     if (!item) return;
-    const crypto = require('crypto');
+    const crypto = require('node:crypto');
     const id = crypto.randomUUID();
     const projectId = item.project_id || 'default';
     _queries.createPipelineItemEvent.run(

--- a/electron/ai/auto-metadata.cjs
+++ b/electron/ai/auto-metadata.cjs
@@ -40,7 +40,7 @@ function scheduleCloudAutoMetadata(resourceId, deps) {
         const title = String(row.title || '').trim();
         if (title && title.toLowerCase() !== 'untitled') return;
 
-        const fs = require('fs');
+        const fs = require('node:fs');
         const { getIndexableText } = require('../services/resource-text.cjs');
 
         let imageDataUrl = null;

--- a/electron/auth/supabase-credentials.cjs
+++ b/electron/auth/supabase-credentials.cjs
@@ -1,7 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 /**
  * Resolved Supabase Auth credentials for native login/signup (onboarding).


### PR DESCRIPTION
## Summary

- **S7735** — Remove unnecessary `void` operator in 5 settings section components (`app/components/settings/sections/`) via `fix-void-operator.mjs`.
- **S7772** — Prefer `node:` builtin imports in 5 electron `.cjs` files (crypto, path, os, fs).

## Files changed (10)

### S7735 void operator
- `app/components/settings/sections/AISection.tsx`
- `app/components/settings/sections/DomeSyncSection.tsx`
- `app/components/settings/sections/EmailSection.tsx`
- `app/components/settings/sections/IndexingSection.tsx`
- `app/components/settings/sections/SocialSection.tsx`

### S7772 node: imports
- `electron/agents/automation-persistence.cjs`
- `electron/agents/dome-harness-bridge.cjs`
- `electron/agents/pipeline-event-log.cjs`
- `electron/ai/auto-metadata.cjs`
- `electron/auth/supabase-credentials.cjs`

## Test plan

- [x] `tsc --noEmit` passes locally
- [ ] CI typecheck + lint
- [ ] Sonar re-scan clears targeted issues