### PR TITLE
fix(sonar): mechanical S7735 void operator wave 2

### DIFF
--- a/app/components/github/GitHubView.tsx
+++ b/app/components/github/GitHubView.tsx
@@ -129,7 +129,7 @@ export default function GitHubView() {
   const handleSyncClick = useCallback(() => {
     if (isSyncing) return;
     setManualSyncing(true);
-    void syncNow(projectId).finally(() => setManualSyncing(false));
+    syncNow(projectId).finally(() => setManualSyncing(false));
   }, [isSyncing, projectId, syncNow]);
 
   const syncDescription = useMemo(
@@ -138,7 +138,7 @@ export default function GitHubView() {
   );
 
   useEffect(() => {
-    void init(projectId);
+    init(projectId);
     return () => dispose();
   }, [init, dispose, projectId]);
 
@@ -159,7 +159,7 @@ export default function GitHubView() {
       const detail = (e as CustomEvent<{ issueId?: string; repoId?: string }>).detail;
       if (!detail?.issueId) return;
       useOpenIntentStore.getState().consume('github-issue');
-      void applyGithubIssueFocus(detail.issueId, detail.repoId);
+      applyGithubIssueFocus(detail.issueId, detail.repoId);
     };
     window.addEventListener('dome:focus-github-issue', onFocus);
     return () => window.removeEventListener('dome:focus-github-issue', onFocus);
@@ -251,7 +251,7 @@ export default function GitHubView() {
                           key={r.id}
                           value={r.full_name}
                           onSelect={() => {
-                            void selectRepo(r.id);
+                            selectRepo(r.id);
                             setRepoPickerOpen(false);
                           }}
                         >

--- a/app/components/github/IssueDetailPanel.tsx
+++ b/app/components/github/IssueDetailPanel.tsx
@@ -221,7 +221,7 @@ export default function IssueDetailPanel({ issueId, onClose }: { issueId: string
   useEffect(() => {
     let cancelled = false;
 
-    void (async () => {
+    (async () => {
       const res = await githubClient.issues.get(issueId);
       if (cancelled || !res.success || !res.issue) return;
       setTitle(res.issue.title);
@@ -240,14 +240,15 @@ export default function IssueDetailPanel({ issueId, onClose }: { issueId: string
   const commentsLoadKey = `${issueId}:${editing}`;
   if (!editing && commentsLoadKey !== prevCommentsLoadKeyRef.current) {
     prevCommentsLoadKeyRef.current = commentsLoadKey;
-    void loadComments();
-    void loadTimeline();
+    loadComments();
+    loadTimeline();
   }
 
   const prevMentionablesIssueIdRef = useRef(issueId);
   if (issueId !== prevMentionablesIssueIdRef.current) {
     prevMentionablesIssueIdRef.current = issueId;
-    void (async () => {
+
+    (async () => {
       const res = await githubClient.issues.listMentionables(issueId);
       setApiMentionables(res.success ? res.users ?? [] : []);
     })();
@@ -376,7 +377,7 @@ export default function IssueDetailPanel({ issueId, onClose }: { issueId: string
         {t('github.cancel')}
       </Button>
       <Button disabled={saving}
-  onClick={() => void save()}
+  onClick={() => save()}
   size="sm">{saving ? <Spinner data-icon="inline-start" /> : <HugeiconsIcon icon={SaveIcon} data-icon="inline-start" />}
         {t('github.dash_save')}
       </Button>
@@ -384,7 +385,7 @@ export default function IssueDetailPanel({ issueId, onClose }: { issueId: string
   ) : (
     <div className="flex items-center justify-end gap-2 w-full">
       <Button disabled={!newComment.trim() || postingComment}
-  onClick={() => void postComment()}
+  onClick={() => postComment()}
   size="sm">{postingComment ? <Spinner data-icon="inline-start" /> : <HugeiconsIcon icon={SentIcon} data-icon="inline-start" />}
         {t('github.post_comment')}
       </Button>

--- a/app/components/github/TrackingDashboard.tsx
+++ b/app/components/github/TrackingDashboard.tsx
@@ -118,13 +118,13 @@ function QuickAdd({
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      void submit();
+      submit();
     }
   };
 
   return (
     <Card className="gap-0 py-0 shadow-none">
-      <form onSubmit={(e) => void submit(e)} className="flex flex-col gap-3 p-3">
+      <form onSubmit={(e) => submit(e)} className="flex flex-col gap-3 p-3">
         <div className="flex min-w-0 items-center gap-2">
           <HugeiconsIcon icon={PlusSignIcon} className="size-3.5 shrink-0 text-muted-foreground" />
           <Input
@@ -369,7 +369,7 @@ export default function TrackingDashboard({
                   issues={list}
                   onOpenObjective={() => onOpenMilestone(m.id)}
                   onOpenIssue={onOpenIssue}
-                  onToggleDone={(issue) => void toggleDone(issue)}
+                  onToggleDone={(issue) => toggleDone(issue)}
                 />
               );
             })
@@ -383,7 +383,7 @@ export default function TrackingDashboard({
             totalLabel={String(sections.inbox.length)}
             issues={sections.inbox}
             onOpenIssue={onOpenIssue}
-            onToggleDone={(issue) => void toggleDone(issue)}
+            onToggleDone={(issue) => toggleDone(issue)}
           />
         ) : null}
 
@@ -394,7 +394,7 @@ export default function TrackingDashboard({
             totalLabel={String(listIssues.length)}
             issues={listIssues}
             onOpenIssue={onOpenIssue}
-            onToggleDone={(issue) => void toggleDone(issue)}
+            onToggleDone={(issue) => toggleDone(issue)}
           />
         ) : null}
 


### PR DESCRIPTION
## Summary

- **S7735** — Remove unnecessary `void` operator in 3 GitHub components (`app/components/github/`) via `fix-void-operator.mjs` (wave 2 after `settings/sections` in #883).
- Batch targets 10 open Sonar issues across 4 files in `app/components/github/`; mechanical void removal applied to the 3 files that contained `void` expressions.

## Files changed

| File | Void removals |
|------|---------------|
| `app/components/github/GitHubView.tsx` | sync/init/focus/repo-select handlers |
| `app/components/github/IssueDetailPanel.tsx` | load effects + save/comment buttons |
| `app/components/github/TrackingDashboard.tsx` | submit form + toggleDone callbacks |

## Sonar keys (batch)

| Key | File |
|-----|------|
| `9c490a2f-2935-4d26-8a5c-79ed18eec965` | GitHubView.tsx |
| `764c3be5-fb05-4d8e-9c29-b9594fafe4c7` | IssueDetailPanel.tsx |
| `a23bcbbf-7a3c-4122-ad40-5414781841f2` | IssueDetailPanel.tsx |
| `31a39449-9618-4967-8457-5b6e6a3e147a` | IssueDetailPanel.tsx |
| `065ea4bf-34aa-4cd8-a269-90d26210d165` | IssueDetailPanel.tsx |
| `e4832ae1-50f0-4c6e-ad56-76cbd0168ea0` | IssueDetailPanel.tsx |
| `e1309fd0-39c1-487f-a139-4df9a82848d4` | TrackingDashboard.tsx |
| `19e1d2e8-4db5-4e9d-a53b-0425982cf21c` | TrackingObjectiveSection.tsx |
| `960ee83c-ec79-4574-a982-dc8ba4fc4ecc` | TrackingObjectiveSection.tsx |
| `234716f4-802a-425a-8180-dfe3eebead48` | TrackingObjectiveSection.tsx |

## Test plan

- [x] `pnpm run typecheck` passes locally
- [ ] CI typecheck + lint
- [ ] Sonar re-scan clears targeted void-operator issues