### PR TITLE
feat(sonar): P-011 clean-code docs, agent rule, and CI guards

### DIFF
--- a/.claude/sops/pr-checklist.md
+++ b/.claude/sops/pr-checklist.md
@@ -27,6 +27,11 @@ Before every PR is considered ready, verify each item below.
 - [ ] Type-only imports use `import type { }` (verbatimModuleSyntax is on)
 - [ ] No `@ts-ignore` or `@ts-expect-error` without a comment explaining why
 
+## Sonar clean code (P-011)
+
+- [ ] No new anti-patterns from [docs/automation/sonar-clean-code.md](../../docs/automation/sonar-clean-code.md) (`void` in handlers, `.sort()`, `require('fs')` without `node:`, `postMessage('*')`, identical ternaries, etc.)
+- [ ] If this PR taught a new recurring Sonar lesson, update that doc + `scripts/check-sonar-patterns.mjs` + its tests
+
 ## Automated Checks
 
 CI will verify these automatically, but check locally first:
@@ -37,6 +42,11 @@ pnpm exec tsc --noEmit
 
 # Lint
 pnpm exec eslint app/
+
+# Sonar pattern guards (strict + progressive on diff)
+pnpm run check:sonar-patterns
+pnpm run check:sonar-patterns -- --diff=origin/main
+pnpm run test:sonar-patterns
 
 # Architecture: must return 0 results
 grep -rE "bun:|require('fs')\|require('better-sqlite3')" app/

--- a/.cursor/rules/no-void-operator.mdc
+++ b/.cursor/rules/no-void-operator.mdc
@@ -6,6 +6,8 @@ alwaysApply: false
 
 # No void operator in handlers
 
+Part of **P-011** — see [docs/automation/sonar-clean-code.md](docs/automation/sonar-clean-code.md) and `pnpm run check:sonar-patterns -- --diff=origin/main`.
+
 Sonar rule: remove unnecessary `void` in callbacks.
 
 **Sync handler** (returns void):

--- a/.cursor/rules/sonar-clean-code.mdc
+++ b/.cursor/rules/sonar-clean-code.mdc
@@ -1,0 +1,26 @@
+---
+description: Avoid Sonar anti-patterns learned from quality campaigns (P-011)
+alwaysApply: true
+---
+
+# Sonar clean code (P-011)
+
+Full table: [docs/automation/sonar-clean-code.md](docs/automation/sonar-clean-code.md). CI: `pnpm run check:sonar-patterns`.
+
+When writing or reviewing code, **do not introduce**:
+
+1. **`postMessage(..., '*')`** in app TS/TSX — use an explicit origin (`'null'` for opaque srcdoc frames).
+2. **`.sort()` with no compare** for strings/ids — use `localeCompare` or numeric comparator.
+3. **`=> void expr`** in handlers — see `no-void-operator.mdc`; prefer block + `.catch()` for async.
+4. **`require('fs'|'path'|'crypto'|…)`** in electron/shared — use `require('node:…')` (S7772).
+5. **`String(x) ??` / `Number(x) ??`** — left side is never nullish (S6638).
+6. **Identical ternary branches** `cond ? a : a` (S3923).
+7. **`{count && <Jsx/>}`** when `count` is a number — use `!!count` or `count > 0` (S6439).
+8. **`$1` in `.replace`** without a capturing group (S6328).
+9. **`font-weight` before `font:`** shorthand in CSS (S4657).
+
+Prefer `globalThis` / `globalThis.window` over bare `window` in the renderer (S7764).
+
+Do not “fix” Sonar SECURITY FPs (password in i18n keys, private IP allowlists) with insecure changes — Accept in Sonar with a comment.
+
+New recurring Sonar lessons → update `docs/automation/sonar-clean-code.md` + the checker + its tests in the same PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,17 @@ jobs:
       - name: Design system ratchet (hardcoded colors)
         run: pnpm run check:design-system
 
+      - name: Sonar clean-code patterns (P-011)
+        run: |
+          pnpm run test:sonar-patterns
+          # Strict rules always; on PRs also progressive rules on the diff
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            pnpm run check:sonar-patterns -- --diff="origin/${{ github.base_ref }}"
+          else
+            pnpm run check:sonar-patterns
+          fi
+
       - name: asarUnpack guard (native addons & bundled binaries)
         run: pnpm run check:asar-unpack
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Execution harness for AI agents (Cursor, Claude, Copilot, etc.).
 - **Tabs**: `useTabStore` — not extra Electron windows
 - **Embeddings** (main only): `electron/services/embeddings.service.cjs` — LangChain (OpenAI / Google / Ollama); settings `embeddings_*`
 
