### PR TITLE
fix(sonar): mechanical S7735 void operator (orchestration)

### DIFF
--- a/app/components/chat/ChatComposerPlusMenu.tsx
+++ b/app/components/chat/ChatComposerPlusMenu.tsx
@@ -263,7 +263,8 @@ function PlusMenuSkillsList({ handlers }: { handlers: ChatComposerSkillsHandlers
 
   useEffect(() => {
     let cancelled = false;
-    void (async () => {
+
+    (async () => {
       const res = await listSkills();
       if (cancelled || !res.success || !Array.isArray(res.data)) {
         if (!cancelled) setSkills([]);

--- a/app/components/chat/ChatMessage.tsx
+++ b/app/components/chat/ChatMessage.tsx
@@ -395,7 +395,7 @@ export default function ChatMessage({
             <Button type="button" size="xs" onClick={handlePdfRegionCloudHandoff}>
               {t('viewer.pdf_region_qa_continue_many')}
             </Button>
-            <Button type="button" size="xs" variant="outline" onClick={() => void handlePdfRegionCopyHandoff()}>
+            <Button type="button" size="xs" variant="outline" onClick={() => handlePdfRegionCopyHandoff()}>
               {t('viewer.pdf_region_qa_copy_handoff')}
             </Button>
           </div>
@@ -419,7 +419,7 @@ export default function ChatMessage({
 
         {isUser && message.content ? (
           <MessageFooter className="gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-            <Button type="button" size="icon-xs" variant="ghost" onClick={() => void handleCopy()} title={t('chat.copy_message')}>
+            <Button type="button" size="icon-xs" variant="ghost" onClick={() => handleCopy()} title={t('chat.copy_message')}>
               <HugeiconsIcon icon={copied ? CheckmarkCircle02Icon : Copy01Icon} />
             </Button>
             <span className="text-xs tabular-nums text-muted-foreground">{formattedTime}</span>
@@ -428,7 +428,7 @@ export default function ChatMessage({
 
         {isAssistant && !message.isStreaming ? (
           <MessageFooter className="gap-0.5">
-            <Button type="button" size="icon-xs" variant="ghost" onClick={() => void handleCopy()} title={t('chat.copy_message')}>
+            <Button type="button" size="icon-xs" variant="ghost" onClick={() => handleCopy()} title={t('chat.copy_message')}>
               <HugeiconsIcon icon={copied ? CheckmarkCircle02Icon : Copy01Icon} />
             </Button>
             {onSaveAsNote && message.content ? (

--- a/app/components/chat/MarkdownRenderer.tsx
+++ b/app/components/chat/MarkdownRenderer.tsx
@@ -455,7 +455,7 @@ export default function MarkdownRenderer({ content, citationMap, onClickCitation
           e.stopPropagation();
           // External links: open via IPC so we don't navigate away from the app
           if (typeof href === 'string' && (href.startsWith('http://') || href.startsWith('https://'))) {
-            void handleOpenExternalUrl(href);
+            handleOpenExternalUrl(href);
           }
         };
 

--- a/app/components/orchestration/AutomationsStudioView.tsx
+++ b/app/components/orchestration/AutomationsStudioView.tsx
@@ -164,7 +164,8 @@ export default function AutomationsStudioView() {
   useEffect(() => {
     if (formMode === 'hidden') return;
     let cancelled = false;
-    void (async () => {
+
+    (async () => {
       try {
         const res = await window.electron?.artifacts?.list(projectId);
         if (cancelled) return;
@@ -490,7 +491,7 @@ export default function AutomationsStudioView() {
           isNew={formMode === 'new'}
           saving={saving}
           onDraftChange={(partial) => setDraft((prev) => ({ ...prev, ...partial }))}
-          onSave={() => void handleSave()}
+          onSave={() => handleSave()}
           onCancel={() => setFormMode('hidden')}
         />
       </div>
@@ -514,7 +515,7 @@ export default function AutomationsStudioView() {
                 accept=".json,application/json"
                 className="hidden"
                 aria-label={t('hubExport.import_automation')}
-                onChange={(e) => void handleImportFile(e)}
+                onChange={(e) => handleImportFile(e)}
                 disabled={importingBundle}
               />
               <Button
@@ -695,7 +696,7 @@ export default function AutomationsStudioView() {
                   <div className="flex shrink-0 items-center gap-1.5">
                     <Switch
                       checked={a.enabled}
-                      onCheckedChange={() => void handleToggleEnabled(a)}
+                      onCheckedChange={() => handleToggleEnabled(a)}
                       size="sm"
                       disabled={togglingId === a.id}
                       aria-label={t('orchestration.automations.toggle_enabled')}
@@ -703,7 +704,7 @@ export default function AutomationsStudioView() {
                     <Button
                       variant="outline"
                       disabled={running}
-                      onClick={() => void handleRun(a)}
+                      onClick={() => handleRun(a)}
                       size="xs"
                     >
                       {running ? (
@@ -726,7 +727,7 @@ export default function AutomationsStudioView() {
                       variant="ghost"
                       title={t('hubExport.export_automation')}
                       aria-label={t('hubExport.export_automation')}
-                      onClick={() => void handleExport(a)}
+                      onClick={() => handleExport(a)}
                       size="icon-xs"
                     >
                       <HugeiconsIcon icon={DownloadIcon} className="size-3.5 text-muted-foreground" />
@@ -765,7 +766,7 @@ export default function AutomationsStudioView() {
         variant="danger"
         confirmLabel={t('ui.delete')}
         cancelLabel={t('ui.cancel')}
-        onConfirm={() => void handleDelete()}
+        onConfirm={() => handleDelete()}
         onCancel={() => setDeleteTarget(null)}
       />
     </div>


### PR DESCRIPTION
## Summary
- Mechanical removal of unnecessary `void` operators via `fix-void-operator.mjs` (batch from `.quality-loop/sonar-s7735-now.json`, orchestration + chat supplement)
- 4 files touched: `AutomationsStudioView.tsx` (orchestration) + 3 chat components
- Formatting cleanup for async IIFE patterns after mechanical strip

## Sonar keys (batch)
| Key | File | Line |
|-----|------|------|
| bcb701e6-8b13-48a5-9e53-be14a2df3255 | AutomationEditor.tsx | 127 |
| a902f7af-9342-4ede-ac85-84b4fac44990 | AutomationEditor.tsx | 129 |
| adecac29-58a9-45c8-b004-a31b79243e79 | AutomationEditor.tsx | 246 |
| e2bd7172-c90d-483a-85dd-688ed6ab557c | AutomationEditor.tsx | 272 |
| 6b89e6aa-e7e8-4534-bce1-9ad430917c0b | AutomationEditor.tsx | 294 |
| e58781b4-5e55-48ef-be5b-f74584aafe5e | AutomationsStudioView.tsx | 277 |
| 34baa199-04cc-4a8b-accf-530daba348ff | ChatComposerPlusMenu.tsx | 399 |
| 122e1172-a66a-44ef-974d-ed6e543bcbf5 | ChatMessage.tsx | 295 |
| 0ca357a0-1d63-4937-b7e4-84500eecc980 | MarkdownRenderer.tsx | 216 |
| 6cc93e26-e798-4e6a-acd7-151c33e8e905 | MarkdownRenderer.tsx | 238 |
| 3da77914-4a95-48a0-82a6-828ee1f44d47 | MarkdownRenderer.tsx | 257 |

## Test plan
- [x] `tsc --noEmit` passes
- [ ] CI lint + typecheck
- [ ] Sonar re-analysis confirms void-operator S7735 resolved in touched files