### PR TITLE
fix: reduce Sonar S3776 in AgentNode and GitHubView

### DIFF
--- a/app/components/agent-canvas/nodes/AgentNode.tsx
+++ b/app/components/agent-canvas/nodes/AgentNode.tsx
@@ -17,7 +17,7 @@ import {
 import { HugeiconsIcon } from '@hugeicons/react';
 import { useTranslation } from 'react-i18next';
 import type { AgentNodeData, SystemAgentRole } from '@/types/canvas';
-import { SYSTEM_AGENTS } from '@/lib/agent-canvas/system-agents';
+import { SYSTEM_AGENTS, type SystemAgentDefinition } from '@/lib/agent-canvas/system-agents';
 import { canvasSystemAgentDescKey } from '@/lib/agent-canvas/canvas-layout';
 
 const Search = (props: Omit<React.ComponentProps<typeof HugeiconsIcon>, 'icon'>) => (
@@ -54,6 +54,165 @@ const STATUS_COLORS = {
   done: { header: 'var(--success-bg)', textColor: 'var(--success)' },
   error: { header: 'color-mix(in srgb, var(--destructive) 12%, transparent)', textColor: 'var(--destructive)' },
 };
+
+type StatusColors = (typeof STATUS_COLORS)[keyof typeof STATUS_COLORS];
+
+function resolveAgentNodeChrome(
+  selected: boolean,
+  isSystemAgent: boolean,
+  systemDef: SystemAgentDefinition | null,
+  colors: StatusColors,
+) {
+  const accent = isSystemAgent && systemDef ? systemDef.color : 'var(--primary)';
+  const headerBg =
+    isSystemAgent && systemDef
+      ? `color-mix(in srgb, ${systemDef.color} 10%, var(--background))`
+      : colors.header;
+  const borderColor =
+    selected && isSystemAgent && systemDef
+      ? systemDef.color
+      : selected
+        ? 'var(--primary)'
+        : 'var(--border)';
+  const boxShadow = selected
+    ? `0 0 0 2px color-mix(in srgb, ${accent} 18%, transparent)`
+    : 'none';
+  return { headerBg, borderColor, boxShadow, accent };
+}
+
+function AgentNodeAvatar({
+  data,
+  isSystemAgent,
+  RoleIcon,
+  systemColor,
+  iconLoadFailed,
+  onIconError,
+  agentInitials,
+}: {
+  data: AgentNodeData;
+  isSystemAgent: boolean;
+  RoleIcon: React.ElementType | null;
+  systemColor: string;
+  iconLoadFailed: boolean;
+  onIconError: () => void;
+  agentInitials: string;
+}) {
+  if (isSystemAgent && RoleIcon) {
+    return <RoleIcon className="size-3.5 text-white" />;
+  }
+  if (data.agentIconIndex > 0 && !iconLoadFailed) {
+    return (
+      <img
+        src={`/agents/sprite_${data.agentIconIndex}.png`}
+        alt={data.agentName ?? 'Agent'}
+        className="size-full object-contain rounded-lg"
+        onError={onIconError}
+      />
+    );
+  }
+  return agentInitials;
+}
+
+function AgentNodeSubtitle({
+  data,
+  isSystemAgent,
+  systemDef,
+  colors,
+  t,
+}: {
+  data: AgentNodeData;
+  isSystemAgent: boolean;
+  systemDef: SystemAgentDefinition | null;
+  colors: StatusColors;
+  t: (key: string) => string;
+}) {
+  if (isSystemAgent && systemDef) {
+    return (
+      <span className="text-[10px] truncate block opacity-60 leading-tight" style={{ color: systemDef.color }}>
+        {systemDef.emoji} {t('canvas.system_agent_badge')}
+      </span>
+    );
+  }
+  if (data.agentName) {
+    return (
+      <span className="text-[10px] truncate block opacity-70 leading-tight" style={{ color: colors.textColor }}>
+        {data.agentName}
+      </span>
+    );
+  }
+  return null;
+}
+
+function AgentNodeBody({
+  data,
+  isSystemAgent,
+  systemDef,
+  systemDesc,
+  t,
+}: {
+  data: AgentNodeData;
+  isSystemAgent: boolean;
+  systemDef: SystemAgentDefinition | null;
+  systemDesc: string;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}) {
+  if (data.status === 'idle' && !data.agentId && !data.systemAgentRole) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <HugeiconsIcon icon={BotIcon} className="size-4 opacity-40 shrink-0" />
+        <span className="italic leading-snug">{t('canvas.no_agent_assigned')}</span>
+      </div>
+    );
+  }
+  if (data.status === 'idle' && isSystemAgent && systemDef && data.systemAgentRole) {
+    return (
+      <div className="text-xs leading-snug" style={{ color: systemDef.color }}>
+        <span className="opacity-70">{systemDesc}</span>
+      </div>
+    );
+  }
+  if (data.status === 'idle' && data.agentId) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <HugeiconsIcon icon={ChevronRightIcon} className="size-3.5 opacity-40 shrink-0" />
+        <span className="italic leading-snug">{t('canvas.ready_to_execute')}</span>
+      </div>
+    );
+  }
+  if (data.status === 'running') {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <div className="h-1.5 rounded-full overflow-hidden bg-background">
+          <div
+            className="size-full rounded-full animate-pulse"
+            style={{
+              background: 'linear-gradient(90deg, transparent 0%, var(--primary) 50%, transparent 100%)',
+            }}
+          />
+        </div>
+        <p className="text-xs leading-snug text-muted-foreground">{t('canvas.processing')}</p>
+        {data.outputText ? (
+          <p className="text-xs line-clamp-3 mt-0.5 leading-snug text-muted-foreground">{data.outputText}</p>
+        ) : null}
+      </div>
+    );
+  }
+  if (data.status === 'done' && data.outputText) {
+    return (
+      <p className="text-xs line-clamp-4 leading-snug" style={{ color: 'var(--muted-foreground)', lineHeight: 1.45 }}>
+        {data.outputText}
+      </p>
+    );
+  }
+  if (data.status === 'error') {
+    return (
+      <p className="text-xs leading-snug text-destructive">
+        {data.errorMessage ?? t('canvas.unknown_error')}
+      </p>
+    );
+  }
+  return null;
+}
 
 function AgentNodeStatusIcon({
   status,
@@ -101,18 +260,13 @@ export default function AgentNode({
   const RoleIcon = data.systemAgentRole ? SYSTEM_ROLE_ICONS[data.systemAgentRole] : null;
 
   const systemDesc = data.systemAgentRole != null ? t(canvasSystemAgentDescKey(data.systemAgentRole)) : '';
-
-  const headerBg =
-    isSystemAgent && systemDef
-      ? `color-mix(in srgb, ${systemDef.color} 10%, var(--background))`
-      : colors.header;
-
-  const borderColor =
-    selected && isSystemAgent && systemDef
-      ? systemDef.color
-      : selected
-        ? 'var(--primary)'
-        : 'var(--border)';
+  const { headerBg, borderColor, boxShadow } = resolveAgentNodeChrome(
+    selected,
+    isSystemAgent,
+    systemDef,
+    colors,
+  );
+  const titleColor = isSystemAgent && systemDef ? systemDef.color : colors.textColor;
 
   return (
     <div
@@ -120,9 +274,7 @@ export default function AgentNode({
       style={{
         width: 220,
         border: `1px solid ${borderColor}`,
-        boxShadow: selected
-          ? `0 0 0 2px color-mix(in srgb, ${isSystemAgent && systemDef ? systemDef.color : 'var(--primary)'} 18%, transparent)`
-          : 'none',
+        boxShadow,
         background: 'var(--card)',
       }}
     >
@@ -137,91 +289,39 @@ export default function AgentNode({
           className="size-6 rounded-lg flex items-center justify-center text-white font-bold text-[10px] shrink-0"
           style={{ background: systemColor }}
         >
-          {isSystemAgent && RoleIcon ? (
-            <RoleIcon className="size-3.5 text-white" />
-          ) : data.agentIconIndex > 0 && !iconLoadFailed ? (
-            <img
-              src={`/agents/sprite_${data.agentIconIndex}.png`}
-              alt={data.agentName ?? 'Agent'}
-              className="size-full object-contain rounded-lg"
-              onError={() => setIconLoadFailed(true)}
-            />
-          ) : (
-            agentInitials
-          )}
+          <AgentNodeAvatar
+            data={data}
+            isSystemAgent={isSystemAgent}
+            RoleIcon={RoleIcon}
+            systemColor={systemColor}
+            iconLoadFailed={iconLoadFailed}
+            onIconError={() => setIconLoadFailed(true)}
+            agentInitials={agentInitials}
+          />
         </div>
         <div className="flex-1 min-w-0">
-          <span
-            className="text-xs font-semibold leading-tight truncate block"
-            style={{ color: isSystemAgent && systemDef ? systemDef.color : colors.textColor }}
-          >
+          <span className="text-xs font-semibold leading-tight truncate block" style={{ color: titleColor }}>
             {data.label}
           </span>
-          {isSystemAgent && systemDef ? (
-            <span className="text-[10px] truncate block opacity-60 leading-tight" style={{ color: systemDef.color }}>
-              {systemDef.emoji} {t('canvas.system_agent_badge')}
-            </span>
-          ) : data.agentName ? (
-            <span className="text-[10px] truncate block opacity-70 leading-tight" style={{ color: colors.textColor }}>
-              {data.agentName}
-            </span>
-          ) : null}
+          <AgentNodeSubtitle
+            data={data}
+            isSystemAgent={isSystemAgent}
+            systemDef={systemDef}
+            colors={colors}
+            t={t}
+          />
         </div>
         <AgentNodeStatusIcon status={data.status} systemColor={systemColor} />
       </div>
 
       <div className="p-3 min-h-[48px]">
-        {data.status === 'idle' && !data.agentId && !data.systemAgentRole && (
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <HugeiconsIcon icon={BotIcon} className="size-4 opacity-40 shrink-0" />
-            <span className="italic leading-snug">{t('canvas.no_agent_assigned')}</span>
-          </div>
-        )}
-        {data.status === 'idle' && isSystemAgent && systemDef && data.systemAgentRole && (
-          <div className="text-xs leading-snug" style={{ color: systemDef.color }}>
-            <span className="opacity-70">{systemDesc}</span>
-          </div>
-        )}
-
-        {data.status === 'idle' && data.agentId && (
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <HugeiconsIcon icon={ChevronRightIcon} className="size-3.5 opacity-40 shrink-0" />
-            <span className="italic leading-snug">{t('canvas.ready_to_execute')}</span>
-          </div>
-        )}
-
-        {data.status === 'running' && (
-          <div className="flex flex-col gap-1.5">
-            <div className="h-1.5 rounded-full overflow-hidden bg-background">
-              <div
-                className="size-full rounded-full animate-pulse"
-                style={{
-                  background: 'linear-gradient(90deg, transparent 0%, var(--primary) 50%, transparent 100%)',
-                }}
-              />
-            </div>
-            <p className="text-xs leading-snug text-muted-foreground">
-              {t('canvas.processing')}
-            </p>
-            {data.outputText && (
-              <p className="text-xs line-clamp-3 mt-0.5 leading-snug text-muted-foreground">
-                {data.outputText}
-              </p>
-            )}
-          </div>
-        )}
-
-        {data.status === 'done' && data.outputText && (
-          <p className="text-xs line-clamp-4 leading-snug" style={{ color: 'var(--muted-foreground)', lineHeight: 1.45 }}>
-            {data.outputText}
-          </p>
-        )}
-
-        {data.status === 'error' && (
-          <p className="text-xs leading-snug text-destructive">
-            {data.errorMessage ?? t('canvas.unknown_error')}
-          </p>
-        )}
+        <AgentNodeBody
+          data={data}
+          isSystemAgent={isSystemAgent}
+          systemDef={systemDef}
+          systemDesc={systemDesc}
+          t={t}
+        />
       </div>
     </div>
   );

--- a/app/components/github/GitHubView.tsx
+++ b/app/components/github/GitHubView.tsx
@@ -24,6 +24,85 @@ import { Spinner } from '@/components/ui/spinner';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
 
+type GitHubRepo = ReturnType<typeof useGitHubStore.getState>['repos'][number];
+
+function buildSyncDescription(
+  t: (key: string, options?: Record<string, unknown>) => string,
+  syncError: string | null,
+  syncStatus: string,
+  isSyncing: boolean,
+  lastSync: number | null,
+): string {
+  if (syncError && syncStatus === 'error') return t('github.sync_error', { error: syncError });
+  if (isSyncing) return t('github.syncing');
+  if (lastSync) {
+    return t('github.dash_subtitle_synced', {
+      time: new Date(lastSync).toLocaleString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+        day: 'numeric',
+        month: 'short',
+      }),
+    });
+  }
+  return t('github.dash_subtitle');
+}
+
+function GitHubSyncBadge({
+  syncStatus,
+  isSyncing,
+  t,
+}: {
+  syncStatus: string;
+  isSyncing: boolean;
+  t: (key: string) => string;
+}) {
+  if (syncStatus === 'error') {
+    return <Badge variant="destructive">{t('github.sync_badge_error')}</Badge>;
+  }
+  if (isSyncing) {
+    return <Badge variant="mint">{t('github.sync_badge_syncing')}</Badge>;
+  }
+  return null;
+}
+
+function getSelectedRepoLabel(
+  selectedRepo: GitHubRepo | null,
+  selectedRepos: GitHubRepo[],
+  t: (key: string) => string,
+): string {
+  if (selectedRepo?.full_name) return selectedRepo.full_name;
+  if (selectedRepos.length === 0) return t('github.select_repos_in_settings');
+  return t('github.tab_title');
+}
+
+function GitHubDetailSidebar({
+  openIssueId,
+  openMilestoneId,
+  onCloseIssue,
+  onCloseMilestone,
+  onOpenIssueFromMilestone,
+}: {
+  openIssueId: string | null;
+  openMilestoneId: string | null;
+  onCloseIssue: () => void;
+  onCloseMilestone: () => void;
+  onOpenIssueFromMilestone: (issueId: string) => void;
+}) {
+  return (
+    <div className="flex h-full min-h-0 w-full shrink-0 flex-col border-l bg-background studio-view-enter md:w-80 lg:w-[28rem]">
+      {openMilestoneId ? (
+        <MilestoneDetailModal
+          milestoneId={openMilestoneId}
+          onClose={onCloseMilestone}
+          onOpenIssue={onOpenIssueFromMilestone}
+        />
+      ) : null}
+      {openIssueId ? <IssueDetailPanel issueId={openIssueId} onClose={onCloseIssue} /> : null}
+    </div>
+  );
+}
+
 export default function GitHubView() {
   const { t } = useTranslation();
   const projectId = useAppStore((s) => s.currentProject?.id ?? 'default');
@@ -53,21 +132,10 @@ export default function GitHubView() {
     void syncNow(projectId).finally(() => setManualSyncing(false));
   }, [isSyncing, projectId, syncNow]);
 
-  const syncDescription = useMemo(() => {
-    if (syncError && syncStatus === 'error') return t('github.sync_error', { error: syncError });
-    if (isSyncing) return t('github.syncing');
-    if (lastSync) {
-      return t('github.dash_subtitle_synced', {
-        time: new Date(lastSync).toLocaleString([], {
-          hour: '2-digit',
-          minute: '2-digit',
-          day: 'numeric',
-          month: 'short',
-        }),
-      });
-    }
-    return t('github.dash_subtitle');
-  }, [isSyncing, lastSync, syncError, syncStatus, t]);
+  const syncDescription = useMemo(
+    () => buildSyncDescription(t, syncError, syncStatus, isSyncing, lastSync),
+    [isSyncing, lastSync, syncError, syncStatus, t],
+  );
 
   useEffect(() => {
     void init(projectId);
@@ -126,11 +194,7 @@ export default function GitHubView() {
           className="w-full"
           actions={
             <>
-              {syncStatus === 'error' ? (
-                <Badge variant="destructive">{t('github.sync_badge_error')}</Badge>
-              ) : isSyncing ? (
-                <Badge variant="mint">{t('github.sync_badge_syncing')}</Badge>
-              ) : null}
+              <GitHubSyncBadge syncStatus={syncStatus} isSyncing={isSyncing} t={t} />
               <SectionGuideHelp sectionKey="github" />
               <Button type="button" variant="outline" size="sm" disabled={isSyncing} onClick={handleSyncClick}>
                 {isSyncing ? (
@@ -171,10 +235,7 @@ export default function GitHubView() {
                 <span className="flex min-w-0 items-center gap-1.5">
                   <HugeiconsIcon icon={GithubIcon} className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
                   <span className="truncate">
-                    {selectedRepo?.full_name ??
-                      (selectedRepos.length === 0
-                        ? t('github.select_repos_in_settings')
-                        : t('github.tab_title'))}
+                    {getSelectedRepoLabel(selectedRepo, selectedRepos, t)}
                   </span>
                 </span>
                 <HugeiconsIcon icon={ChevronDownIcon} className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
@@ -250,21 +311,16 @@ export default function GitHubView() {
         </div>
 
         {detailOpen ? (
-          <div className="flex h-full min-h-0 w-full shrink-0 flex-col border-l bg-background studio-view-enter md:w-80 lg:w-[28rem]">
-            {openMilestoneId ? (
-              <MilestoneDetailModal
-                milestoneId={openMilestoneId}
-                onClose={() => setOpenMilestoneId(null)}
-                onOpenIssue={(id) => {
-                  setOpenMilestoneId(null);
-                  setOpenIssueId(id);
-                }}
-              />
-            ) : null}
-            {openIssueId ? (
-              <IssueDetailPanel issueId={openIssueId} onClose={() => setOpenIssueId(null)} />
-            ) : null}
-          </div>
+          <GitHubDetailSidebar
+            openIssueId={openIssueId}
+            openMilestoneId={openMilestoneId}
+            onCloseIssue={() => setOpenIssueId(null)}
+            onCloseMilestone={() => setOpenMilestoneId(null)}
+            onOpenIssueFromMilestone={(id) => {
+              setOpenMilestoneId(null);
+              setOpenIssueId(id);
+            }}
+          />
         ) : null}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Refactor `AgentNode.tsx` (ola2-1): extract avatar, subtitle, body, and chrome helpers to reduce cognitive complexity from 27.
- Refactor `GitHubView.tsx` (ola2-16): extract sync description/badge, repo label, and detail sidebar helpers to reduce complexity from 16.
- No behavior changes; minimal structural extraction only.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Sonar re-scan confirms S3776 resolved for both files
- [ ] Smoke: agent canvas node renders all statuses; GitHub view sync badge, repo picker, and detail panel still work