-Full rules: [docs/principles.md](docs/principles.md) · Architecture: [docs/architecture/README.md](docs/architecture/README.md) · New IPC: [.claude/sops/new-ipc-channel.md](.claude/sops/new-ipc-channel.md)
+Full rules: [docs/principles.md](docs/principles.md) · Architecture: [docs/architecture/README.md](docs/architecture/README.md) · New IPC: [.claude/sops/new-ipc-channel.md](.claude/sops/new-ipc-channel.md) · Sonar patterns (P-011): [docs/automation/sonar-clean-code.md](docs/automation/sonar-clean-code.md)
 
 ---
 
@@ -52,6 +52,8 @@ pnpm run typecheck
 pnpm run lint
 pnpm run build
 pnpm run check:ipc-inventory
+pnpm run check:sonar-patterns
+pnpm run check:sonar-patterns -- --diff=origin/main
 pnpm run depcruise
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,6 +354,7 @@ When replacing or rewriting a component, **never leave residual code behind**:
 5. **File paths**: Always use IPC handlers, never access filesystem directly from renderer
 6. **Native addons / bundled binaries**: Any new dep with a `.node` addon or a spawned executable MUST be added to `asarUnpack` (and `after-pack.cjs` `criticalModules`), and its path rewritten from `app.asar` → `app.asar.unpacked` before `spawn`. See **Build & Packaging → asarUnpack**. Forgetting this crashes the packaged app only (dev is fine).
 7. **Residual components**: no `*V2`/`*New` names, no deprecated alias re-exports, no dead variants — delete the old component before creating its replacement. See **Component Lifecycle — No Residual Code**.
+8. **Sonar regressions (P-011)**: do not reintroduce patterns in [docs/automation/sonar-clean-code.md](docs/automation/sonar-clean-code.md) (`void` in handlers, bare `.sort()`, `require('fs')` without `node:`, `postMessage('*')`, identical ternaries, etc.). Local/CI: `pnpm run check:sonar-patterns` and `pnpm run test:sonar-patterns`.
 
 ## File-based skills (Claude / Agent Skills)
 
