### PR TITLE
fix(sonar): S6439 leaked values + MindMap S3923

### DIFF
--- a/app/components/chat/ArtifactCard.tsx
+++ b/app/components/chat/ArtifactCard.tsx
@@ -505,7 +505,7 @@ function PDFSummaryContent({ artifact }: { artifact: PDFSummaryArtifact }) {
           {artifact.metadata.author && (
             <span><span className="font-semibold">{t('artifacts.author')}:</span> {artifact.metadata.author}</span>
           )}
-          {artifact.total_pages && (
+          {!!artifact.total_pages && (
             <span><span className="font-semibold">{t('artifacts.pages')}:</span> {artifact.total_pages}</span>
           )}
           <span><span className="font-semibold">{t('artifacts.characters')}:</span> {artifact.chars_extracted.toLocaleString()}</span>

--- a/app/components/home/ResourceCard.tsx
+++ b/app/components/home/ResourceCard.tsx
@@ -351,7 +351,7 @@ export default memo(function ResourceCard({
         </div>
       )}
 
-      {resource.updated_at && (
+      {!!resource.updated_at && (
         <div className="absolute top-2 right-2 px-1.5 py-0.5 rounded text-[10px] font-medium bg-[color-mix(in_srgb,var(--card)_90%,transparent)] text-muted-foreground shadow-sm backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
           {formatShortDistance(resource.updated_at)}
         </div>

--- a/app/components/studio/MindMap.tsx
+++ b/app/components/studio/MindMap.tsx
@@ -302,7 +302,7 @@ export default function MindMap({ data, title, onClose, onExport, onSelectedNode
                       fill="var(--card)"
                       stroke={color}
                       strokeWidth={isSelected ? 3 : 2}
-                      opacity={isSelected ? 1 : 1}
+                      opacity={1}
                     />
                     <foreignObject
                       x={x}


### PR DESCRIPTION
## Summary
- `ArtifactCard`: `!!artifact.total_pages` to avoid leaking `0` (S6439)
- `ResourceCard`: `!!resource.updated_at` (S6439)
- `MindMap`: remove identical `opacity={isSelected ? 1 : 1}` (S3923)

Closes #904

## Test plan
- [ ] Artifact cards with/without page counts render correctly
- [ ] Resource cards show updated badge on hover
- [ ] Mind map node selection still works