### PR TITLE
fix(sonar): prefer node: imports in electron/agents (S7772)

### DIFF
--- a/electron/agents/pipeline-report.cjs
+++ b/electron/agents/pipeline-report.cjs
@@ -15,7 +15,7 @@
  * pipeline-runner's onRunTerminal hook and only acts on report runs it started.
  */
 
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 const { serializeArtifactRecord } = require('../artifacts/artifact-serialize.cjs');
 const { afterArtifactMutation } = require('../artifacts/artifact-index-sync.cjs');
 const { buildReportHtml } = require('./report-markdown.cjs');

--- a/electron/agents/pipeline-service.cjs
+++ b/electron/agents/pipeline-service.cjs
@@ -7,7 +7,7 @@
  * (or by pipeline-runner for run-related transitions).
  */
 
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 const database = require('../core/database.cjs');
 const pipelineRunner = require('./pipeline-runner.cjs');
 const pipelineCalendarSync = require('./pipeline-calendar-sync.cjs');

--- a/electron/agents/run-engine.cjs
+++ b/electron/agents/run-engine.cjs
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 const { BrowserWindow } = require('electron');
-const { setMaxListeners } = require('events');
+const { setMaxListeners } = require('node:events');
 const approval = require('../ipc/agents/approval.cjs');
 // Single agent runtime: every agent turn runs through the Dome-native
 // `@dome/agent-core` loop (electron/agents/agent-runtime.cjs).

--- a/electron/agents/run-store.cjs
+++ b/electron/agents/run-store.cjs
@@ -6,7 +6,7 @@
  * run-engine.cjs re-exports this API unchanged.
  */
 
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 const { safeStringify } = require('../tools/tool-result-cap.cjs');
 
 const RUN_EVENT_CHANNEL = 'runs:updated';


### PR DESCRIPTION
## Summary
- Mechanical Sonar S7772 fix: use `node:` prefix for built-in module imports in `electron/agents/`.
- Files: `pipeline-report.cjs`, `pipeline-service.cjs`, `run-engine.cjs`, `run-store.cjs`.

## Test plan
- [ ] CI passes (no behavior change expected)