@@ -370,6 +371,8 @@ Skills are **SKILL.md** files. Every agent (Many, agent-chat, agent-team, workfl
 - `.claude/rules/architecture-rules.md` — Critical architecture rules
 - `.claude/rules/electron-best-practices.md` — Electron patterns and security
 - `.claude/rules/dome-style-guide.md` — Code style (note: any legacy "Next.js" mention in that file may be outdated)
+- `docs/automation/sonar-clean-code.md` — Sonar anti-patterns (P-011) + CI guards
+- `.cursor/rules/sonar-clean-code.mdc` — always-on agent rule for the above
 
 ## Standard Operating Procedures (SOPs)
 

--- a/app/lib/many/stripForTts.ts
+++ b/app/lib/many/stripForTts.ts
@@ -4,7 +4,7 @@ export function stripForTts(text: string): string {
     text
       .replace(/```[\s\S]*?```/g, ' ')
       .replace(/`[^`]+`/g, ' ')
-      .replace(/\[[^\]]*]\([^)]*\)/g, '$1')
+      .replace(/\[[^\]]*]\([^)]*\)/g, ' ')
       .replace(/\*\*?|__/g, '')
       .replace(/^#+\s+/gm, '')
       .replace(/\n+/g, ' ')

--- a/docs/automation/sonar-clean-code.md
+++ b/docs/automation/sonar-clean-code.md
@@ -1,0 +1,155 @@
+# Sonar clean-code patterns (agent + CI)
+
+Patterns learned from SonarQube campaigns on `dome`. Agents **must** avoid introducing them. CI enforces a subset via `pnpm run check:sonar-patterns` (see [scripts/check-sonar-patterns.mjs](../../scripts/check-sonar-patterns.mjs)).
+
+Principle id: **P-011**. Cursor rule: [`.cursor/rules/sonar-clean-code.mdc`](../../.cursor/rules/sonar-clean-code.mdc).
+
+## Priority when fixing / reviewing
+
+1. SECURITY / BUG / VULNERABILITY  
+2. CRITICAL maintainability (cognitive complexity S3776) — only small/medium files  
+3. Mechanical debt (S7735, S7772, S7764) in focused batches  
+
+## Rules (do / don't)
+
+### S2819 — `postMessage` target origin
+
+| Bad | Good |
+|-----|------|
+| `win.postMessage(msg, '*')` | `win.postMessage(msg, artifactFrameTargetOrigin(src))` |
+
+Sandboxed artifact frames: use the frame URL origin, or `'null'` for opaque `srcdoc`. Prefer a shared helper (see `ArtifactWorkspaceClient`).
+
+**Allow:** messages inside generated iframe `srcdoc` HTML that talk to `window.parent` (opaque origin contract).
+
+### S2871 — `.sort()` without compare
+
+| Bad | Good |
+|-----|------|
+| `keys.sort()` | `keys.sort((a, b) => a.localeCompare(b))` |
+| `ids.sort()` (strings) | same |
+
+Numeric sorts: `(a, b) => a - b`. Never rely on default lexicographic sort for domain data.
+
+### S7735 — unnecessary `void`
+
+| Bad | Good |
+|-----|------|
+| `onClick={() => void save()}` | `onClick={() => { void save().catch(() => {}); }}` or sync call without `void` |
+
+See [`.cursor/rules/no-void-operator.mdc`](../../.cursor/rules/no-void-operator.mdc). Mechanical: `node scripts/sonar/fix-void-operator.mjs`.
+
+### S7772 — Node core imports
+
+In `electron/` / `shared/` CJS:
+
+| Bad | Good |
+|-----|------|
+| `require('fs')` | `require('node:fs')` |
+| `require('path')` | `require('node:path')` |
+| `require('crypto')` | `require('node:crypto')` |
+
+Same for `events`, `os`, `url`, `util`, `stream`, `buffer`, `child_process`, `worker_threads`, etc.
+
+### S7764 — `globalThis` vs `window` (renderer)
+
+Prefer `globalThis` / `globalThis.window` for Electron-safe access:
+
+```ts
+const win = globalThis.window;
+if (!win?.electron?.on) return;
+```
+
+Do **not** blindly rewrite Electron `main` process code.
+
+### S6638 — constant nullish / truthiness
+
+| Bad | Good |
+|-----|------|
+| `String(x) ?? null` | `String(x)` (or `x == null ? null : String(x)`) |
+| `Number(x) ?? 37214` | `Number(x) \|\| 37214` (or `Number.isFinite`) |
+| `0 && expr` / always-true `\|\|` | delete dead branch |
+
+### S3923 — identical branches
+
+| Bad | Good |
+|-----|------|
+| `cond ? 'local' : 'local'` | `'local'` |
+| `isSelected ? 1 : 1` | `1` |
+
+### S6439 — leaked values in JSX `&&`
+
+| Bad | Good |
+|-----|------|
+| `{count && <Badge />}` | `{!!count && <Badge />}` or `{count > 0 && …}` |
+
+Numbers (`0`) and some strings leak into the DOM.
+
+### S4822 — promises in `try` without `await`
+
+Await the promise inside `try`, or attach `.catch()` outside and do not wrap a floating promise in `try/catch` expecting rejection to be caught.
+
+### S6328 — regex replace groups
+
+Only use `$1` when the pattern has a capturing group:
+
+```ts
+// Bad: no group
+.replace(/\[[^\]]*]\([^)]*\)/g, '$1')
+// Good: capture label or drop links
+.replace(/\[([^\]]*)]\([^)]*\)/g, '$1')
+// or .replace(..., ' ')
+```
+
+### S4657 — CSS `font` shorthand
+
+Put longhand **after** shorthand if both are needed:
+
+```css
+font: inherit;
+font-weight: 500; /* after font */
+```
+
+### S3403 — absurd equality
+
+Do not compare with `===` / `!==` when types make the result always true/false. Coerce or use the correct operator (`==` only when intentional for nullish).
+
+### S1534 — duplicate object keys
+
+Never repeat the same key in an object literal; merge entries.
+
+### False positives (Accept in Sonar, do not “fix” insecurely)
+
+| Rule | Example | Action |
+|------|---------|--------|
+| S2068 | i18n key `weak_password`, env name `DOME_*_PASSWORD` | Accept + comment |
+| S1313 | Private IP ranges in SSRF allowlists (`url-guard`) | Accept + document |
+| S6440 | Helper named `useViteDevServer` in Electron (not a React hook) | Accept or rename without `use` prefix |
+
+### S3776 — cognitive complexity
+
+Extract helpers / early returns. **Defer** `migrations.cjs` and files &gt;1500 LOC to dedicated PRs. Max ~2 complexity issues per PR when heavy.
+
+## CI / local
+
+```bash
+# Full tree — strict (low-noise) rules
+pnpm run check:sonar-patterns
+
+# Only files changed vs main (strict + progressive rules)
+pnpm run check:sonar-patterns -- --diff=origin/main
+
+# Unit tests for the checker
+pnpm run test:sonar-patterns
+```
+
+CI (`Lint` job) runs both the full strict check and the diff progressive check on pull requests.
+
+## Extending this list
+
+When a Sonar batch teaches a new recurring pattern:
+
+1. Add a row here (bad / good).  
+2. Add a detector in `scripts/check-sonar-patterns.mjs` (prefer **diff** mode until backlog ≈ 0).  
+3. Add a fixture case in `scripts/__tests__/check-sonar-patterns.test.mjs`.  
+4. Mention the rule id in the PR that cleans the last occurrences if promoting to **strict**.

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -172,6 +172,17 @@ Tras merge a `main`:
 2. Confirmar stage *Agent fix (OpenCode)* verde y `verify-loop-diff.sh` sin falsos positivos
 3. PR auto-merge solo si CI pasa — **no confiar en auto-merge hasta 1 run verde**
 
+## Preventing regressions (P-011)
+
+Agents and CI share a living catalog of anti-patterns learned from Sonar batches:
+
+- [sonar-clean-code.md](./sonar-clean-code.md)
+- Cursor rule `.cursor/rules/sonar-clean-code.mdc` (`alwaysApply`)
+- `pnpm run check:sonar-patterns` (strict full-tree) + `--diff=origin/main` (progressive on PR)
+- `pnpm run test:sonar-patterns`
+
+When a batch discovers a new recurring smell, extend the doc + checker + tests in the same PR that fixes it.
+
 ## Quality Gate
 
 Ver [sonar-quality-gate.md](./sonar-quality-gate.md).

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -14,6 +14,7 @@ Cada regla tiene un id **P-NNN** que linters, CI y el auditor pueden citar en me
 | P-008  | Planes de trabajo no triviales en `docs/plans/active/` (versionado) |
 | P-009  | Política de merge con alto caudal (flaky, fix-forward, PRs pequeños) |
 | P-010  | Embeddings: proveedor LangChain solo en `embeddings.service.cjs` |
+| P-011  | Patrones Sonar: no reintroducir anti-patterns documentados |
 
 ## P-001 — Renderer nunca importa módulos Node/DB
 
@@ -59,3 +60,11 @@ Cambios complejos: plan en `docs/plans/active/<slug>.md` con frontmatter, antes 
 ## P-010 — Embeddings (LangChain)
 
 No duplicar lógica de embedding ni lectura de `embeddings_*` settings fuera de `electron/services/embeddings.service.cjs`. Para modelos Ollama cuyo id contiene `nomic`, el servicio añade los prefijos `search_document:` / `search_query:` al texto.
+
+## P-011 — Sonar clean code
+
+No reintroducir anti-patterns que ya limpiamos en campañas Sonar (void innecesario, `.sort()` sin compare, `require('fs')` sin `node:`, `postMessage('*')`, ternarios idénticos, `String(x) ??`, etc.).
+
+- Catálogo: [automation/sonar-clean-code.md](./automation/sonar-clean-code.md)
+- Regla Cursor: `.cursor/rules/sonar-clean-code.mdc`
+- CI: `pnpm run check:sonar-patterns` (+ `--diff` en PRs) y `pnpm run test:sonar-patterns`

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -158,7 +158,10 @@ if (process.platform !== 'win32') {
         // Fallback: add the latest installed NVM version
         const nvmVersionsDir = path.join(home, '.nvm', 'versions', 'node');
         if (fs.existsSync(nvmVersionsDir)) {
-          const versions = fs.readdirSync(nvmVersionsDir).sort().reverse();
+          const versions = fs
+            .readdirSync(nvmVersionsDir)
+            .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+            .reverse();
           if (versions.length > 0) {
             const nvmBin = path.join(nvmVersionsDir, versions[0], 'bin');
             if (!currentParts.includes(nvmBin)) currentParts.push(nvmBin);

--- a/electron/personality/personality-loader.cjs
+++ b/electron/personality/personality-loader.cjs
@@ -346,7 +346,7 @@ function getRecentMemory(days = 7) {
 
   const files = fs.readdirSync(memoryDir)
     .filter((f) => f.endsWith('.md'))
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
     .reverse()
     .slice(0, days);
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "check:asar-unpack": "node scripts/check-asar-unpack.cjs",
     "check:prompts-martin": "node scripts/check-no-martin-prompts.mjs",
     "check:prompt-tool-parity": "node scripts/check-prompt-tool-parity.mjs",
+    "check:sonar-patterns": "node scripts/check-sonar-patterns.mjs",
+    "test:sonar-patterns": "node --test scripts/__tests__/check-sonar-patterns.test.mjs",
     "test:many-thread-bridge": "tsx --test scripts/test-many-thread-bridge.mts",
     "test:streaming-snapshot": "tsx --test scripts/test-streaming-snapshot.mts",
     "test:execution-log-display": "tsx --test scripts/test-execution-log-display.mts",

--- a/scripts/__tests__/check-sonar-patterns.test.mjs
+++ b/scripts/__tests__/check-sonar-patterns.test.mjs
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for Sonar pattern detectors (P-011).
+ * Run: pnpm run test:sonar-patterns
+ */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import {
+  ALL_RULES,
+  PROGRESSIVE_RULES,
+  STRICT_RULES,
+  annotateLines,
+  scanFile,
+} from '../check-sonar-patterns.mjs';
+
+function writeTemp(name, content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sonar-pat-'));
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+describe('STRICT_RULES', () => {
+  it('flags String(...) ??', () => {
+    const file = writeTemp('a.ts', 'const x = String(id) ?? null;\n');
+    const hits = scanFile(file, STRICT_RULES);
+    assert.ok(hits.some((h) => h.id === 'string-nullish'));
+  });
+
+  it('flags .sort() without compare', () => {
+    const file = writeTemp('b.cjs', 'const a = list.sort();\n');
+    const hits = scanFile(file, STRICT_RULES);
+    assert.ok(hits.some((h) => h.id === 'sort-no-compare'));
+  });
+
+  it('allows .sort with localeCompare', () => {
+    const file = writeTemp('c.ts', "keys.sort((a, b) => a.localeCompare(b));\n");
+    const hits = scanFile(file, STRICT_RULES);
+    assert.equal(hits.filter((h) => h.id === 'sort-no-compare').length, 0);
+  });
+
+  it('flags $1 replace without capturing group', () => {
+    const file = writeTemp(
+      'd.ts',
+      "s.replace(/\\[[^\\]]*]\\([^)]*\\)/g, '$1');\n",
+    );
+    const hits = scanFile(file, STRICT_RULES);
+    assert.ok(hits.some((h) => h.id === 'replace-dollar-without-group'));
+  });
+
+  it('allows $1 when regex has a group', () => {
+    const file = writeTemp(
+      'e.ts',
+      "s.replace(/\\[([^\\]]*)]\\([^)]*\\)/g, '$1');\n",
+    );
+    const hits = scanFile(file, STRICT_RULES);
+    assert.equal(hits.filter((h) => h.id === 'replace-dollar-without-group').length, 0);
+  });
+});
+
+describe('PROGRESSIVE_RULES', () => {
+  it('flags void arrow', () => {
+    const file = writeTemp('f.tsx', 'onClick={() => void save()}\n');
+    const hits = scanFile(file, PROGRESSIVE_RULES);
+    assert.ok(hits.some((h) => h.id === 'void-arrow'));
+  });
+
+  it('flags require(fs) without node:', () => {
+    const file = writeTemp('g.cjs', "const fs = require('fs');\n");
+    // allowPath skips non-electron — simulate under electron via rewriting scan
+    // scanFile uses real path; put file content check via rule.test directly
+    const rule = PROGRESSIVE_RULES.find((r) => r.id === 'node-builtin-require');
+    assert.ok(rule.test("const fs = require('fs');", { rel: 'electron/x.cjs', lineNo: 1, line: '', inTemplate: false }));
+    assert.equal(rule.test("const fs = require('node:fs');", { rel: 'electron/x.cjs', lineNo: 1, line: '', inTemplate: false }), false);
+  });
+
+  it('flags identical ternary', () => {
+    const file = writeTemp('h.ts', 'const o = cond ? value : value;\nconst n = x ? 1 : 1;\n');
+    const hits = scanFile(file, PROGRESSIVE_RULES);
+    assert.ok(hits.some((h) => h.id === 'identical-ternary'));
+  });
+
+  it('flags numeric JSX && leak', () => {
+    const file = writeTemp('i.tsx', '{item.total_pages && (\n');
+    const hits = scanFile(file, PROGRESSIVE_RULES);
+    assert.ok(hits.some((h) => h.id === 'jsx-numeric-and'));
+  });
+
+  it('allows !!total_pages &&', () => {
+    const file = writeTemp('j.tsx', '{!!item.total_pages && (\n');
+    const hits = scanFile(file, PROGRESSIVE_RULES);
+    assert.equal(hits.filter((h) => h.id === 'jsx-numeric-and').length, 0);
+  });
+});
+
+describe('annotateLines', () => {
+  it('splits source into lines', () => {
+    const rows = annotateLines('const s = 1;\nconst y = 2;');
+    assert.ok(rows.length >= 2);
+    assert.equal(rows[0].lineNo, 1);
+    assert.equal(rows[1].lineNo, 2);
+  });
+});
+
+describe('rule catalog', () => {
+  it('exports unique rule ids', () => {
+    const ids = ALL_RULES.map((r) => r.id);
+    assert.equal(new Set(ids).size, ids.length);
+  });
+});

--- a/scripts/check-sonar-patterns.mjs
+++ b/scripts/check-sonar-patterns.mjs
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+/**
+ * Guard against Sonar anti-patterns (P-011).
+ *
+ * Usage:
+ *   node scripts/check-sonar-patterns.mjs              # strict rules, full tree
+ *   node scripts/check-sonar-patterns.mjs --diff=origin/main   # + progressive on changed files
+ *   node scripts/check-sonar-patterns.mjs --json        # machine-readable
+ *
+ * Docs: docs/automation/sonar-clean-code.md
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** @typedef {{ id: string; rule: string; tier: 'strict' | 'progressive'; message: string; test: (line: string, ctx: LineCtx) => boolean; allowPath?: (rel: string) => boolean }} PatternRule */
+/** @typedef {{ rel: string; lineNo: number; line: string; inTemplate: boolean }} LineCtx */
+
+const NODE_BUILTINS = [
+  'assert',
+  'buffer',
+  'child_process',
+  'cluster',
+  'crypto',
+  'dgram',
+  'dns',
+  'events',
+  'fs',
+  'fs/promises',
+  'http',
+  'http2',
+  'https',
+  'module',
+  'net',
+  'os',
+  'path',
+  'perf_hooks',
+  'process',
+  'querystring',
+  'readline',
+  'stream',
+  'string_decoder',
+  'timers',
+  'tls',
+  'tty',
+  'url',
+  'util',
+  'v8',
+  'vm',
+  'worker_threads',
+  'zlib',
+];
+
+const REQUIRE_BUILTIN_RE = new RegExp(
+  `require\\s*\\(\\s*['"](${NODE_BUILTINS.map((b) => b.replace('/', '\\/')).join('|')})['"]\\s*\\)`,
+);
+
+/** Paths where postMessage('*') is intentional (iframe srcdoc ↔ parent). */
+function allowPostMessageStar(rel) {
+  return (
+    rel.includes('artifact') ||
+    rel.endsWith('artifactIframeNavigate.ts') ||
+    rel.endsWith('HtmlArtifactFrame.tsx') ||
+    rel.endsWith('artifactStorageShim.ts')
+  );
+}
+
+/** @type {PatternRule[]} */
+export const STRICT_RULES = [
+  {
+    id: 'string-nullish',
+    rule: 'S6638',
+    tier: 'strict',
+    message: 'String(...) is never nullish — do not use ?? on it',
+    test: (line) => /String\s*\([^)]*\)\s*\?\?/.test(line),
+  },
+  {
+    id: 'number-nullish',
+    rule: 'S6638',
+    tier: 'strict',
+    message: 'Number(...) is never nullish — use || / Number.isFinite instead of ??',
+    test: (line) => /Number\s*\([^)]*\)\s*\?\?/.test(line),
+  },
+  {
+    id: 'sort-no-compare',
+    rule: 'S2871',
+    tier: 'strict',
+    message: 'Provide a compare function to .sort() (e.g. localeCompare)',
+    test: (line) => /\.sort\s*\(\s*\)/.test(line),
+  },
+  {
+    id: 'replace-dollar-without-group',
+    rule: 'S6328',
+    tier: 'strict',
+    message: 'Do not use $1 in replace when the regex has no capturing group',
+    test: (line) => {
+      if (!/\.replace\s*\(/.test(line) || !/'\$1'|"\$1"|`\$1`/.test(line)) return false;
+      // Heuristic: /.../ with $1 but no (...) group in the same literal
+      const m = line.match(/\.replace\s*\(\s*\/((?:\\.|[^/])*)\/[gimsuy]*\s*,\s*['"`]\$1['"`]/);
+      if (!m) return false;
+      const body = m[1];
+      // Has an unescaped capturing group?
+      if (/(^|[^\\])\((?!\?)/.test(body)) return false;
+      return true;
+    },
+  },
+];
+
+/** @type {PatternRule[]} */
+export const PROGRESSIVE_RULES = [
+  {
+    id: 'postMessage-star',
+    rule: 'S2819',
+    tier: 'progressive',
+    message: "Specify postMessage target origin (avoid '*')",
+    allowPath: allowPostMessageStar,
+    test: (line, ctx) => {
+      if (ctx.inTemplate) return false;
+      return /\.postMessage\s*\([\s\S]*?,\s*['"]\*['"]\s*\)/.test(line) ||
+        /postMessage\s*\([^)]*,\s*['"]\*['"]\s*\)/.test(line);
+    },
+  },
+  {
+    id: 'void-arrow',
+    rule: 'S7735',
+    tier: 'progressive',
+    message: 'Avoid unnecessary void in arrow callbacks (see no-void-operator.mdc)',
+    test: (line) => /=>\s*void\s+/.test(line),
+    allowPath: (rel) => rel.startsWith('electron/') || rel.startsWith('scripts/'),
+  },
+  {
+    id: 'node-builtin-require',
+    rule: 'S7772',
+    tier: 'progressive',
+    message: "Prefer require('node:…') for Node builtins",
+    test: (line) => REQUIRE_BUILTIN_RE.test(line),
+    allowPath: (rel) =>
+      !rel.startsWith('electron/') &&
+      !rel.startsWith('shared/') &&
+      !rel.startsWith('packages/'),
+  },
+  {
+    id: 'identical-ternary',
+    rule: 'S3923',
+    tier: 'progressive',
+    message: 'Identical ternary branches — simplify',
+    test: (line) =>
+      /\?\s*([a-zA-Z_$][\w.$]*|true|false|null|\d+(?:\.\d+)?)\s*:\s*\1\b/.test(line),
+  },
+  {
+    id: 'jsx-numeric-and',
+    rule: 'S6439',
+    tier: 'progressive',
+    message: 'Coerce numeric JSX guards (use !!n or n > 0) to avoid leaked 0',
+    test: (line) => /\{(?!!!)[a-zA-Z_$][\w.]*\.(?:total_pages|length|count|size|index)\s*&&/.test(line),
+  },
+];
+
+export const ALL_RULES = [...STRICT_RULES, ...PROGRESSIVE_RULES];
+
+const SCAN_ROOTS = ['app', 'electron', 'packages', 'shared'];
+const FILE_RE = /\.(?:tsx?|jsx?|mjs|cjs|css)$/;
+
+/**
+ * @param {string} dir
+ * @param {string[]} out
+ */
+function walk(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (
+      entry.name === 'node_modules' ||
+      entry.name === 'dist' ||
+      entry.name === 'vendor' ||
+      entry.name === 'coverage' ||
+      entry.name === '.git'
+    ) {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (FILE_RE.test(entry.name) && !/\.test\.[jt]sx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** @returns {string[]} absolute paths */
+export function collectScanFiles() {
+  const files = [];
+  for (const root of SCAN_ROOTS) {
+    walk(path.join(ROOT, root), files);
+  }
+  return files.filter((f) => {
+    const rel = path.relative(ROOT, f).split(path.sep).join('/');
+    return !rel.includes('/vendor/') && !rel.includes('/__tests__/') && !rel.includes('/test/');
+  });
+}
+
+/**
+ * @param {string} baseRef
+ * @returns {string[]} absolute paths of changed files that exist
+ */
+export function collectDiffFiles(baseRef) {
+  const out = execFileSync(
+    'git',
+    ['diff', '--name-only', '--diff-filter=ACMR', `${baseRef}...HEAD`],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  const rels = out
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return rels
+    .filter((rel) => FILE_RE.test(rel) && !/\.test\.[jt]sx?$/.test(rel))
+    .map((rel) => path.join(ROOT, rel))
+    .filter((abs) => fs.existsSync(abs));
+}
+
+/**
+ * Strip line comments and track crude template-literal state per line (not nested-perfect).
+ * @param {string} source
+ * @returns {Array<{ lineNo: number; line: string; inTemplate: boolean }>}
+ */
+export function annotateLines(source) {
+  /** @type {Array<{ lineNo: number; line: string; inTemplate: boolean }>} */
+  const rows = [];
+  let inTemplate = false;
+  const lines = source.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+    const trimmed = line.trim();
+    // skip full-line comments
+    if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+      rows.push({ lineNo: i + 1, line, inTemplate });
+      continue;
+    }
+    // crude template toggle on odd number of unescaped backticks
+    const ticks = line.match(/(?<!\\)`/g);
+    if (ticks && ticks.length % 2 === 1) inTemplate = !inTemplate;
+    rows.push({ lineNo: i + 1, line, inTemplate: inTemplate || (ticks ? ticks.length > 0 : false) });
+  }
+  return rows;
+}
+
+/**
+ * @param {string} absPath
+ * @param {PatternRule[]} rules
+ * @returns {Array<{ rel: string; line: number; id: string; rule: string; message: string; snippet: string }>}
+ */
+export function scanFile(absPath, rules) {
+  const rel = path.relative(ROOT, absPath).split(path.sep).join('/');
+  const source = fs.readFileSync(absPath, 'utf8');
+  const rows = annotateLines(source);
+  /** @type {Array<{ rel: string; line: number; id: string; rule: string; message: string; snippet: string }>} */
+  const hits = [];
+
+  for (const row of rows) {
+    const ctx = { rel, lineNo: row.lineNo, line: row.line, inTemplate: row.inTemplate };
+    for (const rule of rules) {
+      if (rule.allowPath?.(rel)) continue;
+      if (!rule.test(row.line, ctx)) continue;
+      hits.push({
+        rel,
+        line: row.lineNo,
+        id: rule.id,
+        rule: rule.rule,
+        message: rule.message,
+        snippet: row.line.trim().slice(0, 160),
+      });
+    }
+  }
+  return hits;
+}
+
+/**
+ * @param {{ files: string[]; rules: PatternRule[] }} opts
+ */
+export function runScan({ files, rules }) {
+  /** @type {ReturnType<typeof scanFile>} */
+  const violations = [];
+  for (const file of files) {
+    violations.push(...scanFile(file, rules));
+  }
+  return violations;
+}
+
+function parseArgs(argv) {
+  /** @type {{ diff: string | null; json: boolean }} */
+  const out = { diff: null, json: false };
+  for (const a of argv) {
+    if (a === '--json') out.json = true;
+    else if (a.startsWith('--diff=')) out.diff = a.slice('--diff='.length);
+    else if (a === '--diff') out.diff = 'origin/main';
+  }
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const strictFiles = collectScanFiles();
+  const strictHits = runScan({ files: strictFiles, rules: STRICT_RULES });
+
+  /** @type {ReturnType<typeof scanFile>} */
+  let progressiveHits = [];
+  if (args.diff) {
+    let diffFiles = [];
+    try {
+      diffFiles = collectDiffFiles(args.diff);
+    } catch (err) {
+      console.warn(`[check-sonar-patterns] git diff failed (${err.message}) — skipping progressive tier`);
+    }
+    progressiveHits = runScan({ files: diffFiles, rules: PROGRESSIVE_RULES });
+  }
+
+  const all = [...strictHits, ...progressiveHits];
+
+  if (args.json) {
+    process.stdout.write(
+      `${JSON.stringify({ strict: strictHits.length, progressive: progressiveHits.length, violations: all }, null, 2)}\n`,
+    );
+  } else {
+    if (all.length === 0) {
+      console.log(
+        `check-sonar-patterns: OK (strict on ${strictFiles.length} files` +
+          (args.diff ? `; progressive on diff vs ${args.diff}` : '') +
+          ')',
+      );
+    } else {
+      console.error('check-sonar-patterns: FAILED — Sonar anti-patterns (P-011)\n');
+      console.error('Docs: docs/automation/sonar-clean-code.md\n');
+      for (const v of all) {
+        console.error(`${v.rel}:${v.line} [${v.rule}/${v.id}] ${v.message}`);
+        console.error(`  ${v.snippet}`);
+      }
+      console.error(`\n${all.length} violation(s) (${strictHits.length} strict, ${progressiveHits.length} progressive)`);
+    }
+  }
+
+  process.exit(all.length > 0 ? 1 : 0);
+}
+
+const isMain =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  main();
+}

--- a/scripts/jenkins/verify-batch-pr.sh
+++ b/scripts/jenkins/verify-batch-pr.sh
@@ -12,6 +12,12 @@ pnpm run typecheck
 echo "=== verify-batch-pr: lint (renderer) ==="
 pnpm run lint
 
+echo "=== verify-batch-pr: sonar clean-code patterns (P-011) ==="
+pnpm run test:sonar-patterns
+# Strict full-tree only here (progressive --diff is enforced on GitHub PR CI;
+# quality-loop batches may touch files that still contain legacy void/node: debt).
+pnpm run check:sonar-patterns
+
 echo "=== verify-batch-pr: IPC inventory ==="
 if ! pnpm run check:ipc-inventory; then
   echo "ipc-channels.md out of date — regenerating (common after electron/ipc edits)..."


### PR DESCRIPTION
## Summary
- Add **P-011** catalog of Sonar anti-patterns learned from campaigns ([docs/automation/sonar-clean-code.md](docs/automation/sonar-clean-code.md))
- Always-on Cursor rule [`.cursor/rules/sonar-clean-code.mdc`](.cursor/rules/sonar-clean-code.mdc) so agents avoid regressions
- New checker `pnpm run check:sonar-patterns` (strict full-tree + progressive on PR `--diff`) with unit tests `pnpm run test:sonar-patterns`
- Wire into GitHub CI Lint job + Jenkins `verify-batch-pr`
- Clear remaining strict violations (`stripForTts` bad `$1`, bare `.sort()` in main/personality-loader)
- Update AGENTS.md, CLAUDE.md, principles, PR checklist, quality-loop docs

## How agents should extend this
When a Sonar batch teaches a new recurring smell → update the doc + checker + tests in the same PR.

## Test plan
- [x] `node --test scripts/__tests__/check-sonar-patterns.test.mjs`
- [x] `node scripts/check-sonar-patterns.mjs`
- [ ] CI Lint job green (new step)
- [ ] Spot-check that progressive `--diff` fails if a PR adds `=> void foo`