### PR TITLE
refactor(ui): unify centered modals under AppModal and ConfirmDialog

### DIFF
--- a/app/components/agents/AgentChatView.tsx
+++ b/app/components/agents/AgentChatView.tsx
@@ -31,7 +31,7 @@ import { UnifiedChatMessageArea } from '@/components/chat/UnifiedChatMessages';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { ArrowLeft01Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { loadMcpServersSetting } from '@/lib/mcp/settings';
 import { useTranslation } from 'react-i18next';
 import {
@@ -752,18 +752,16 @@ export default function AgentChatView({ agentId, onBack }: AgentChatViewProps) {
         onSetActiveStickySkill={setActiveStickySkillId}
       />
     </div>
-    <AlertDialog open={clearDialogOpen} onOpenChange={setClearDialogOpen}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{t('agent.clear_chat')}</AlertDialogTitle>
-          <AlertDialogDescription>{t('chat.clear_confirm')}</AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-          <AlertDialogAction variant="destructive" onClick={handleClear}>{t('agent.clear_chat')}</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <ConfirmDialog
+      isOpen={clearDialogOpen}
+      title={t('agent.clear_chat')}
+      message={t('chat.clear_confirm')}
+      confirmLabel={t('agent.clear_chat')}
+      cancelLabel={t('common.cancel')}
+      variant="danger"
+      onConfirm={handleClear}
+      onCancel={() => setClearDialogOpen(false)}
+    />
     </>
   );
 }

--- a/app/components/calendar/DayEventsModal.tsx
+++ b/app/components/calendar/DayEventsModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { HugeiconsIcon } from '@hugeicons/react';
-import { Add01Icon, CalendarDaysIcon, Clock01Icon } from '@hugeicons/core-free-icons';
+import { Add01Icon, Clock01Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Item, ItemContent, ItemDescription, ItemGroup, ItemMedia, ItemTitle } from '@/components/ui/item';
@@ -9,8 +9,14 @@ import { format } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 import type { CalendarEvent } from '@/lib/store/useCalendarStore';
 import { getDateFnsLocale, getDateTimeLocaleTag } from '@/lib/i18n';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 function formatEventTime(event: CalendarEvent, locale: string): string {
   if (event.all_day) return '';
   return new Date(event.start_at).toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' });
@@ -40,48 +46,60 @@ export default function DayEventsModal({
       : t('calendarPage.day_events_count_other', { count: events.length });
 
   return (
-    <Dialog open onOpenChange={(next) => { if (!next) (onClose)(); }}><DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-md"><DialogHeader className="flex shrink-0 flex-row items-center justify-between gap-3 border-b px-4 py-3"><div className="flex min-w-0 items-center gap-3">{<span className="inline-flex size-7 items-center justify-center rounded-md bg-primary/10 text-primary">
-          <HugeiconsIcon icon={CalendarDaysIcon} className="size-4" />
-        </span>}<div className="min-w-0"><DialogTitle className="truncate">{dayLabel}</DialogTitle>{subtitle ? <DialogDescription className="truncate">{subtitle}</DialogDescription> : null}</div></div></DialogHeader><div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-      <ItemGroup className="max-h-[min(420px,60vh)] gap-1.5 overflow-y-auto">
-        {events.map((event) => {
-          const time = formatEventTime(event, locale);
-          return (
-            <Item key={event.id} variant="outline" size="sm" render={<button type="button" className="h-auto justify-start text-left" />}
-                onClick={() => onEventClick(event)}
-              >
-                <ItemMedia><span className="size-2 rounded-full bg-primary" aria-hidden /></ItemMedia>
-                <ItemContent>
-                  <ItemTitle>
-                    {event.title || t('workspace.untitled')}
-                  </ItemTitle>
-                  <ItemDescription className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-                    {time ? (
-                      <span className="inline-flex items-center gap-1">
-                        <HugeiconsIcon icon={Clock01Icon} className="size-3" aria-hidden />
-                        {time}
-                      </span>
-                    ) : (
-                      <span>{t('calendarPage.all_day')}</span>
-                    )}
-                    {event.calendar_title ? (
-                      <Badge variant="secondary">{event.calendar_title}</Badge>
-                    ) : null}
-                  </ItemDescription>
-                </ItemContent>
-              </Item>
-          );
-        })}
-      </ItemGroup>
-    </div><DialogFooter className="border-t px-4 py-3">{<div className="flex items-center justify-between gap-2 w-full">
-          <Button variant="ghost"
-  onClick={onClose}>
+    <AppModal
+      open
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <AppModalContent size="md">
+        <AppModalHeader title={dayLabel} description={subtitle} />
+        <AppModalBody>
+          <ItemGroup className="max-h-[min(420px,60vh)] gap-1.5 overflow-y-auto">
+            {events.map((event) => {
+              const time = formatEventTime(event, locale);
+              return (
+                <Item
+                  key={event.id}
+                  variant="outline"
+                  size="sm"
+                  render={<button type="button" className="h-auto justify-start text-left" />}
+                  onClick={() => onEventClick(event)}
+                >
+                  <ItemMedia>
+                    <span className="size-2 rounded-full bg-primary" aria-hidden />
+                  </ItemMedia>
+                  <ItemContent>
+                    <ItemTitle>{event.title || t('workspace.untitled')}</ItemTitle>
+                    <ItemDescription className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                      {time ? (
+                        <span className="inline-flex items-center gap-1">
+                          <HugeiconsIcon icon={Clock01Icon} className="size-3" aria-hidden />
+                          {time}
+                        </span>
+                      ) : (
+                        <span>{t('calendarPage.all_day')}</span>
+                      )}
+                      {event.calendar_title ? (
+                        <Badge variant="secondary">{event.calendar_title}</Badge>
+                      ) : null}
+                    </ItemDescription>
+                  </ItemContent>
+                </Item>
+              );
+            })}
+          </ItemGroup>
+        </AppModalBody>
+        <AppModalFooter className="sm:justify-between">
+          <Button variant="outline" onClick={onClose}>
             {t('common.cancel')}
           </Button>
           <Button onClick={onCreateEvent}>
             <HugeiconsIcon icon={Add01Icon} className="size-3.5" />
             {t('calendarPage.new_event')}
           </Button>
-        </div>}</DialogFooter></DialogContent></Dialog>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/calendar/EventModal.tsx
+++ b/app/components/calendar/EventModal.tsx
@@ -37,17 +37,7 @@ import type { PipelineItem } from '@/lib/pipelines/types';
 import type { Resource } from '@/types';
 import { cn } from '@/lib/utils';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Field, FieldLabel } from '@/components/ui/field';
@@ -181,7 +171,7 @@ interface PipelineDetail {
   pipelineName: string | null;
 }
 
-/** Delete button with shadcn AlertDialog confirmation (replaces window.confirm). */
+/** Delete button with ConfirmDialog confirmation (replaces window.confirm). */
 function DeleteEventAction({
   deleting,
   onConfirm,
@@ -190,26 +180,30 @@ function DeleteEventAction({
   onConfirm: () => void;
 }) {
   const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
   return (
-    <AlertDialog>
-      <AlertDialogTrigger
-        render={
-          <Button variant="ghost" size="sm" className="mr-auto text-destructive" loading={deleting}>
-            {t('common.delete')}
-          </Button>
-        }
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="mr-auto text-destructive"
+        loading={deleting}
+        onClick={() => setOpen(true)}
+      >
+        {t('common.delete')}
+      </Button>
+      <ConfirmDialog
+        isOpen={open}
+        title={t('common.delete')}
+        message={t('calendarPage.delete_event_confirm')}
+        confirmLabel={t('common.delete')}
+        cancelLabel={t('common.cancel')}
+        variant="danger"
+        busy={deleting}
+        onConfirm={onConfirm}
+        onCancel={() => setOpen(false)}
       />
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{t('common.delete')}</AlertDialogTitle>
-          <AlertDialogDescription>{t('calendarPage.delete_event_confirm')}</AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm}>{t('common.delete')}</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    </>
   );
 }
 

--- a/app/components/cloud/CloudFilePicker.tsx
+++ b/app/components/cloud/CloudFilePicker.tsx
@@ -1,6 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import type { KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HugeiconsIcon } from '@hugeicons/react';
@@ -176,9 +182,13 @@ export default function CloudFilePicker({ onClose, projectId, folderId }: Props)
   };
 
   return (
-    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
-      <DialogContent className="flex h-[min(80vh,560px)] max-w-3xl flex-col overflow-hidden">
-        <DialogHeader><DialogTitle className="flex items-center gap-2"><HugeiconsIcon icon={CloudIcon} />{t('cloud.import_title', 'Import from Cloud')}</DialogTitle><DialogDescription>{t('cloud.import_description', 'Browse a connected account and import compatible documents into Dome.')}</DialogDescription></DialogHeader>
+    <AppModal open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <AppModalContent size="xl" className="h-[min(80vh,560px)] sm:max-w-3xl">
+        <AppModalHeader
+          title={t('cloud.import_title', 'Import from Cloud')}
+          description={t('cloud.import_description', 'Browse a connected account and import compatible documents into Dome.')}
+        />
+        <AppModalBody className="flex flex-col gap-0 p-0">
 
         {/* Account selector (if multiple) */}
         {accounts.length > 1 && (
@@ -318,22 +328,20 @@ export default function CloudFilePicker({ onClose, projectId, folderId }: Props)
                 </ItemGroup>
               )}
             </div>
-
-            {/* Footer */}
-            <DialogFooter className="items-center sm:justify-between">
-              <span className="text-xs text-muted-foreground">
-                {selectedAccount.email} · {files.filter((f) => !f.isFolder).length} archivos
-              </span>
-              <Button type="button"
-  variant="secondary"
-  onClick={onClose}
-  size="sm">
-                Cerrar
-              </Button>
-            </DialogFooter>
           </>
         )}
-      </DialogContent>
-    </Dialog>
+        </AppModalBody>
+        <AppModalFooter className="sm:justify-between">
+          <span className="text-xs text-muted-foreground">
+            {selectedAccount
+              ? `${selectedAccount.email} · ${files.filter((f) => !f.isFolder).length} archivos`
+              : null}
+          </span>
+          <Button type="button" variant="outline" onClick={onClose} size="sm">
+            Cerrar
+          </Button>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/editor/ResourcePickerModal.tsx
+++ b/app/components/editor/ResourcePickerModal.tsx
@@ -6,7 +6,12 @@ import ResourceIcon from '@/components/shared/ResourceIcon';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { useTranslation } from 'react-i18next';
 import ListState from '@/components/shared/ListState';
 function ResourceRowIcon({ type, title }: { type: ResourceType; title?: string }) {
@@ -84,42 +89,52 @@ export default function ResourcePickerModal({
   }, [opened, load, query]);
 
   return (
-    <Dialog open={opened} onOpenChange={(next) => { if (!next) (onClose)(); }}><DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-md"><DialogHeader className="flex shrink-0 flex-row items-center justify-between gap-3 border-b px-4 py-3"><div className="flex min-w-0 items-center gap-3"><div className="min-w-0"><DialogTitle className="truncate">{title}</DialogTitle></div></div></DialogHeader><div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-      <div className="flex flex-col gap-3">
-        <Input
-          placeholder="Buscar en la librería…"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-        />
-        <p className="text-xs text-muted-foreground">
-          {loading ? 'Buscando…' : `${items.length} resultado(s)`}
-        </p>
-        <ScrollArea className="h-[280px]">
-          <div className="flex flex-col gap-1 pr-2">
-            {items.map((r) => (
-              <button
-                key={r.id}
-                type="button"
-                onClick={() => {
-                  onSelect(r);
-                  onClose();
-                }}
-                className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left hover:bg-accent"
-              >
-                <ResourceRowIcon type={r.type} title={r.title} />
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-medium">{r.title || 'Sin título'}</p>
-                  <p className="truncate text-xs text-muted-foreground">{r.type}</p>
-                </div>
-              </button>
-            ))}
-            {error ? <ListState variant="error" errorMessage={error} compact /> : null}
-            {!loading && !error && items.length === 0 && (
-              <p className="py-4 text-center text-sm text-muted-foreground">Sin resultados</p>
-            )}
+    <AppModal
+      open={opened}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <AppModalContent size="md">
+        <AppModalHeader title={title} />
+        <AppModalBody>
+          <div className="flex flex-col gap-3">
+            <Input
+              placeholder="Buscar en la librería…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              {loading ? 'Buscando…' : `${items.length} resultado(s)`}
+            </p>
+            <ScrollArea className="h-[280px]">
+              <div className="flex flex-col gap-1 pr-2">
+                {items.map((r) => (
+                  <button
+                    key={r.id}
+                    type="button"
+                    onClick={() => {
+                      onSelect(r);
+                      onClose();
+                    }}
+                    className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left hover:bg-accent"
+                  >
+                    <ResourceRowIcon type={r.type} title={r.title} />
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">{r.title || 'Sin título'}</p>
+                      <p className="truncate text-xs text-muted-foreground">{r.type}</p>
+                    </div>
+                  </button>
+                ))}
+                {error ? <ListState variant="error" errorMessage={error} compact /> : null}
+                {!loading && !error && items.length === 0 && (
+                  <p className="py-4 text-center text-sm text-muted-foreground">Sin resultados</p>
+                )}
+              </div>
+            </ScrollArea>
           </div>
-        </ScrollArea>
-      </div>
-    </div></DialogContent></Dialog>
+        </AppModalBody>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/email/MailComposePanel.tsx
+++ b/app/components/email/MailComposePanel.tsx
@@ -4,16 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Field, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { Spinner } from '@/components/ui/spinner';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { InlineDetailCard } from '@/components/shared/InlineDetailCard';
 import EmailErrorNotice, { type EmailErrorInfo } from '@/components/email/EmailErrorNotice';
 import { useTranslation } from 'react-i18next';
@@ -302,22 +293,16 @@ export function MailComposePanel({
         </div>
       </InlineDetailCard>
 
-      <AlertDialog open={confirmDiscard} onOpenChange={setConfirmDiscard}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('email.compose')}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('common.unsaved_changes')}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-            <AlertDialogAction variant="destructive" onClick={onClose}>
-              {t('common.discard')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmDialog
+        isOpen={confirmDiscard}
+        title={t('email.compose')}
+        message={t('common.unsaved_changes')}
+        confirmLabel={t('common.discard')}
+        cancelLabel={t('common.cancel')}
+        variant="danger"
+        onConfirm={onClose}
+        onCancel={() => setConfirmDiscard(false)}
+      />
     </>
   );
 }

--- a/app/components/feeders/FeederApprovalModal.tsx
+++ b/app/components/feeders/FeederApprovalModal.tsx
@@ -10,7 +10,13 @@ import { Button } from '@/components/ui/button';
 import type { FeederRecord } from '@/lib/feeders/api';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 type Props = {
   feeder: FeederRecord | null;
   opened: boolean;
@@ -26,7 +32,10 @@ export default function FeederApprovalModal({ feeder, opened, onClose, onApprove
   const secretRefs = (feeder.envSecretRefs ?? []).filter((r) => r?.envName && r?.secretName);
 
   return (
-    <Dialog open={opened} onOpenChange={(next) => { if (!next) (onClose)(); }}><DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl"><DialogHeader className="flex shrink-0 flex-row items-center justify-between gap-3 border-b px-4 py-3"><div className="flex min-w-0 items-center gap-3"><div className="min-w-0"><DialogTitle className="truncate">{t('feeders.approve_title', { name: feeder.name })}</DialogTitle></div></div></DialogHeader><div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+    <AppModal open={opened} onOpenChange={(next) => { if (!next) onClose(); }}>
+      <AppModalContent size="xl">
+        <AppModalHeader title={t('feeders.approve_title', { name: feeder.name })} />
+        <AppModalBody>
       <div className="flex flex-col gap-4">
         {/* Metadata pills */}
         <div className="flex flex-wrap items-center gap-1.5">
@@ -86,13 +95,17 @@ export default function FeederApprovalModal({ feeder, opened, onClose, onApprove
           </pre>
         </div>
       </div>
-    </div><DialogFooter className="border-t px-4 py-3">{<>
-          <Button variant="ghost" onClick={onClose}>
+        </AppModalBody>
+        <AppModalFooter>
+          <Button variant="outline" onClick={onClose}>
             {t('common.cancel')}
           </Button>
-          <Button onClick={onApprove} loading={approving}>{<HugeiconsIcon icon={SecurityCheckIcon} className="size-4" />}
+          <Button onClick={onApprove} loading={approving}>
+            <HugeiconsIcon icon={SecurityCheckIcon} className="size-4" />
             {t('feeders.approve_action')}
           </Button>
-        </>}</DialogFooter></DialogContent></Dialog>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/feeders/SecretsManager.tsx
+++ b/app/components/feeders/SecretsManager.tsx
@@ -25,7 +25,13 @@ import { cn } from '@/lib/utils';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Input } from '@/components/ui/input';
 import { Field, FieldLabel, FieldDescription } from '@/components/ui/field';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 type Props = {
   opened: boolean;
   onClose: () => void;
@@ -119,7 +125,10 @@ export default function SecretsManager({ opened, onClose, initialName }: Props) 
   const canSave = name.trim().length > 0 && value.length > 0 && !saving;
 
   return (
-    <Dialog open={opened} onOpenChange={(next) => { if (!next) (onClose)(); }}><DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-md"><DialogHeader className="flex shrink-0 flex-row items-center justify-between gap-3 border-b px-4 py-3"><div className="flex min-w-0 items-center gap-3"><div className="min-w-0"><DialogTitle className="truncate">{t('feeders.secrets_title')}</DialogTitle></div></div></DialogHeader><div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+    <AppModal open={opened} onOpenChange={(next) => { if (!next) onClose(); }}>
+      <AppModalContent size="md">
+        <AppModalHeader title={t('feeders.secrets_title')} />
+        <AppModalBody>
       {!vaultAvailable ? (
         <Alert variant="destructive" role="note"><HugeiconsIcon icon={AlertCircleIcon} aria-hidden /><AlertTitle className="text-xs">{t('feeders.vault_unavailable_title', { defaultValue: 'Encrypted vault unavailable' })}</AlertTitle><AlertDescription className="text-xs">
           {t('feeders.vault_unavailable')}
@@ -240,8 +249,13 @@ export default function SecretsManager({ opened, onClose, initialName }: Props) 
           </div>
         </div>
       )}
-    </div><DialogFooter className="border-t px-4 py-3">{<Button variant="ghost" onClick={onClose}>
-          {t('common.close')}
-        </Button>}</DialogFooter></DialogContent></Dialog>
+        </AppModalBody>
+        <AppModalFooter>
+          <Button variant="outline" onClick={onClose}>
+            {t('common.close')}
+          </Button>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/home/ProjectsDashboard.tsx
+++ b/app/components/home/ProjectsDashboard.tsx
@@ -15,25 +15,22 @@ import { db, type Project, type Resource } from '@/lib/db/client';
 import { showToast } from '@/lib/store/useToastStore';
 import { useTranslation } from 'react-i18next';
 import { ProjectCard } from '@/components/home/projects/ProjectCard';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { PageHeader } from '@/components/shared/PageHeader';
 import { PageToolbar } from '@/components/shared/PageToolbar';
 
@@ -154,41 +151,80 @@ function CreateProjectDialog({
   const { t } = useTranslation();
 
   return (
-    <Dialog open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onReset(); else onOpenChange(true); }}>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>{t('projects.new_project')}</DialogTitle>
-          <DialogDescription>{t('projects.new_project_desc')}</DialogDescription>
-        </DialogHeader>
-        <form className="contents" onSubmit={(event) => { event.preventDefault(); onSubmit(); }}>
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="new-project-name">{t('projects.project_name')}</FieldLabel>
-              <Input id="new-project-name" value={name} onChange={(event) => onNameChange(event.target.value)} placeholder={t('projects.project_name_placeholder')} />
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="new-project-description">{t('projects.brief_description')}</FieldLabel>
-              <Textarea id="new-project-description" value={description} onChange={(event) => onDescriptionChange(event.target.value)} placeholder={t('projects.brief_description_placeholder')} />
-            </Field>
-            <Field>
-              <FieldLabel>{t('projects.vault_folder_label')}</FieldLabel>
-              <FieldDescription className="truncate">{vaultRoot || t('projects.vault_default_hint')}</FieldDescription>
-              <div className="flex flex-wrap gap-2">
-                <Button type="button" variant="outline" onClick={async () => { const dir = await window.electron?.selectFolder?.(); if (dir) onVaultRootChange(dir); }}>
-                  <HugeiconsIcon icon={Folder01Icon} data-icon="inline-start" />
-                  {vaultRoot ? t('projects.vault_change_folder') : t('projects.choose_vault_folder')}
-                </Button>
-                {vaultRoot ? <Button type="button" variant="ghost" onClick={() => onVaultRootChange('')}>{t('projects.vault_use_default')}</Button> : null}
-              </div>
-            </Field>
-          </FieldGroup>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={onReset}>{t('common.cancel')}</Button>
-            <Button type="submit" loading={creating} disabled={!name.trim()}>{t('projects.create_project')}</Button>
-          </DialogFooter>
+    <AppModal
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onReset();
+        else onOpenChange(true);
+      }}
+    >
+      <AppModalContent size="lg">
+        <AppModalHeader title={t('projects.new_project')} description={t('projects.new_project_desc')} />
+        <form
+          className="contents"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmit();
+          }}
+        >
+          <AppModalBody>
+            <FieldGroup>
+              <Field>
+                <FieldLabel htmlFor="new-project-name">{t('projects.project_name')}</FieldLabel>
+                <Input
+                  id="new-project-name"
+                  value={name}
+                  onChange={(event) => onNameChange(event.target.value)}
+                  placeholder={t('projects.project_name_placeholder')}
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="new-project-description">{t('projects.brief_description')}</FieldLabel>
+                <Textarea
+                  id="new-project-description"
+                  value={description}
+                  onChange={(event) => onDescriptionChange(event.target.value)}
+                  placeholder={t('projects.brief_description_placeholder')}
+                />
+              </Field>
+              <Field>
+                <FieldLabel>{t('projects.vault_folder_label')}</FieldLabel>
+                <FieldDescription className="truncate">
+                  {vaultRoot || t('projects.vault_default_hint')}
+                </FieldDescription>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      void window.electron?.selectFolder?.().then((dir) => {
+                        if (dir) onVaultRootChange(dir);
+                      });
+                    }}
+                  >
+                    <HugeiconsIcon icon={Folder01Icon} data-icon="inline-start" />
+                    {vaultRoot ? t('projects.vault_change_folder') : t('projects.choose_vault_folder')}
+                  </Button>
+                  {vaultRoot ? (
+                    <Button type="button" variant="ghost" onClick={() => onVaultRootChange('')}>
+                      {t('projects.vault_use_default')}
+                    </Button>
+                  ) : null}
+                </div>
+              </Field>
+            </FieldGroup>
+          </AppModalBody>
+          <AppModalFooter>
+            <Button type="button" variant="outline" onClick={onReset}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" loading={creating} disabled={!name.trim()}>
+              {t('projects.create_project')}
+            </Button>
+          </AppModalFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </AppModalContent>
+    </AppModal>
   );
 }
 
@@ -216,30 +252,55 @@ function EditProjectDialog({
   const { t } = useTranslation();
 
   return (
-    <Dialog open={Boolean(target)} onOpenChange={(open) => { if (!open) onClose(); }}>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>{t('common.edit', 'Editar')} {target?.name}</DialogTitle>
-          <DialogDescription>{t('projects.new_project_desc')}</DialogDescription>
-        </DialogHeader>
-        <form className="contents" onSubmit={(event) => { event.preventDefault(); onSubmit(); }}>
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="edit-project-name">{t('projects.project_name')}</FieldLabel>
-              <Input id="edit-project-name" value={name} onChange={(event) => onNameChange(event.target.value)} />
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="edit-project-description">{t('projects.brief_description')}</FieldLabel>
-              <Textarea id="edit-project-description" value={description} onChange={(event) => onDescriptionChange(event.target.value)} />
-            </Field>
-          </FieldGroup>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={onClose}>{t('common.cancel')}</Button>
-            <Button type="submit" loading={submitting} disabled={!name.trim()}>{t('common.save', 'Guardar')}</Button>
-          </DialogFooter>
+    <AppModal
+      open={Boolean(target)}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <AppModalContent size="lg">
+        <AppModalHeader
+          title={`${t('common.edit', 'Editar')} ${target?.name ?? ''}`}
+          description={t('projects.new_project_desc')}
+        />
+        <form
+          className="contents"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmit();
+          }}
+        >
+          <AppModalBody>
+            <FieldGroup>
+              <Field>
+                <FieldLabel htmlFor="edit-project-name">{t('projects.project_name')}</FieldLabel>
+                <Input
+                  id="edit-project-name"
+                  value={name}
+                  onChange={(event) => onNameChange(event.target.value)}
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="edit-project-description">{t('projects.brief_description')}</FieldLabel>
+                <Textarea
+                  id="edit-project-description"
+                  value={description}
+                  onChange={(event) => onDescriptionChange(event.target.value)}
+                />
+              </Field>
+            </FieldGroup>
+          </AppModalBody>
+          <AppModalFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" loading={submitting} disabled={!name.trim()}>
+              {t('common.save', 'Guardar')}
+            </Button>
+          </AppModalFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </AppModalContent>
+    </AppModal>
   );
 }
 
@@ -267,35 +328,52 @@ function DeleteProjectDialog({
   const { t } = useTranslation();
 
   return (
-    <AlertDialog open={Boolean(target)} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{t('projects.delete_critical_title')}</AlertDialogTitle>
-          <AlertDialogDescription>{t('projects.delete_critical_warning')} <strong>{target?.name}</strong></AlertDialogDescription>
-        </AlertDialogHeader>
-        <div className="rounded-2xl border border-dashed p-3 text-sm text-muted-foreground">
-          {impactLoading ? <Skeleton className="h-16" /> : (
-            <ul className="flex flex-col gap-1">
-              {DELETE_IMPACT_ORDER.map((key) => {
-                const count = impact?.[key] ?? 0;
-                return count > 0 ? <li key={key}>{t(`projects.delete_impact_${key}` as 'projects.delete_impact_resources')}: <span className="tabular-nums">{count}</span></li> : null;
-              })}
-            </ul>
-          )}
-        </div>
-        <Field data-invalid={Boolean(confirmName && confirmName !== target?.name)}>
-          <FieldLabel htmlFor="delete-project-confirm-input">{t('projects.delete_confirm_prompt')}</FieldLabel>
-          <Input id="delete-project-confirm-input" value={confirmName} onChange={(event) => onConfirmNameChange(event.target.value)} placeholder={t('projects.delete_confirm_placeholder')} autoComplete="off" />
-          {confirmName && confirmName !== target?.name ? <FieldDescription>{t('projects.delete_confirm_mismatch')}</FieldDescription> : null}
-        </Field>
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={submitting}>{t('common.cancel')}</AlertDialogCancel>
-          <AlertDialogAction variant="destructive" loading={submitting} disabled={impactLoading || confirmName !== target?.name} onClick={onDelete}>
-            {t('projects.delete_execute')}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <ConfirmDialog
+      isOpen={Boolean(target)}
+      title={t('projects.delete_critical_title')}
+      message={
+        <>
+          {t('projects.delete_critical_warning')} <strong>{target?.name}</strong>
+        </>
+      }
+      confirmLabel={t('projects.delete_execute')}
+      variant="danger"
+      busy={submitting}
+      confirmDisabled={impactLoading || confirmName !== target?.name}
+      onConfirm={onDelete}
+      onCancel={() => onOpenChange(false)}
+    >
+      <div className="rounded-2xl border border-dashed p-3 text-sm text-muted-foreground">
+        {impactLoading ? (
+          <Skeleton className="h-16" />
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {DELETE_IMPACT_ORDER.map((key) => {
+              const count = impact?.[key] ?? 0;
+              return count > 0 ? (
+                <li key={key}>
+                  {t(`projects.delete_impact_${key}` as 'projects.delete_impact_resources')}:{' '}
+                  <span className="tabular-nums">{count}</span>
+                </li>
+              ) : null;
+            })}
+          </ul>
+        )}
+      </div>
+      <Field data-invalid={Boolean(confirmName && confirmName !== target?.name)}>
+        <FieldLabel htmlFor="delete-project-confirm-input">{t('projects.delete_confirm_prompt')}</FieldLabel>
+        <Input
+          id="delete-project-confirm-input"
+          value={confirmName}
+          onChange={(event) => onConfirmNameChange(event.target.value)}
+          placeholder={t('projects.delete_confirm_placeholder')}
+          autoComplete="off"
+        />
+        {confirmName && confirmName !== target?.name ? (
+          <FieldDescription>{t('projects.delete_confirm_mismatch')}</FieldDescription>
+        ) : null}
+      </Field>
+    </ConfirmDialog>
   );
 }
 
@@ -320,21 +398,24 @@ function BulkDeleteProjectsDialog({
   const selectedProjects = projects.filter((project) => selectedIds.has(project.id) && project.id !== 'default');
 
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{t('projects.delete_critical_title')}</AlertDialogTitle>
-          <AlertDialogDescription>{t('projects.delete_critical_warning')}</AlertDialogDescription>
-        </AlertDialogHeader>
-        <div className="flex max-h-40 flex-col gap-2 overflow-y-auto">
-          {selectedProjects.map((project) => <Badge key={project.id} variant="outline">{project.name}</Badge>)}
-        </div>
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={submitting}>{t('common.cancel')}</AlertDialogCancel>
-          <AlertDialogAction variant="destructive" loading={submitting} onClick={onDelete}>{t('projects.delete_execute')}</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <ConfirmDialog
+      isOpen={open}
+      title={t('projects.delete_critical_title')}
+      message={t('projects.delete_critical_warning')}
+      confirmLabel={t('projects.delete_execute')}
+      variant="danger"
+      busy={submitting}
+      onConfirm={onDelete}
+      onCancel={() => onOpenChange(false)}
+    >
+      <div className="flex max-h-40 flex-col gap-2 overflow-y-auto">
+        {selectedProjects.map((project) => (
+          <Badge key={project.id} variant="outline">
+            {project.name}
+          </Badge>
+        ))}
+      </div>
+    </ConfirmDialog>
   );
 }
 

--- a/app/components/learn/DeckEditor.tsx
+++ b/app/components/learn/DeckEditor.tsx
@@ -7,10 +7,16 @@ import { showToast } from '@/lib/store/useToastStore';
 import type { FlashcardDeck } from '@/types';
 
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { Field, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Spinner } from '@/components/ui/spinner';
@@ -161,18 +167,28 @@ export default function DeckEditor({ onClose }: DeckEditorProps) {
 
   if (isLoading) {
     return (
-      <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
-        <DialogContent aria-busy="true"><DialogHeader><DialogTitle>{t('flashcard.edit_deck', 'Edit deck')}</DialogTitle><DialogDescription>{t('ui.loading', 'Loading')}</DialogDescription></DialogHeader><div className="flex justify-center py-12"><Spinner aria-label={t('ui.loading', 'Loading')} /></div>
-        </DialogContent>
-      </Dialog>
+      <AppModal open onOpenChange={(open) => { if (!open) onClose(); }}>
+        <AppModalContent size="xl" aria-busy>
+          <AppModalHeader title={t('flashcard.edit_deck', 'Edit deck')} description={t('ui.loading', 'Loading')} />
+          <AppModalBody>
+            <div className="flex justify-center py-12">
+              <Spinner aria-label={t('ui.loading', 'Loading')} />
+            </div>
+          </AppModalBody>
+        </AppModalContent>
+      </AppModal>
     );
   }
 
   return (
-    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
-      <DialogContent className="max-h-[85vh] w-full max-w-3xl overflow-hidden sm:max-w-3xl">
-        <DialogHeader><DialogTitle>{t('flashcard.edit_deck', 'Edit deck')}</DialogTitle><DialogDescription>{t('flashcard.edit_deck_hint', 'Update the title, description and cards.')}</DialogDescription></DialogHeader>
-        <div className="flex min-h-0 flex-col gap-5 overflow-y-auto pr-1">
+    <AppModal open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <AppModalContent size="xl" className="max-h-[85vh] sm:max-w-3xl">
+        <AppModalHeader
+          title={t('flashcard.edit_deck', 'Edit deck')}
+          description={t('flashcard.edit_deck_hint', 'Update the title, description and cards.')}
+        />
+        <AppModalBody>
+        <div className="flex min-h-0 flex-col gap-5 pr-1">
           {deck && (
             <FieldGroup>
               <Field><FieldLabel htmlFor="deck-editor-title">{t('flashcard.deck_title', 'Title')}</FieldLabel><Input
@@ -230,8 +246,9 @@ export default function DeckEditor({ onClose }: DeckEditorProps) {
             </Button>
           </section>
         </div>
+        </AppModalBody>
 
-        <DialogFooter>
+        <AppModalFooter>
             <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
               {t('learn.cancel', 'Cancel')}
             </Button>
@@ -239,9 +256,18 @@ export default function DeckEditor({ onClose }: DeckEditorProps) {
               {isSaving ? <Spinner data-icon="inline-start" /> : null}
               {t('flashcard.save_changes', 'Save changes')}
             </Button>
-        </DialogFooter>
-        <AlertDialog open={pendingRemove != null} onOpenChange={(open) => { if (!open) setPendingRemove(null); }}><AlertDialogContent><AlertDialogHeader><AlertDialogTitle>{t('flashcard.delete_card_confirm', 'Delete this card?')}</AlertDialogTitle><AlertDialogDescription>{pendingRemove != null ? cards[pendingRemove]?.question : ''}</AlertDialogDescription></AlertDialogHeader><AlertDialogFooter><AlertDialogCancel>{t('common.cancel', 'Cancel')}</AlertDialogCancel><AlertDialogAction variant="destructive" onClick={() => pendingRemove != null && void handleRemoveCard(pendingRemove)}>{t('ui.delete', 'Delete')}</AlertDialogAction></AlertDialogFooter></AlertDialogContent></AlertDialog>
-      </DialogContent>
-    </Dialog>
+        </AppModalFooter>
+        <ConfirmDialog
+          isOpen={pendingRemove != null}
+          title={t('flashcard.delete_card_confirm', 'Delete this card?')}
+          message={pendingRemove != null ? (cards[pendingRemove]?.question ?? '') : ''}
+          confirmLabel={t('ui.delete', 'Delete')}
+          cancelLabel={t('common.cancel', 'Cancel')}
+          variant="danger"
+          onConfirm={() => { if (pendingRemove != null) void handleRemoveCard(pendingRemove); }}
+          onCancel={() => setPendingRemove(null)}
+        />
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/learn/deck/DeckOverview.tsx
+++ b/app/components/learn/deck/DeckOverview.tsx
@@ -20,7 +20,7 @@ import TableView from '../table/TableView';
 import type { DeckSettings } from './DeckSettingsTab';
 import { computeQuizDeckStats } from '@/lib/learn/quizStats';
 import { flashcardStudyableCount, resolveFlashDeckId } from '@/lib/learn/deckItems';
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 
 export default function DeckOverview() {
   const { t } = useTranslation();
@@ -299,7 +299,16 @@ export default function DeckOverview() {
           onDelete={handleDelete}
         />
       ) : null}
-      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}><AlertDialogContent><AlertDialogHeader><AlertDialogTitle>{isFlashDeck ? t('flashcard.confirm_delete_deck', 'Delete this deck?') : t('content.confirm_delete_content', 'Delete this content?')}</AlertDialogTitle><AlertDialogDescription>{title}</AlertDialogDescription></AlertDialogHeader><AlertDialogFooter><AlertDialogCancel>{t('common.cancel', 'Cancel')}</AlertDialogCancel><AlertDialogAction variant="destructive" onClick={confirmDelete}>{t('ui.delete', 'Delete')}</AlertDialogAction></AlertDialogFooter></AlertDialogContent></AlertDialog>
+      <ConfirmDialog
+        isOpen={deleteOpen}
+        title={isFlashDeck ? t('flashcard.confirm_delete_deck', 'Delete this deck?') : t('content.confirm_delete_content', 'Delete this content?')}
+        message={title}
+        confirmLabel={t('ui.delete', 'Delete')}
+        cancelLabel={t('common.cancel', 'Cancel')}
+        variant="danger"
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteOpen(false)}
+      />
     </div>
   );
 }

--- a/app/components/learn/deck/DeckQuestionsTab.tsx
+++ b/app/components/learn/deck/DeckQuestionsTab.tsx
@@ -2,7 +2,13 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PencilIcon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/empty';
@@ -109,9 +115,10 @@ export default function DeckQuestionsTab({
       </ItemGroup>
 
       {editingId ? (
-        <Dialog open onOpenChange={(open) => { if (!open) setEditingId(null); }}>
-          <DialogContent>
-            <DialogHeader><DialogTitle>{t('learn.edit_question', 'Edit question')}</DialogTitle><DialogDescription>{t('learn.edit_question_description', 'Update the study content without changing its review history.')}</DialogDescription></DialogHeader>
+        <AppModal open onOpenChange={(open) => { if (!open) setEditingId(null); }}>
+          <AppModalContent size="sm">
+            <AppModalHeader title={t('learn.edit_question', 'Edit question')} description={t('learn.edit_question_description', 'Update the study content without changing its review history.')} />
+            <AppModalBody>
             <FieldGroup>
               <Field><FieldLabel htmlFor="learn-question">{t('flashcard.question', 'Question')}</FieldLabel><Textarea id="learn-question"
                   value={draftQuestion}
@@ -124,7 +131,8 @@ export default function DeckQuestionsTab({
                   /></Field>
               ) : null}
             </FieldGroup>
-            <DialogFooter>
+            </AppModalBody>
+            <AppModalFooter>
                 <Button type="button" variant="outline" onClick={() => setEditingId(null)}>
                   {t('learn.cancel', 'Cancel')}
                 </Button>
@@ -135,9 +143,9 @@ export default function DeckQuestionsTab({
                 >
                   {saving ? <Spinner data-icon="inline-start" /> : null}{t('ui.save', 'Save')}
                 </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+            </AppModalFooter>
+          </AppModalContent>
+        </AppModal>
       ) : null}
     </div>
   );

--- a/app/components/learn/generate/GenerateWizard.tsx
+++ b/app/components/learn/generate/GenerateWizard.tsx
@@ -1,6 +1,12 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 import { useLearnStore } from '@/lib/store/useLearnStore';
@@ -102,15 +108,16 @@ export default function GenerateWizard({ onClose }: GenerateWizardProps) {
   };
 
   return (
-    <Dialog open onOpenChange={(open) => { if (!open && !isGenerating) handleClose(); }}>
-      <DialogContent className="max-h-[85vh] w-full max-w-3xl overflow-hidden sm:max-w-3xl">
-        <DialogHeader>
-            <DialogTitle>{t('learn.generate_title', 'Generate content')}</DialogTitle>
-            <DialogDescription>{wizardHint}</DialogDescription>
-            {!showProgress ? <WizardStepper step={wizard.step} /> : null}
-        </DialogHeader>
+    <AppModal open onOpenChange={(open) => { if (!open && !isGenerating) handleClose(); }}>
+      <AppModalContent size="xl" className="max-h-[85vh] sm:max-w-3xl">
+        <AppModalHeader title={t('learn.generate_title', 'Generate content')} description={wizardHint} />
+        {!showProgress ? (
+          <div className="shrink-0 border-b px-4 pb-3">
+            <WizardStepper step={wizard.step} />
+          </div>
+        ) : null}
 
-        <div className="min-h-0 overflow-y-auto pr-1">
+        <AppModalBody>
           {showProgress ? (
             <GenerateProgressView progress={progress} onRetry={handleRetry} />
           ) : wizard.step === 0 ? (
@@ -124,10 +131,10 @@ export default function GenerateWizard({ onClose }: GenerateWizardProps) {
           ) : (
             <StepConfigure config={wizard.config} onChange={setWizardConfig} />
           )}
-        </div>
+        </AppModalBody>
 
         {!showProgress ? (
-          <DialogFooter className="items-center sm:justify-between">
+          <AppModalFooter className="sm:justify-between">
             <div className="text-xs text-muted-foreground">
               {wizard.step === 1
                 ? t('learn.source_selected_count', '{{count}} selected', { count: wizard.sourceIds.length })
@@ -150,9 +157,9 @@ export default function GenerateWizard({ onClose }: GenerateWizardProps) {
                 {isGenerating ? <Spinner data-icon="inline-start" /> : null}{wizard.step === 2 ? t('learn.generate_btn', 'Generate') : t('learn.next', 'Next')}
               </Button>
             </div>
-          </DialogFooter>
+          </AppModalFooter>
         ) : null}
-      </DialogContent>
-    </Dialog>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/learn/library/LearnLibrary.tsx
+++ b/app/components/learn/library/LearnLibrary.tsx
@@ -15,7 +15,7 @@ import LearnFilterBar from './LearnFilterBar';
 import LearnSection from './LearnSection';
 import LearnDeckCard from './LearnDeckCard';
 import LearnEmptyState from './LearnEmptyState';
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/empty';
 import type { LearnDeckItem } from '@/lib/learn/types';
 
@@ -201,9 +201,16 @@ export default function LearnLibrary() {
           </>
         )}
       </div>
-      <AlertDialog open={Boolean(pendingDelete)} onOpenChange={(open) => { if (!open) setPendingDelete(null); }}>
-        <AlertDialogContent><AlertDialogHeader><AlertDialogTitle>{pendingDelete?.kind === 'flashcard_deck' ? t('flashcard.confirm_delete_deck', 'Delete this deck?') : t('content.confirm_delete_content', 'Delete this content?')}</AlertDialogTitle><AlertDialogDescription>{pendingDelete?.title}</AlertDialogDescription></AlertDialogHeader><AlertDialogFooter><AlertDialogCancel>{t('common.cancel', 'Cancel')}</AlertDialogCancel><AlertDialogAction variant="destructive" onClick={confirmDelete}>{t('ui.delete', 'Delete')}</AlertDialogAction></AlertDialogFooter></AlertDialogContent>
-      </AlertDialog>
+      <ConfirmDialog
+        isOpen={Boolean(pendingDelete)}
+        title={pendingDelete?.kind === 'flashcard_deck' ? t('flashcard.confirm_delete_deck', 'Delete this deck?') : t('content.confirm_delete_content', 'Delete this content?')}
+        message={pendingDelete?.title ?? ''}
+        confirmLabel={t('ui.delete', 'Delete')}
+        cancelLabel={t('common.cancel', 'Cancel')}
+        variant="danger"
+        onConfirm={confirmDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
     </div>
   );
 }

--- a/app/components/notes/NoteQuickTagModal.tsx
+++ b/app/components/notes/NoteQuickTagModal.tsx
@@ -3,7 +3,14 @@ import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { Input } from '@/components/ui/input';
 import { Field, FieldLabel } from '@/components/ui/field';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
+
 interface NoteQuickTagModalProps {
   opened: boolean;
   onClose: () => void;
@@ -43,40 +50,46 @@ export default function NoteQuickTagModal({
   };
 
   return (
-    <Dialog open={opened} onOpenChange={(next) => { if (!next) (onClose)(); }}><DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-sm"><DialogHeader className="flex shrink-0 flex-row items-center justify-between gap-3 border-b px-4 py-3"><div className="flex min-w-0 items-center gap-3"><div className="min-w-0"><DialogTitle className="truncate">{t('notes.quick_tag_title')}</DialogTitle></div></div></DialogHeader><div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-      <Field className="gap-1.5">
-        <FieldLabel htmlFor="note-quick-tag" className="text-xs">{t('notes.quick_tag_label')}</FieldLabel>
-        <Input
-          id="note-quick-tag"
-          placeholder={t('notes.quick_tag_placeholder')}
-          value={name}
-          disabled={busy}
-          onChange={(e) => setName(e.currentTarget.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              void submit();
-            }
-          }}
-          // Focus the single input of a just-opened quick modal (expected UX).
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus
-        />
-      </Field>
-    </div><DialogFooter className="border-t px-4 py-3">{<>
-          <Button type="button"
-  variant="ghost"
-  onClick={onClose}
-  disabled={busy}
-  size="sm">
+    <AppModal
+      open={opened}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <AppModalContent size="sm">
+        <AppModalHeader title={t('notes.quick_tag_title')} />
+        <AppModalBody>
+          <Field className="gap-1.5">
+            <FieldLabel htmlFor="note-quick-tag" className="text-xs">
+              {t('notes.quick_tag_label')}
+            </FieldLabel>
+            <Input
+              id="note-quick-tag"
+              placeholder={t('notes.quick_tag_placeholder')}
+              value={name}
+              disabled={busy}
+              onChange={(e) => setName(e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  void submit();
+                }
+              }}
+              // Focus the single input of a just-opened quick modal (expected UX).
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus
+            />
+          </Field>
+        </AppModalBody>
+        <AppModalFooter>
+          <Button type="button" variant="outline" onClick={onClose} disabled={busy} size="sm">
             {t('common.cancel')}
           </Button>
-          <Button type="button"
-  loading={busy}
-  onClick={() => void submit()}
-  size="sm">
+          <Button type="button" loading={busy} onClick={() => void submit()} size="sm">
             {t('notes.quick_tag_save')}
           </Button>
-        </>}</DialogFooter></DialogContent></Dialog>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/onboarding/SectionOnboardingCard.tsx
+++ b/app/components/onboarding/SectionOnboardingCard.tsx
@@ -2,10 +2,16 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { HelpCircleIcon, SparklesIcon } from '@hugeicons/core-free-icons';
+import { HelpCircleIcon } from '@hugeicons/core-free-icons';
 import { getSectionGuide } from '@/lib/onboarding/sectionGuides';
 import { useSectionTourStore } from '@/lib/store/useSectionTourStore';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 interface SectionGuideProps {
   sectionKey: string;
   className?: string;
@@ -53,11 +59,24 @@ function SectionGuideModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={(next) => { if (!next) (onClose)(); }}><DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-sm"><DialogHeader className="flex shrink-0 flex-row items-center justify-between gap-3 border-b px-4 py-3"><div className="flex min-w-0 items-center gap-3">{<HugeiconsIcon icon={SparklesIcon} className="size-4 shrink-0 text-primary" />}<div className="min-w-0"><DialogTitle className="truncate">{t(guide.titleKey)}</DialogTitle></div></div></DialogHeader><div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-      <SectionGuideSteps sectionKey={sectionKey} />
-    </div><DialogFooter className="border-t px-4 py-3">{<Button type="button" onClick={handleGotIt} size="sm">
-          {t('sectionGuide.got_it')}
-        </Button>}</DialogFooter></DialogContent></Dialog>
+    <AppModal
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <AppModalContent size="sm">
+        <AppModalHeader title={t(guide.titleKey)} />
+        <AppModalBody>
+          <SectionGuideSteps sectionKey={sectionKey} />
+        </AppModalBody>
+        <AppModalFooter>
+          <Button type="button" onClick={handleGotIt} size="sm">
+            {t('sectionGuide.got_it')}
+          </Button>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }
 

--- a/app/components/pipelines/CardDetailModal.tsx
+++ b/app/components/pipelines/CardDetailModal.tsx
@@ -22,17 +22,7 @@ import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger , DropdownMenuGroup } from '@/components/ui/dropdown-menu';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import type { ReactNode } from 'react';
 interface TodoItem {
   id: string;
@@ -222,6 +212,7 @@ export default function CardDetailModal({
   const [launching, setLaunching] = useState(false);
   const [tab, setTab] = useState<DetailTab>('details');
   const [editing, setEditing] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const [events, setEvents] = useState<PipelineItemEvent[]>([]);
   const [eventsLoading, setEventsLoading] = useState(false);
   const [eventsReloadKey, setEventsReloadKey] = useState(0);
@@ -468,28 +459,15 @@ export default function CardDetailModal({
 
   const footer = editing ? (
     <div className="flex w-full flex-wrap items-center gap-2">
-      <AlertDialog>
-        <AlertDialogTrigger
-          render={
-            <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive" />
-          }
-        >
-          <HugeiconsIcon icon={Delete02Icon} data-icon="inline-start" />
-          {t('pipelines.delete')}
-        </AlertDialogTrigger>
-        <AlertDialogContent size="sm">
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('pipelines.delete')}</AlertDialogTitle>
-            <AlertDialogDescription>{item.title}</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t('pipelines.cancel')}</AlertDialogCancel>
-            <AlertDialogAction variant="destructive" onClick={() => void onDelete()}>
-              {t('pipelines.delete')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-destructive hover:text-destructive"
+        onClick={() => setConfirmDelete(true)}
+      >
+        <HugeiconsIcon icon={Delete02Icon} data-icon="inline-start" />
+        {t('pipelines.delete')}
+      </Button>
       <div className="min-w-2 flex-1" />
       <Button variant="outline" size="sm" onClick={() => setEditing(false)}>
         {t('pipelines.cancel')}
@@ -532,28 +510,15 @@ export default function CardDetailModal({
     </div>
   ) : (
     <div className="flex w-full flex-wrap items-center gap-2">
-      <AlertDialog>
-        <AlertDialogTrigger
-          render={
-            <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive" />
-          }
-        >
-          <HugeiconsIcon icon={Delete02Icon} data-icon="inline-start" />
-          {t('pipelines.delete')}
-        </AlertDialogTrigger>
-        <AlertDialogContent size="sm">
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('pipelines.delete')}</AlertDialogTitle>
-            <AlertDialogDescription>{item.title}</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t('pipelines.cancel')}</AlertDialogCancel>
-            <AlertDialogAction variant="destructive" onClick={() => void onDelete()}>
-              {t('pipelines.delete')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-destructive hover:text-destructive"
+        onClick={() => setConfirmDelete(true)}
+      >
+        <HugeiconsIcon icon={Delete02Icon} data-icon="inline-start" />
+        {t('pipelines.delete')}
+      </Button>
       <div className="min-w-2 flex-1" />
       <Button variant="outline" size="sm" onClick={() => setEditing(true)}>
         <HugeiconsIcon icon={PencilIcon} data-icon="inline-start" />
@@ -914,14 +879,29 @@ export default function CardDetailModal({
   }
 
   return (
-    <InlineDetailCard
-      onClose={onClose}
-      title={headerTitle}
-      badges={badgeLabel ? <ColorPill>{badgeLabel}</ColorPill> : undefined}
-      footer={footer}
-      containerName="pipeline-card"
-    >
-      {body}
-    </InlineDetailCard>
+    <>
+      <InlineDetailCard
+        onClose={onClose}
+        title={headerTitle}
+        badges={badgeLabel ? <ColorPill>{badgeLabel}</ColorPill> : undefined}
+        footer={footer}
+        containerName="pipeline-card"
+      >
+        {body}
+      </InlineDetailCard>
+      <ConfirmDialog
+        isOpen={confirmDelete}
+        title={t('pipelines.delete')}
+        message={item.title}
+        confirmLabel={t('pipelines.delete')}
+        cancelLabel={t('pipelines.cancel')}
+        variant="danger"
+        onConfirm={() => {
+          void onDelete();
+          setConfirmDelete(false);
+        }}
+        onCancel={() => setConfirmDelete(false)}
+      />
+    </>
   );
 }

--- a/app/components/pipelines/DataSourcePanel.tsx
+++ b/app/components/pipelines/DataSourcePanel.tsx
@@ -5,17 +5,7 @@ import { HugeiconsIcon, type IconSvgElement } from '@hugeicons/react';
 import { DatabaseIcon, Delete02Icon, FileSpreadsheetIcon, HandIcon, Loading03Icon, PlusSignIcon, RefreshIcon, SparklesIcon } from '@hugeicons/core-free-icons';
 import type { CreateSourceInput, PipelineSource, PipelineStage, SourceType } from '@/lib/pipelines/types';
 import SourceConfigModal from './SourceConfigModal';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 
 const SOURCE_ICON: Record<SourceType, IconSvgElement> = {
   internal_resources: DatabaseIcon,
@@ -37,6 +27,7 @@ export default function DataSourcePanel({ sources, stages, onCreate, onSync, onD
   const { t } = useTranslation();
   const [adding, setAdding] = useState(false);
   const [syncingId, setSyncingId] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null);
 
   const sourceLabel = (s: SourceType) =>
     t(`pipelines.source_${s === 'internal_resources' ? 'internal' : s}`);
@@ -82,22 +73,15 @@ export default function DataSourcePanel({ sources, stages, onCreate, onSync, onD
                 <span className="text-sm flex-1 truncate text-foreground">
                   {s.name}
                 </span>
-                <AlertDialog>
-                  <AlertDialogTrigger render={<Button type="button" variant="ghost" size="icon-xs" />}>
-                    <HugeiconsIcon icon={Delete02Icon} className="text-destructive" />
-                    <span className="sr-only">{t('pipelines.delete')}</span>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent size="sm">
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>{t('pipelines.delete')}</AlertDialogTitle>
-                      <AlertDialogDescription>{s.name}</AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>{t('pipelines.cancel')}</AlertDialogCancel>
-                      <AlertDialogAction variant="destructive" onClick={() => void onDelete(s.id)}>{t('pipelines.delete')}</AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => setPendingDelete({ id: s.id, name: s.name })}
+                >
+                  <HugeiconsIcon icon={Delete02Icon} className="text-destructive" />
+                  <span className="sr-only">{t('pipelines.delete')}</span>
+                </Button>
               </div>
               <span className="text-[10px] text-muted-foreground">
                 {sourceLabel(s.sourceType)}
@@ -131,6 +115,20 @@ export default function DataSourcePanel({ sources, stages, onCreate, onSync, onD
       {adding && (
         <SourceConfigModal stages={stages} onClose={() => setAdding(false)} onCreate={onCreate} />
       )}
+
+      <ConfirmDialog
+        isOpen={Boolean(pendingDelete)}
+        title={t('pipelines.delete')}
+        message={pendingDelete?.name ?? ''}
+        confirmLabel={t('pipelines.delete')}
+        cancelLabel={t('pipelines.cancel')}
+        variant="danger"
+        onConfirm={() => {
+          if (pendingDelete) void onDelete(pendingDelete.id);
+          setPendingDelete(null);
+        }}
+        onCancel={() => setPendingDelete(null)}
+      />
     </div>
   );
 }

--- a/app/components/pipelines/PipelinesBoard.tsx
+++ b/app/components/pipelines/PipelinesBoard.tsx
@@ -20,23 +20,13 @@ import { askStudioMany } from '@/components/studio-hub';
 import { HubHeader, HubPageHeader } from '@/components/hub';
 
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue , SelectGroup } from '@/components/ui/select';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator , DropdownMenuGroup } from '@/components/ui/dropdown-menu';
@@ -425,50 +415,47 @@ export default function PipelinesBoard() {
         )}
       </div>
 
-      <AlertDialog open={confirmDelete && Boolean(activePipeline)} onOpenChange={setConfirmDelete}>
-        <AlertDialogContent size="sm">
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('pipelines.delete')}</AlertDialogTitle>
-            <AlertDialogDescription>{t('pipelines.confirm_delete_pipeline')}</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={busy}>{t('pipelines.cancel')}</AlertDialogCancel>
-            <AlertDialogAction
-              variant="destructive"
-              disabled={busy}
-              onClick={() => void handleDelete()}
-            >
-              {t('pipelines.delete')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmDialog
+        isOpen={confirmDelete && Boolean(activePipeline)}
+        title={t('pipelines.delete')}
+        message={t('pipelines.confirm_delete_pipeline')}
+        confirmLabel={t('pipelines.delete')}
+        cancelLabel={t('pipelines.cancel')}
+        variant="danger"
+        busy={busy}
+        onConfirm={() => {
+          void handleDelete();
+        }}
+        onCancel={() => setConfirmDelete(false)}
+      />
 
-      <Dialog open={creatingPipeline} onOpenChange={setCreatingPipeline}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t('pipelines.new_pipeline')}</DialogTitle>
-            <DialogDescription>{t('pipelines.pipeline_name_placeholder')}</DialogDescription>
-          </DialogHeader>
-          <Input
-            value={newName}
-            onChange={(event) => setNewName(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') void handleCreatePipeline();
-            }}
-            placeholder={t('pipelines.pipeline_name_placeholder')}
-            aria-label={t('pipelines.pipeline_name_placeholder')}
+      <AppModal open={creatingPipeline} onOpenChange={setCreatingPipeline}>
+        <AppModalContent size="sm">
+          <AppModalHeader
+            title={t('pipelines.new_pipeline')}
+            description={t('pipelines.pipeline_name_placeholder')}
           />
-          <DialogFooter>
+          <AppModalBody>
+            <Input
+              value={newName}
+              onChange={(event) => setNewName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') void handleCreatePipeline();
+              }}
+              placeholder={t('pipelines.pipeline_name_placeholder')}
+              aria-label={t('pipelines.pipeline_name_placeholder')}
+            />
+          </AppModalBody>
+          <AppModalFooter>
             <Button variant="outline" onClick={() => setCreatingPipeline(false)}>
               {t('pipelines.cancel')}
             </Button>
             <Button onClick={() => void handleCreatePipeline()} disabled={!newName.trim()}>
               {t('pipelines.create')}
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </AppModalFooter>
+        </AppModalContent>
+      </AppModal>
     </div>
   );
 }

--- a/app/components/pipelines/SourceConfigModal.tsx
+++ b/app/components/pipelines/SourceConfigModal.tsx
@@ -4,13 +4,12 @@ import { useTranslation } from 'react-i18next';
 import type { CreateSourceInput, PipelineStage, SourceType } from '@/lib/pipelines/types';
 
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue , SelectGroup } from '@/components/ui/select';
 import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
@@ -60,12 +59,10 @@ export default function SourceConfigModal({ stages, onClose, onCreate }: Props) 
     t(`pipelines.source_${s === 'internal_resources' ? 'internal' : s}`);
 
   return (
-    <Dialog open onOpenChange={(next) => { if (!next) onClose(); }}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t('pipelines.add_source')}</DialogTitle>
-          <DialogDescription>{t('pipelines.source_type')}</DialogDescription>
-        </DialogHeader>
+    <AppModal open onOpenChange={(next) => { if (!next) onClose(); }}>
+      <AppModalContent size="sm">
+        <AppModalHeader title={t('pipelines.add_source')} description={t('pipelines.source_type')} />
+        <AppModalBody>
       <div className="flex flex-col gap-3">
         <Field className="gap-1.5"><FieldLabel className="text-xs">{t('pipelines.source_type')}</FieldLabel><Select value={sourceType ?? null} onValueChange={(next) => { if (next != null) (setSourceType)(next); }} items={SOURCE_TYPES.map((s) => ({ value: s, label: label(s) }))}><SelectTrigger className="w-full"><SelectValue placeholder="—" /></SelectTrigger><SelectContent><SelectGroup>{(SOURCE_TYPES.map((s) => ({ value: s, label: label(s) }))).map((opt: { value: string; label: ReactNode; icon?: ReactNode; description?: ReactNode }) => (<SelectItem key={opt.value} value={opt.value}>{opt.icon}<span className="min-w-0 flex-1"><span className="block truncate">{opt.label}</span>{opt.description ? <span className="block truncate text-xs text-muted-foreground">{opt.description}</span> : null}</span></SelectItem>))}</SelectGroup></SelectContent></Select></Field>
 
@@ -109,15 +106,16 @@ export default function SourceConfigModal({ stages, onClose, onCreate }: Props) 
           </div>
         )}
       </div>
-        <DialogFooter>
-          <Button variant="ghost" onClick={onClose}>
+        </AppModalBody>
+        <AppModalFooter>
+          <Button variant="outline" onClick={onClose}>
             {t('pipelines.cancel')}
           </Button>
           <Button onClick={() => void save()} disabled={saving}>
             {saving ? t('pipelines.saving') : t('pipelines.create')}
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/pipelines/StageConfigModal.tsx
+++ b/app/components/pipelines/StageConfigModal.tsx
@@ -21,17 +21,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue , SelectG
 import { Field, FieldLabel } from '@/components/ui/field';
 import { Checkbox } from '@/components/ui/checkbox';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -81,6 +71,7 @@ export default function StageConfigModal({
   const [extraAgents, setExtraAgents] = useState<ExecutorOption[]>([]);
   const [creatingAgent, setCreatingAgent] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const templateRef = useRef<HTMLTextAreaElement>(null);
   const macroScrollRef = useRef<HTMLDivElement>(null);
   useHorizontalScroll(macroScrollRef);
@@ -182,6 +173,7 @@ export default function StageConfigModal({
   }
 
   return (
+    <>
     <InlineDetailCard
       onClose={onClose}
       title={t('pipelines.configure')}
@@ -189,22 +181,14 @@ export default function StageConfigModal({
       containerName="pipeline-stage"
       footer={
         <>
-          <AlertDialog>
-            <AlertDialogTrigger render={<Button variant="ghost" className="text-destructive hover:text-destructive" />}>
-              <HugeiconsIcon icon={Delete02Icon} data-icon="inline-start" />
-              {t('pipelines.delete')}
-            </AlertDialogTrigger>
-            <AlertDialogContent size="sm">
-              <AlertDialogHeader>
-                <AlertDialogTitle>{t('pipelines.delete')}</AlertDialogTitle>
-                <AlertDialogDescription>{stage.title}</AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>{t('pipelines.cancel')}</AlertDialogCancel>
-                <AlertDialogAction variant="destructive" onClick={() => void onDelete()}>{t('pipelines.delete')}</AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+          <Button
+            variant="ghost"
+            className="text-destructive hover:text-destructive"
+            onClick={() => setConfirmDelete(true)}
+          >
+            <HugeiconsIcon icon={Delete02Icon} data-icon="inline-start" />
+            {t('pipelines.delete')}
+          </Button>
           <div className="flex-1" />
           <Button onClick={() => void save()} disabled={saving}>
             {saving ? t('pipelines.saving') : t('pipelines.save')}
@@ -343,5 +327,19 @@ export default function StageConfigModal({
         </Field>
       </div>
     </InlineDetailCard>
+    <ConfirmDialog
+      isOpen={confirmDelete}
+      title={t('pipelines.delete')}
+      message={stage.title}
+      confirmLabel={t('pipelines.delete')}
+      cancelLabel={t('pipelines.cancel')}
+      variant="danger"
+      onConfirm={() => {
+        void onDelete();
+        setConfirmDelete(false);
+      }}
+      onCancel={() => setConfirmDelete(false)}
+    />
+    </>
   );
 }

--- a/app/components/search/CommandPalette.tsx
+++ b/app/components/search/CommandPalette.tsx
@@ -28,11 +28,15 @@ import { Command, CommandInput } from '@/components/ui/command';
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { Spinner } from '@/components/ui/spinner';
 import { Button } from '@/components/ui/button';
 import { Field, FieldDescription, FieldLabel } from '@/components/ui/field';
@@ -607,12 +611,12 @@ export default function CommandPalette() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={addUrlOpen} onOpenChange={setAddUrlOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t('command.add_url')}</DialogTitle>
-            <DialogDescription>{t('command.please_enter_url')}</DialogDescription>
-          </DialogHeader>
+      <AppModal open={addUrlOpen} onOpenChange={setAddUrlOpen}>
+        <AppModalContent size="md">
+          <AppModalHeader
+            title={t('command.add_url')}
+            description={t('command.please_enter_url')}
+          />
           <form
             className="contents"
             onSubmit={(event) => {
@@ -620,28 +624,30 @@ export default function CommandPalette() {
               void createUrlResource();
             }}
           >
-            <Field>
-              <FieldLabel htmlFor="command-add-url">URL</FieldLabel>
-              <Input
-                id="command-add-url"
-                type="url"
-                value={urlValue}
-                onChange={(event) => setUrlValue(event.target.value)}
-                placeholder="https://example.com"
-              />
-              <FieldDescription>{t('command.add_url')}</FieldDescription>
-            </Field>
-            <DialogFooter>
+            <AppModalBody>
+              <Field>
+                <FieldLabel htmlFor="command-add-url">URL</FieldLabel>
+                <Input
+                  id="command-add-url"
+                  type="url"
+                  value={urlValue}
+                  onChange={(event) => setUrlValue(event.target.value)}
+                  placeholder="https://example.com"
+                />
+                <FieldDescription>{t('command.add_url')}</FieldDescription>
+              </Field>
+            </AppModalBody>
+            <AppModalFooter>
               <Button type="button" variant="outline" onClick={() => setAddUrlOpen(false)}>
                 {t('common.cancel')}
               </Button>
               <Button type="submit" loading={urlSubmitting} disabled={!urlValue.trim()}>
                 {t('command.add_url')}
               </Button>
-            </DialogFooter>
+            </AppModalFooter>
           </form>
-        </DialogContent>
-      </Dialog>
+        </AppModalContent>
+      </AppModal>
     </>
   );
 }

--- a/app/components/settings/ai/ProviderModelsConfigModal.tsx
+++ b/app/components/settings/ai/ProviderModelsConfigModal.tsx
@@ -9,13 +9,12 @@ import {
 } from '@hugeicons/core-free-icons';
 import { Button } from '@/components/ui/button';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { Input } from '@/components/ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
 import { Spinner } from '@/components/ui/spinner';
@@ -297,21 +296,18 @@ export default function ProviderModelsConfigModal({
   );
 
   return (
-    <Dialog
+    <AppModal
       open={open}
       onOpenChange={(next) => {
         if (!next) onClose();
       }}
     >
-      <DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-4xl">
-        <DialogHeader className="shrink-0 border-b px-4 py-3">
-          <DialogTitle className="truncate">{t('settings.ai.visible_models.title')}</DialogTitle>
-          <DialogDescription className="truncate">
-            {t('settings.ai.visible_models.subtitle', { provider: providerLabel })}
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+      <AppModalContent size="xl">
+        <AppModalHeader
+          title={t('settings.ai.visible_models.title')}
+          description={t('settings.ai.visible_models.subtitle', { provider: providerLabel })}
+        />
+        <AppModalBody>
           <div className="flex flex-col gap-4">
             <InputGroup>
               <InputGroupAddon align="inline-start">
@@ -411,16 +407,16 @@ export default function ProviderModelsConfigModal({
               </div>
             </div>
           </div>
-        </div>
+        </AppModalBody>
 
-        <DialogFooter className="border-t px-4 py-3">
+        <AppModalFooter>
           <div className="flex w-full items-center justify-between gap-3">
-            <Button type="button" variant="ghost" size="sm" onClick={resetDefaults}>
+            <Button type="button" variant="outline" size="sm" onClick={resetDefaults}>
               <HugeiconsIcon icon={RotateLeft01Icon} data-icon="inline-start" />
               {t('settings.ai.visible_models.reset')}
             </Button>
             <div className="flex items-center gap-2">
-              <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+              <Button type="button" variant="outline" size="sm" onClick={onClose}>
                 {t('common.cancel')}
               </Button>
               <Button
@@ -433,8 +429,8 @@ export default function ProviderModelsConfigModal({
               </Button>
             </div>
           </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/settings/sections/CloudStorageSection.tsx
+++ b/app/components/settings/sections/CloudStorageSection.tsx
@@ -2,17 +2,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { CloudIcon, Delete02Icon } from '@hugeicons/core-free-icons';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Spinner } from '@/components/ui/spinner';
@@ -189,25 +180,18 @@ export default function CloudStorageSection() {
         />
       </SettingsGroup>
 
-      <AlertDialog
-        open={Boolean(pendingDisconnect)}
-        onOpenChange={(open) => {
-          if (!open) setPendingDisconnect(null);
+      <ConfirmDialog
+        isOpen={Boolean(pendingDisconnect)}
+        title={t('settings.cloud.disconnect')}
+        message={pendingDisconnect?.email ?? ''}
+        confirmLabel={t('settings.cloud.disconnect')}
+        cancelLabel={t('common.cancel')}
+        variant="danger"
+        onConfirm={() => {
+          void handleDisconnect();
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('settings.cloud.disconnect')}</AlertDialogTitle>
-            <AlertDialogDescription>{pendingDisconnect?.email}</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-            <AlertDialogAction variant="destructive" onClick={() => void handleDisconnect()}>
-              {t('settings.cloud.disconnect')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onCancel={() => setPendingDisconnect(null)}
+      />
     </SettingsSurface>
   );
 }

--- a/app/components/settings/sections/McpSection.tsx
+++ b/app/components/settings/sections/McpSection.tsx
@@ -18,12 +18,12 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -642,7 +642,7 @@ export default function McpSection() {
         )}
       </SettingsGroup>
 
-      <Dialog
+      <AppModal
         open={showImport}
         onOpenChange={(next) => {
           if (!next) {
@@ -652,11 +652,9 @@ export default function McpSection() {
           }
         }}
       >
-        <DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
-          <DialogHeader className="shrink-0 border-b px-4 py-3">
-            <DialogTitle className="truncate">{t('settings.mcp.import_title')}</DialogTitle>
-          </DialogHeader>
-          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+        <AppModalContent size="xl">
+          <AppModalHeader title={t('settings.mcp.import_title')} />
+          <AppModalBody>
             <p className="mb-3 text-xs text-muted-foreground">
               {t('settings.mcp.import_format', { format: FORMAT_EXAMPLE })}
             </p>
@@ -672,8 +670,8 @@ export default function McpSection() {
               onChange={(e) => setImportJson(e.target.value)}
               rows={12}
             />
-          </div>
-          <DialogFooter className="border-t px-4 py-3">
+          </AppModalBody>
+          <AppModalFooter>
             <Button
               type="button"
               variant="outline"
@@ -689,9 +687,9 @@ export default function McpSection() {
             <Button type="button" size="sm" onClick={handleImport}>
               {t('settings.mcp.import_btn')}
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </AppModalFooter>
+        </AppModalContent>
+      </AppModal>
     </SettingsSurface>
   );
 }

--- a/app/components/settings/sections/PluginRuntimeDialog.tsx
+++ b/app/components/settings/sections/PluginRuntimeDialog.tsx
@@ -5,12 +5,11 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { Spinner } from '@/components/ui/spinner';
 import type { DomePluginInfo } from '@/types/plugin';
 import { permissionForPluginMethod } from '@/components/plugins/pluginPermissions';
@@ -177,37 +176,35 @@ export default function PluginRuntimeDialog({ plugin, onClose }: PluginRuntimeDi
   }, [permissions]);
 
   return (
-    <Dialog
+    <AppModal
       open
       onOpenChange={(next) => {
         if (!next) onClose();
       }}
     >
-      <DialogContent className="flex h-[85vh] max-h-[min(90vh,640px)] flex-col overflow-hidden sm:max-w-6xl">
-        <DialogHeader className="shrink-0">
-          <DialogTitle className="truncate">{plugin.name}</DialogTitle>
-          <DialogDescription className="truncate">
-            {plugin.author} · v{plugin.version} · {entry}
-          </DialogDescription>
-          <div className="flex flex-wrap items-center gap-1">
-            {plugin.permissions?.map((permission) => (
-              <Badge key={permission} variant="outline">
-                {permission}
-              </Badge>
-            ))}
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => setReloadKey((value) => value + 1)}
-              title="Recargar plugin"
-              aria-label="Recargar plugin"
-            >
-              <HugeiconsIcon icon={RefreshIcon} />
-            </Button>
-          </div>
-        </DialogHeader>
-        <div className="min-h-0 flex-1">
+      <AppModalContent size="xl" className="h-[85vh] sm:max-w-6xl">
+        <AppModalHeader
+          title={plugin.name}
+          description={`${plugin.author} · v${plugin.version} · ${entry}`}
+        />
+        <div className="flex shrink-0 flex-wrap items-center gap-1 border-b px-4 pb-3">
+          {plugin.permissions?.map((permission) => (
+            <Badge key={permission} variant="outline">
+              {permission}
+            </Badge>
+          ))}
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => setReloadKey((value) => value + 1)}
+            title="Recargar plugin"
+            aria-label="Recargar plugin"
+          >
+            <HugeiconsIcon icon={RefreshIcon} />
+          </Button>
+        </div>
+        <AppModalBody className="min-h-0 flex-1">
           <div className="relative h-full min-h-[60vh] overflow-hidden rounded-xl border bg-background">
             {loading ? (
               <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
@@ -232,8 +229,8 @@ export default function PluginRuntimeDialog({ plugin, onClose }: PluginRuntimeDi
               />
             )}
           </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+        </AppModalBody>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/settings/sections/PluginsSection.tsx
+++ b/app/components/settings/sections/PluginsSection.tsx
@@ -10,17 +10,8 @@ import {
   PuzzleIcon,
 } from '@hugeicons/core-free-icons';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -282,31 +273,19 @@ export default function PluginsSection() {
         </SheetContent>
       </Sheet>
 
-      <AlertDialog
-        open={pendingUninstallId !== null}
-        onOpenChange={(open) => {
-          if (!open) setPendingUninstallId(null);
+      <ConfirmDialog
+        isOpen={pendingUninstallId !== null}
+        title={t('settings.plugins.uninstall', 'Uninstall plugin')}
+        message={t('settings.plugins.uninstall_confirm')}
+        confirmLabel={t('settings.plugins.uninstall', 'Uninstall')}
+        cancelLabel={t('common.cancel')}
+        variant="danger"
+        onConfirm={() => {
+          if (pendingUninstallId) void handleUninstall(pendingUninstallId);
+          setPendingUninstallId(null);
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('settings.plugins.uninstall', 'Uninstall plugin')}</AlertDialogTitle>
-            <AlertDialogDescription>{t('settings.plugins.uninstall_confirm')}</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-            <AlertDialogAction
-              variant="destructive"
-              onClick={() => {
-                if (pendingUninstallId) void handleUninstall(pendingUninstallId);
-                setPendingUninstallId(null);
-              }}
-            >
-              {t('settings.plugins.uninstall', 'Uninstall')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onCancel={() => setPendingUninstallId(null)}
+      />
     </SettingsSurface>
   );
 }

--- a/app/components/settings/sections/SocialConnectDialog.tsx
+++ b/app/components/settings/sections/SocialConnectDialog.tsx
@@ -14,13 +14,12 @@ import {
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { Input } from '@/components/ui/input';
 import { Spinner } from '@/components/ui/spinner';
 import { cn } from '@/lib/utils';
@@ -177,25 +176,18 @@ export default function SocialConnectDialog({
   const done = connectedNow || (showConnect && activeAccount !== null);
 
   return (
-    <Dialog
+    <AppModal
       open
       onOpenChange={(next) => {
         if (!next) onClose();
       }}
     >
-      <DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
-        <DialogHeader className="shrink-0 border-b px-4 py-3">
-          <DialogTitle className="truncate">
-            {t('social.wizard.title', { provider: PROVIDER_LABELS[provider] })}
-          </DialogTitle>
-          {t(`social.wizard.${provider}.intro`) ? (
-            <DialogDescription className="truncate">
-              {t(`social.wizard.${provider}.intro`)}
-            </DialogDescription>
-          ) : null}
-        </DialogHeader>
-
-        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+      <AppModalContent size="xl">
+        <AppModalHeader
+          title={t('social.wizard.title', { provider: PROVIDER_LABELS[provider] })}
+          description={t(`social.wizard.${provider}.intro`) || undefined}
+        />
+        <AppModalBody>
           <div className="flex flex-col gap-4 text-sm">
             <ol className="flex flex-wrap items-center gap-1.5">
               {STEP_IDS.map((id, i) => (
@@ -433,13 +425,13 @@ export default function SocialConnectDialog({
               ) : null}
             </div>
           </div>
-        </div>
+        </AppModalBody>
 
-        <DialogFooter className="border-t px-4 py-3">
+        <AppModalFooter>
           <div className="flex w-full items-center justify-between gap-2">
             <Button
               type="button"
-              variant="ghost"
+              variant="outline"
               size="sm"
               onClick={() => setStep((s) => Math.max(0, s - 1))}
               disabled={step === 0}
@@ -462,8 +454,8 @@ export default function SocialConnectDialog({
               </Button>
             )}
           </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/shared/AppModal.tsx
+++ b/app/components/shared/AppModal.tsx
@@ -1,0 +1,114 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+const contentWidthClass = {
+  sm: 'sm:max-w-sm',
+  md: 'sm:max-w-md',
+  lg: 'sm:max-w-lg',
+  xl: 'sm:max-w-2xl',
+} as const;
+
+export type AppModalSize = keyof typeof contentWidthClass;
+
+export interface AppModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}
+
+/** Centered modal shell — shared chrome for form/picker dialogs. */
+export function AppModal({ open, onOpenChange, children }: AppModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {children}
+    </Dialog>
+  );
+}
+
+export interface AppModalContentProps {
+  size?: AppModalSize;
+  className?: string;
+  children: ReactNode;
+  showCloseButton?: boolean;
+  'aria-busy'?: boolean;
+}
+
+export function AppModalContent({
+  size = 'sm',
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: AppModalContentProps) {
+  return (
+    <DialogContent
+      showCloseButton={showCloseButton}
+      className={cn(
+        'flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0',
+        contentWidthClass[size],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogContent>
+  );
+}
+
+export interface AppModalHeaderProps {
+  title: ReactNode;
+  description?: ReactNode;
+  className?: string;
+}
+
+export function AppModalHeader({ title, description, className }: AppModalHeaderProps) {
+  return (
+    <DialogHeader
+      className={cn(
+        'shrink-0 gap-0.5 border-b px-4 py-3 pr-12 text-left',
+        className,
+      )}
+    >
+      <DialogTitle className="truncate">{title}</DialogTitle>
+      {description ? (
+        <DialogDescription className="truncate">{description}</DialogDescription>
+      ) : null}
+    </DialogHeader>
+  );
+}
+
+export function AppModalBody({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn('min-h-0 flex-1 overflow-y-auto px-4 py-3', className)}>
+      {children}
+    </div>
+  );
+}
+
+export function AppModalFooter({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <DialogFooter className={cn('shrink-0 border-t px-4 py-3 sm:justify-end', className)}>
+      {children}
+    </DialogFooter>
+  );
+}

--- a/app/components/shared/ConfirmDialog.tsx
+++ b/app/components/shared/ConfirmDialog.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Alert02Icon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { useTranslation } from 'react-i18next';
@@ -16,10 +17,13 @@ import {
 interface ConfirmDialogProps {
   isOpen: boolean;
   title: string;
-  message: string;
+  message: ReactNode;
   confirmLabel?: string;
   cancelLabel?: string;
   variant?: 'danger' | 'default';
+  busy?: boolean;
+  confirmDisabled?: boolean;
+  children?: ReactNode;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -31,6 +35,9 @@ export function ConfirmDialog({
   confirmLabel,
   cancelLabel,
   variant = 'default',
+  busy = false,
+  confirmDisabled = false,
+  children,
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
@@ -43,10 +50,10 @@ export function ConfirmDialog({
     <AlertDialog
       open={isOpen}
       onOpenChange={(open) => {
-        if (!open) onCancel();
+        if (!open && !busy) onCancel();
       }}
     >
-      <AlertDialogContent size="sm">
+      <AlertDialogContent size="default">
         <AlertDialogHeader>
           {isDanger ? (
             <AlertDialogMedia className="bg-destructive/10">
@@ -56,9 +63,17 @@ export function ConfirmDialog({
           <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription>{message}</AlertDialogDescription>
         </AlertDialogHeader>
+        {children}
         <AlertDialogFooter>
-          <AlertDialogCancel onClick={onCancel}>{resolvedCancel}</AlertDialogCancel>
-          <AlertDialogAction variant={isDanger ? 'destructive' : 'default'} onClick={onConfirm}>
+          <AlertDialogCancel disabled={busy} onClick={onCancel}>
+            {resolvedCancel}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            variant={isDanger ? 'destructive' : 'default'}
+            loading={busy}
+            disabled={busy || confirmDisabled}
+            onClick={onConfirm}
+          >
             {resolvedConfirm}
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/app/components/shared/PromptModal.tsx
+++ b/app/components/shared/PromptModal.tsx
@@ -5,12 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { SentIcon } from '@hugeicons/core-free-icons';
 import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { Input } from '@/components/ui/input';
 import { Field, FieldLabel } from '@/components/ui/field';
 
@@ -36,43 +36,39 @@ export default function PromptModal() {
   };
 
   return (
-    <Dialog
+    <AppModal
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) handleCancel();
       }}
     >
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>{t('promptModal.input')}</DialogTitle>
-        </DialogHeader>
-        <form id="prompt-modal-form" onSubmit={onSubmit}>
-          <Field>
-          <FieldLabel htmlFor="prompt-modal-input">
-            {message}
-          </FieldLabel>
-          <Input
-            id="prompt-modal-input"
-            ref={inputRef}
-            type="text"
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            placeholder={t('promptModal.typeHere')}
-          />
-          </Field>
+      <AppModalContent size="md">
+        <AppModalHeader title={t('promptModal.input')} />
+        <form id="prompt-modal-form" onSubmit={onSubmit} className="contents">
+          <AppModalBody>
+            <Field>
+              <FieldLabel htmlFor="prompt-modal-input">{message}</FieldLabel>
+              <Input
+                id="prompt-modal-input"
+                ref={inputRef}
+                type="text"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                placeholder={t('promptModal.typeHere')}
+              />
+            </Field>
+          </AppModalBody>
+          <AppModalFooter>
+            <Button type="button" variant="outline" onClick={handleCancel}>
+              {t('promptModal.cancel')}
+            </Button>
+            <Button type="submit" form="prompt-modal-form">
+              <HugeiconsIcon icon={SentIcon} data-icon="inline-start" />
+              {t('promptModal.accept')}
+            </Button>
+          </AppModalFooter>
         </form>
-        <DialogFooter>
-          <Button type="button"
-  variant="secondary"
-  onClick={handleCancel}>
-            {t('promptModal.cancel')}
-          </Button>
-          <Button type="submit"
-  form="prompt-modal-form"><HugeiconsIcon icon={SentIcon} data-icon="inline-start" />
-            {t('promptModal.accept')}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/social/SocialReportsSection.tsx
+++ b/app/components/social/SocialReportsSection.tsx
@@ -8,17 +8,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Field, FieldLabel } from '@/components/ui/field';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue , SelectGroup } from '@/components/ui/select';
 import { Spinner } from '@/components/ui/spinner';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import MarkdownRenderer from '@/components/chat/MarkdownRenderer';
 import type { SocialReport, SocialReportConfig } from '@/components/social/socialTypes';
 
@@ -185,6 +175,7 @@ function ReportRow({
   onDelete: () => void;
 }) {
   const { t } = useTranslation();
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const chevronIcon = open ? ChevronDownIcon : ChevronRightIcon;
   return (
     <div className="overflow-hidden rounded-lg border bg-card">
@@ -225,24 +216,26 @@ function ReportRow({
           </span>
           <HugeiconsIcon icon={chevronIcon} className="size-4 shrink-0 text-muted-foreground" />
         </Button>
-        <AlertDialog>
-          <AlertDialogTrigger render={<Button type="button" size="icon-xs" variant="ghost" className="shrink-0" />}>
-            <HugeiconsIcon icon={Delete02Icon} className="text-destructive" />
-            <span className="sr-only">{t('social.hub.delete')}</span>
-          </AlertDialogTrigger>
-          <AlertDialogContent size="sm">
-            <AlertDialogHeader>
-              <AlertDialogTitle>{t('social.hub.delete')}</AlertDialogTitle>
-              <AlertDialogDescription>{report.title || t('social.reports.untitled')}</AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-              <AlertDialogAction variant="destructive" onClick={onDelete}>
-                {t('social.hub.delete')}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <Button
+          type="button"
+          size="icon-xs"
+          variant="ghost"
+          className="shrink-0"
+          onClick={() => setConfirmOpen(true)}
+        >
+          <HugeiconsIcon icon={Delete02Icon} className="text-destructive" />
+          <span className="sr-only">{t('social.hub.delete')}</span>
+        </Button>
+        <ConfirmDialog
+          isOpen={confirmOpen}
+          title={t('social.hub.delete')}
+          message={report.title || t('social.reports.untitled')}
+          confirmLabel={t('social.hub.delete')}
+          cancelLabel={t('common.cancel')}
+          variant="danger"
+          onConfirm={onDelete}
+          onCancel={() => setConfirmOpen(false)}
+        />
       </div>
       {open && (
         <div className="border-t px-4 pb-4">

--- a/app/components/studio/GenerateSourceModal.tsx
+++ b/app/components/studio/GenerateSourceModal.tsx
@@ -19,7 +19,13 @@ import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { type Resource } from '@/types';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 function getTypeIcon(type: string, size = 14) {
   const props = { size, className: 'shrink-0' };
   switch (type) {
@@ -339,8 +345,12 @@ export default function GenerateSourceModal({
   }
 
   return (
-    <Dialog open={isOpen} onOpenChange={(next) => { if (!next) (onClose)(); }}><DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl"><DialogHeader className="flex shrink-0 flex-row items-center justify-between gap-3 border-b px-4 py-3"><div className="flex min-w-0 items-center gap-3"><div className="min-w-0"><DialogTitle className="truncate">{titleOverride ??
-        t('studio.generate_title', { tileTitle })}</DialogTitle></div></div></DialogHeader><div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+    <AppModal open={isOpen} onOpenChange={(next) => { if (!next) onClose(); }}>
+      <AppModalContent size="xl">
+        <AppModalHeader
+          title={titleOverride ?? t('studio.generate_title', { tileTitle })}
+        />
+        <AppModalBody>
       <div className="flex flex-col gap-4">
         <p className="text-sm text-muted-foreground">
           {descriptionOverride ??
@@ -380,11 +390,13 @@ export default function GenerateSourceModal({
           )}
         </div>
       </div>
-    </div><DialogFooter className="border-t px-4 py-3">{<>
+        </AppModalBody>
+        <AppModalFooter>
           <Button
             type="button"
             onClick={onClose}
-            variant="ghost" className="min-h-[44px] px-4"
+            variant="outline"
+            className="min-h-[44px] px-4"
           >
             {t('common.cancel')}
           </Button>
@@ -396,6 +408,8 @@ export default function GenerateSourceModal({
           >
             {t('learn.generate')}
           </Button>
-        </>}</DialogFooter></DialogContent></Dialog>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/workspace/MetadataModal.tsx
+++ b/app/components/workspace/MetadataModal.tsx
@@ -1,4 +1,3 @@
-
 import { useState, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { HugeiconsIcon } from '@hugeicons/react';
@@ -14,10 +13,15 @@ import {
 } from '@hugeicons/core-free-icons';
 import { type Resource } from '@/types';
 import { formatDateFull, getResourceTypeLabel } from '@/lib/utils';
-import { useTranslation } from 'react-i18next';
-
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { Input } from '@/components/ui/input';
+
 interface MetadataModalProps {
   resource: Resource;
   isOpen: boolean;
@@ -50,7 +54,6 @@ export default function MetadataModal({
   onClose,
   onSave,
 }: MetadataModalProps) {
-  const { t } = useTranslation();
   const [title, setTitle] = useState(resource.title);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -96,120 +99,123 @@ export default function MetadataModal({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={(next) => { if (!next) (onClose)(); }}><DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-md"><DialogHeader className="flex shrink-0 flex-row items-center justify-between gap-3 border-b px-4 py-3"><div className="flex min-w-0 items-center gap-3"><div className="min-w-0"><DialogTitle className="truncate">Resource Info</DialogTitle></div></div></DialogHeader><div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-      <div className="flex flex-col gap-y-4">
-          <div>
-            <label htmlFor="metadata-title" className="block text-xs font-medium mb-1.5 text-muted-foreground">
-              Title
-            </label>
-            <Input
-              id="metadata-title"
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-            />
-          </div>
-
-          <div className="flex items-center gap-3">
-            <HugeiconsIcon icon={File02Icon} size={16} className="text-muted-foreground" />
+    <AppModal
+      open={isOpen}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <AppModalContent size="md">
+        <AppModalHeader title="Resource Info" />
+        <AppModalBody>
+          <div className="flex flex-col gap-y-4">
             <div>
-              <p className="text-xs text-muted-foreground">
-                Type
-              </p>
-              <p className="text-sm font-medium text-foreground">
-                {getResourceTypeLabel(resource.type)}
-              </p>
+              <label htmlFor="metadata-title" className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                Title
+              </label>
+              <Input
+                id="metadata-title"
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+              />
             </div>
-          </div>
 
-          {resource.file_size ? (
-            <div className="flex items-center gap-3">
-              <HugeiconsIcon icon={HardDriveIcon} size={16} className="text-muted-foreground" />
-              <div>
-                <p className="text-xs text-muted-foreground">
-                  File Size
-                </p>
-                <p className="text-sm font-medium text-foreground">
-                  {formatMetadataFileSize(resource.file_size)}
-                </p>
-              </div>
-            </div>
-          ) : null}
-
-          {resource.file_hash ? (
-            <div className="flex items-center gap-3">
-              <HugeiconsIcon icon={HashIcon} size={16} className="text-muted-foreground" />
-              <div>
-                <p className="text-xs text-muted-foreground">
-                  Hash
-                </p>
-                <p
-                  className="text-sm font-mono text-foreground"
-                >
-                  {resource.file_hash}
-                </p>
-              </div>
-            </div>
-          ) : null}
-
-          {resource.original_filename ? (
             <div className="flex items-center gap-3">
               <HugeiconsIcon icon={File02Icon} size={16} className="text-muted-foreground" />
               <div>
-                <p className="text-xs text-muted-foreground">
-                  Original Filename
-                </p>
-                <p className="text-sm text-foreground">
-                  {resource.original_filename}
+                <p className="text-xs text-muted-foreground">Type</p>
+                <p className="text-sm font-medium text-foreground">
+                  {getResourceTypeLabel(resource.type)}
                 </p>
               </div>
             </div>
-          ) : null}
 
-          <div className="flex items-center gap-3">
-            <HugeiconsIcon icon={Calendar03Icon} size={16} className="text-muted-foreground" />
-            <div>
-              <p className="text-xs text-muted-foreground">
-                Created
-              </p>
-              <p className="text-sm text-foreground">
-                {formatMetadataDate(resource.created_at)}
-              </p>
+            {resource.file_size ? (
+              <div className="flex items-center gap-3">
+                <HugeiconsIcon icon={HardDriveIcon} size={16} className="text-muted-foreground" />
+                <div>
+                  <p className="text-xs text-muted-foreground">File Size</p>
+                  <p className="text-sm font-medium text-foreground">
+                    {formatMetadataFileSize(resource.file_size)}
+                  </p>
+                </div>
+              </div>
+            ) : null}
+
+            {resource.file_hash ? (
+              <div className="flex items-center gap-3">
+                <HugeiconsIcon icon={HashIcon} size={16} className="text-muted-foreground" />
+                <div>
+                  <p className="text-xs text-muted-foreground">Hash</p>
+                  <p className="font-mono text-sm text-foreground">{resource.file_hash}</p>
+                </div>
+              </div>
+            ) : null}
+
+            {resource.original_filename ? (
+              <div className="flex items-center gap-3">
+                <HugeiconsIcon icon={File02Icon} size={16} className="text-muted-foreground" />
+                <div>
+                  <p className="text-xs text-muted-foreground">Original Filename</p>
+                  <p className="text-sm text-foreground">{resource.original_filename}</p>
+                </div>
+              </div>
+            ) : null}
+
+            <div className="flex items-center gap-3">
+              <HugeiconsIcon icon={Calendar03Icon} size={16} className="text-muted-foreground" />
+              <div>
+                <p className="text-xs text-muted-foreground">Created</p>
+                <p className="text-sm text-foreground">{formatMetadataDate(resource.created_at)}</p>
+              </div>
             </div>
+
+            <div className="flex items-center gap-3">
+              <HugeiconsIcon icon={Calendar03Icon} size={16} className="text-muted-foreground" />
+              <div>
+                <p className="text-xs text-muted-foreground">Modified</p>
+                <p className="text-sm text-foreground">{formatMetadataDate(resource.updated_at)}</p>
+              </div>
+            </div>
+
+            {resource.internal_path || resource.file_path ? (
+              <div className="flex gap-2 pt-2">
+                <Button
+                  type="button"
+                  onClick={() => {
+                    void handleOpenFile().catch(() => {});
+                  }}
+                  variant="outline"
+                  className="flex items-center gap-1.5"
+                >
+                  <HugeiconsIcon icon={ExternalLinkIcon} size={14} />
+                  Open with default app
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => {
+                    void handleShowInFolder().catch(() => {});
+                  }}
+                  variant="outline"
+                  className="flex items-center gap-1.5"
+                >
+                  <HugeiconsIcon icon={FolderOpenIcon} size={14} />
+                  Show in Finder
+                </Button>
+              </div>
+            ) : null}
           </div>
-
-          <div className="flex items-center gap-3">
-            <HugeiconsIcon icon={Calendar03Icon} size={16} className="text-muted-foreground" />
-            <div>
-              <p className="text-xs text-muted-foreground">
-                Modified
-              </p>
-              <p className="text-sm text-foreground">
-                {formatMetadataDate(resource.updated_at)}
-              </p>
-            </div>
-          </div>
-
-          {(resource.internal_path || resource.file_path) ? (
-            <div className="flex gap-2 pt-2">
-              <Button type="button" onClick={handleOpenFile} variant="secondary" className="flex items-center gap-1.5">
-                <HugeiconsIcon icon={ExternalLinkIcon} size={14} />
-                Open with default app
-              </Button>
-              <Button type="button" onClick={handleShowInFolder} variant="secondary" className="flex items-center gap-1.5">
-                <HugeiconsIcon icon={FolderOpenIcon} size={14} />
-                Show in Finder
-              </Button>
-            </div>
-          ) : null}
-      </div>
-    </div><DialogFooter className="border-t px-4 py-3">{<>
-          <Button type="button" onClick={onClose} variant="ghost">
+        </AppModalBody>
+        <AppModalFooter>
+          <Button type="button" onClick={onClose} variant="outline">
             Cancel
           </Button>
           <Button
             type="button"
-            onClick={handleSave}
+            onClick={() => {
+              void handleSave().catch(() => {});
+            }}
             disabled={isSaving || title === resource.title}
             className="flex items-center gap-1.5"
           >
@@ -220,6 +226,8 @@ export default function MetadataModal({
             )}
             Save Changes
           </Button>
-        </>}</DialogFooter></DialogContent></Dialog>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/workspace/MoveFolderModal.tsx
+++ b/app/components/workspace/MoveFolderModal.tsx
@@ -13,8 +13,14 @@ import { buildMoveFolderRows } from '@/lib/workspace/buildMoveFolderRows';
 import { getFolderColor } from '@/components/shell/folder-tab/folderTabShared';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 export interface MoveFolderModalProps {
   open: boolean;
   onClose: () => void;
@@ -108,51 +114,59 @@ export default function MoveFolderModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={(next) => { if (!next) (onClose)(); }}><DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-sm"><DialogHeader className="flex shrink-0 flex-row items-center justify-between gap-3 border-b px-4 py-3"><div className="flex min-w-0 items-center gap-3"><div className="min-w-0"><DialogTitle className="truncate">{title}</DialogTitle>{subtitle ? <DialogDescription className="truncate">{subtitle}</DialogDescription> : null}</div></div></DialogHeader><div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-      <div className="flex flex-col gap-2">
-        <ScrollArea className="max-h-[280px]">
-          <div className="flex flex-col gap-1 pr-2">
-            <FolderPickButton selected={selectedId === null} onClick={() => setSelectedId(null)}>
-              <span className="text-sm font-medium">{t('selection.move_to_root')}</span>
-            </FolderPickButton>
-            {rows.map(({ folder: f, depth }) => (
-              <FolderPickButton
-                key={f.id}
-                selected={selectedId === f.id}
-                onClick={() => setSelectedId(f.id)}
-              >
-                <span
-                  className="flex min-w-0 items-center gap-2"
-                  style={{ marginLeft: depth * 20 }}
-                >
-                  {depth > 0 ? (
-                    <HugeiconsIcon icon={ChevronRightIcon}
-                      className="size-3 shrink-0 opacity-60 text-muted-foreground"
-                      aria-hidden
-                    />
-                  ) : null}
-                  <HugeiconsIcon icon={Folder01Icon}
-                    className="size-4 shrink-0"
-                    style={{ color: getFolderColor(f) ?? 'var(--primary)' }}
-                    strokeWidth={1.75}
-                  />
-                  <span className="truncate text-sm font-medium">{f.title}</span>
-                </span>
+    <AppModal
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <AppModalContent size="sm">
+        <AppModalHeader title={title} description={subtitle} />
+        <AppModalBody>
+          <ScrollArea className="max-h-[280px]">
+            <div className="flex flex-col gap-1 pr-2">
+              <FolderPickButton selected={selectedId === null} onClick={() => setSelectedId(null)}>
+                <span className="text-sm font-medium">{t('selection.move_to_root')}</span>
               </FolderPickButton>
-            ))}
-          </div>
-        </ScrollArea>
-      </div>
-    </div><DialogFooter className="border-t px-4 py-3">{<>
-          <Button variant="secondary"
-  onClick={onClose}
-  disabled={submitting}>
+              {rows.map(({ folder: f, depth }) => (
+                <FolderPickButton
+                  key={f.id}
+                  selected={selectedId === f.id}
+                  onClick={() => setSelectedId(f.id)}
+                >
+                  <span
+                    className="flex min-w-0 items-center gap-2"
+                    style={{ marginLeft: depth * 20 }}
+                  >
+                    {depth > 0 ? (
+                      <HugeiconsIcon
+                        icon={ChevronRightIcon}
+                        className="size-3 shrink-0 opacity-60 text-muted-foreground"
+                        aria-hidden
+                      />
+                    ) : null}
+                    <HugeiconsIcon
+                      icon={Folder01Icon}
+                      className="size-4 shrink-0"
+                      style={{ color: getFolderColor(f) ?? 'var(--primary)' }}
+                      strokeWidth={1.75}
+                    />
+                    <span className="truncate text-sm font-medium">{f.title}</span>
+                  </span>
+                </FolderPickButton>
+              ))}
+            </div>
+          </ScrollArea>
+        </AppModalBody>
+        <AppModalFooter>
+          <Button variant="outline" onClick={onClose} disabled={submitting}>
             {t('common.cancel')}
           </Button>
-          <Button onClick={() => void handleMove()}
-  loading={submitting}>
+          <Button onClick={() => void handleMove().catch(() => {})} loading={submitting}>
             {t('common.move')}
           </Button>
-        </>}</DialogFooter></DialogContent></Dialog>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/workspace/MoveToProjectModal.tsx
+++ b/app/components/workspace/MoveToProjectModal.tsx
@@ -8,8 +8,14 @@ import { useTranslation } from 'react-i18next';
 import type { Project } from '@/types';
 import type { Resource } from '@/lib/hooks/useResources';
 import { filterMoveProjectRoots } from '@/lib/workspace/filterMoveProjectRoots';
+import {
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 export interface MoveToProjectModalProps {
   opened: boolean;
   onClose: () => void;
@@ -168,49 +174,60 @@ export default function MoveToProjectModal({
   }, [pickedId, roots, onClose, onCompleted, t]);
 
   return (
-    <Dialog open={opened} onOpenChange={(next) => { if (!next) (onClose)(); }}><DialogContent className="flex max-h-[min(90vh,640px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-md"><DialogHeader className="flex shrink-0 flex-row items-center justify-between gap-3 border-b px-4 py-3"><div className="flex min-w-0 items-center gap-3"><div className="min-w-0"><DialogTitle className="truncate">{t('moveProject.title')}</DialogTitle></div></div></DialogHeader><div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-      <div className="flex flex-col gap-4">
-        <p className="text-sm text-muted-foreground">{t('moveProject.description')}</p>
-        <p className="text-sm font-medium">{t('moveProject.itemsCount', { count: roots.length })}</p>
+    <AppModal
+      open={opened}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <AppModalContent size="md">
+        <AppModalHeader title={t('moveProject.title')} />
+        <AppModalBody>
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-muted-foreground">{t('moveProject.description')}</p>
+            <p className="text-sm font-medium">
+              {t('moveProject.itemsCount', { count: roots.length })}
+            </p>
 
-        {loading ? (
-          <p className="text-sm">{t('common.loading')}</p>
-        ) : eligibleProjects.length === 0 ? (
-          <p className="text-sm text-orange-600">{t('moveProject.noTargets')}</p>
-        ) : (
-          <ScrollArea className="max-h-[280px]">
-            <div className="flex flex-col gap-1 pr-2">
-              {eligibleProjects.map((p) => (
-                <ProjectPickButton
-                  key={p.id}
-                  selected={pickedId === p.id}
-                  onClick={() => setPickedId(p.id)}
-                >
-                  <p className="text-sm font-medium">{p.name}</p>
-                  {p.description ? (
-                    <p className="line-clamp-2 text-xs text-muted-foreground">{p.description}</p>
-                  ) : null}
-                </ProjectPickButton>
-              ))}
-            </div>
-          </ScrollArea>
-        )}
+            {loading ? (
+              <p className="text-sm">{t('common.loading')}</p>
+            ) : eligibleProjects.length === 0 ? (
+              <p className="text-sm text-orange-600">{t('moveProject.noTargets')}</p>
+            ) : (
+              <ScrollArea className="max-h-[280px]">
+                <div className="flex flex-col gap-1 pr-2">
+                  {eligibleProjects.map((p) => (
+                    <ProjectPickButton
+                      key={p.id}
+                      selected={pickedId === p.id}
+                      onClick={() => setPickedId(p.id)}
+                    >
+                      <p className="text-sm font-medium">{p.name}</p>
+                      {p.description ? (
+                        <p className="line-clamp-2 text-xs text-muted-foreground">{p.description}</p>
+                      ) : null}
+                    </ProjectPickButton>
+                  ))}
+                </div>
+              </ScrollArea>
+            )}
 
-        {error ? (
-          <p className="text-sm text-destructive">{error}</p>
-        ) : null}
-      </div>
-    </div><DialogFooter className="border-t px-4 py-3">{<>
-          <Button variant="secondary"
-  onClick={onClose}
-  disabled={submitting}>
+            {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          </div>
+        </AppModalBody>
+        <AppModalFooter>
+          <Button variant="outline" onClick={onClose} disabled={submitting}>
             {t('common.cancel')}
           </Button>
-          <Button onClick={() => void handleMove()}
-  loading={submitting}
-  disabled={!pickedId || roots.length === 0 || eligibleProjects.length === 0}>
+          <Button
+            onClick={() => void handleMove().catch(() => {})}
+            loading={submitting}
+            disabled={!pickedId || roots.length === 0 || eligibleProjects.length === 0}
+          >
             {t('moveProject.confirm')}
           </Button>
-        </>}</DialogFooter></DialogContent></Dialog>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/components/workspace/sidebar/SidebarModals.tsx
+++ b/app/components/workspace/sidebar/SidebarModals.tsx
@@ -6,13 +6,12 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import type { Resource } from '@/lib/hooks/useResources';
 
@@ -61,9 +60,10 @@ export function BulkDeleteConfirmModal({
       isOpen
       title={t('selection.bulk_delete_confirm', { count })}
       message={`${t('selection.items_selected', { count })} — ${t('ui.delete_content_warning')}`}
-      confirmLabel={busy ? '…' : t('ui.delete')}
+      confirmLabel={t('ui.delete')}
       cancelLabel={t('ui.cancel')}
       variant="danger"
+      busy={busy}
       onConfirm={() => {
         if (!busy) onConfirm();
       }}
@@ -98,36 +98,40 @@ export function NewFolderModal({
   };
 
   return (
-    <Dialog open onOpenChange={(next) => { if (!next) onClose(); }}>
-      <DialogContent className="sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle>{t('ui.new_folder')}</DialogTitle>
-          <DialogDescription className="sr-only">{t('ui.folder_name')}</DialogDescription>
-        </DialogHeader>
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="new-folder-name">{t('ui.folder_name')}</Label>
-          <Input
-            ref={inputRef}
-            id="new-folder-name"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') submit();
-            }}
-            placeholder={t('ui.folder_name')}
-          />
-        </div>
-        <DialogFooter>
+    <AppModal
+      open
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <AppModalContent size="sm">
+        <AppModalHeader title={t('ui.new_folder')} description={t('ui.folder_name')} />
+        <AppModalBody>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="new-folder-name">{t('ui.folder_name')}</Label>
+            <Input
+              ref={inputRef}
+              id="new-folder-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') submit();
+              }}
+              placeholder={t('ui.folder_name')}
+            />
+          </div>
+        </AppModalBody>
+        <AppModalFooter>
           <Button variant="outline" onClick={onClose}>
             {t('ui.cancel')}
           </Button>
           <Button onClick={submit} disabled={!name.trim()}>
             {t('ui.create')}
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }
 
@@ -155,35 +159,39 @@ export function UrlInputModal({
   };
 
   return (
-    <Dialog open onOpenChange={(next) => { if (!next) onClose(); }}>
-      <DialogContent className="sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle>{t('ui.add_url')}</DialogTitle>
-          <DialogDescription className="sr-only">{t('ui.add_url')}</DialogDescription>
-        </DialogHeader>
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="url-input">{t('ui.add_url')}</Label>
-          <Input
-            ref={inputRef}
-            id="url-input"
-            type="url"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') submit();
-            }}
-            placeholder="https://..."
-          />
-        </div>
-        <DialogFooter>
+    <AppModal
+      open
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <AppModalContent size="sm">
+        <AppModalHeader title={t('ui.add_url')} />
+        <AppModalBody>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="url-input">{t('ui.add_url')}</Label>
+            <Input
+              ref={inputRef}
+              id="url-input"
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') submit();
+              }}
+              placeholder="https://..."
+            />
+          </div>
+        </AppModalBody>
+        <AppModalFooter>
           <Button variant="outline" onClick={onClose}>
             {t('ui.cancel')}
           </Button>
           <Button onClick={submit} disabled={!url.trim()}>
             {t('ui.add')}
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </AppModalFooter>
+      </AppModalContent>
+    </AppModal>
   );
 }

--- a/app/pages/CalendarPage.tsx
+++ b/app/pages/CalendarPage.tsx
@@ -23,13 +23,12 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  AppModal,
+  AppModalBody,
+  AppModalContent,
+  AppModalFooter,
+  AppModalHeader,
+} from '@/components/shared/AppModal';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Field, FieldLabel } from '@/components/ui/field';
 import { Spinner } from '@/components/ui/spinner';
@@ -435,42 +434,43 @@ const loadCalendars = useCallback(async () => {
       </div>
 
       {showImport && importPreview ? (
-        <Dialog open onOpenChange={(next) => { if (!next && !importBusy) setShowImport(false); }}>
-          <DialogContent className="sm:max-w-md">
-            <DialogHeader>
-              <DialogTitle>{t('calendarPage.import_title')}</DialogTitle>
-              <DialogDescription>
-                {t('calendarPage.import_preview', { count: importPreview.events.length, raw: importPreview.rawCount })}
-              </DialogDescription>
-            </DialogHeader>
+        <AppModal open onOpenChange={(next) => { if (!next && !importBusy) setShowImport(false); }}>
+          <AppModalContent size="md">
+            <AppModalHeader
+              title={t('calendarPage.import_title')}
+              description={t('calendarPage.import_preview', {
+                count: importPreview.events.length,
+                raw: importPreview.rawCount,
+              })}
+            />
+            <AppModalBody>
+              <Field className="gap-1.5">
+                <FieldLabel className="text-xs">{t('calendarPage.import_target')}</FieldLabel>
+                <Select
+                  value={importTargetId || null}
+                  onValueChange={(next) => { if (next != null) setImportTargetId(String(next)); }}
+                  items={calendars.map((c) => ({ value: c.id, label: c.title }))}
+                >
+                  <SelectTrigger className="w-full"><SelectValue placeholder="—" /></SelectTrigger>
+                  <SelectContent>
+                    {calendars.map((c) => (
+                      <SelectItem key={c.id} value={c.id}>
+                        <span className="block truncate">{c.title}</span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
 
-            <Field className="gap-1.5">
-              <FieldLabel className="text-xs">{t('calendarPage.import_target')}</FieldLabel>
-              <Select
-                value={importTargetId || null}
-                onValueChange={(next) => { if (next != null) setImportTargetId(String(next)); }}
-                items={calendars.map((c) => ({ value: c.id, label: c.title }))}
-              >
-                <SelectTrigger className="w-full"><SelectValue placeholder="—" /></SelectTrigger>
-                <SelectContent>
-                  {calendars.map((c) => (
-                    <SelectItem key={c.id} value={c.id}>
-                      <span className="block truncate">{c.title}</span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Field>
-
-            <FieldLabel className="flex items-center gap-2 text-sm font-normal">
-              <Checkbox
-                checked={importSkipDup}
-                onCheckedChange={(checked) => setImportSkipDup(checked === true)}
-              />
-              {t('calendarPage.import_skip_dup')}
-            </FieldLabel>
-
-            <DialogFooter>
+              <FieldLabel className="mt-3 flex items-center gap-2 text-sm font-normal">
+                <Checkbox
+                  checked={importSkipDup}
+                  onCheckedChange={(checked) => setImportSkipDup(checked === true)}
+                />
+                {t('calendarPage.import_skip_dup')}
+              </FieldLabel>
+            </AppModalBody>
+            <AppModalFooter>
               <Button type="button" variant="outline" disabled={importBusy} onClick={() => setShowImport(false)}>
                 {t('common.cancel')}
               </Button>
@@ -482,9 +482,9 @@ const loadCalendars = useCallback(async () => {
               >
                 {t('calendarPage.import_confirm')}
               </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+            </AppModalFooter>
+          </AppModalContent>
+        </AppModal>
       ) : null}
 
       {dayModalDate ? (


### PR DESCRIPTION
## Summary
- Introduce shared `AppModal` shell (header/body/footer) for form and picker dialogs
- Align `ConfirmDialog` (danger icon, busy/disabled, optional children) as the single confirmation surface
- Migrate workspace/home, learn, pipelines, settings, and related consumers off ad-hoc Dialog/AlertDialog layouts

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run check:sonar-patterns` (+ `--diff=origin/main`)
- [x] `pnpm run check:ipc-inventory`
- [x] `pnpm run depcruise`
- [x] `pnpm run build`
- [ ] Smoke: Move to folder, bulk delete, New folder, one orchestration ConfirmDialog