### PR TITLE
feat: automate hourly Self-Harness experiments

### DIFF
--- a/Jenkinsfile.self-harness
+++ b/Jenkinsfile.self-harness
@@ -1,0 +1,222 @@
+pipeline {
+  agent any
+
+  triggers {
+    cron('H * * * *')
+  }
+
+  options {
+    skipDefaultCheckout(true)
+    disableConcurrentBuilds(abortPrevious: false)
+    buildDiscarder(logRotator(numToKeepStr: '30', artifactNumToKeepStr: '14'))
+    timeout(time: 24, unit: 'HOURS')
+  }
+
+  environment {
+    PNPM_VERSION = '11.8.0'
+    NODE_VERSION = '24.13.0'
+    NODE_HOME = "${WORKSPACE}/.jenkins-node"
+    PATH = "${WORKSPACE}/.jenkins-tools/bin:${WORKSPACE}/.jenkins-node/bin:${env.PATH}"
+    GITHUB_REPOSITORY = 'maxprain12/dome'
+    XVFB_DISPLAY = ':99'
+    SELF_HARNESS_PROVIDER = 'minimax'
+    SELF_HARNESS_MODEL = 'MiniMax-M2.7'
+    SELF_HARNESS_ROUNDS = '5'
+    SELF_HARNESS_WIDTH = '4'
+    SELF_HARNESS_REPEATS = '2'
+    SELF_HARNESS_CONCURRENCY = '1'
+  }
+
+  stages {
+    stage('Checkout trusted main') {
+      steps {
+        checkout scm
+        sh '''
+          set -eux
+          git fetch origin main
+          git checkout --detach origin/main
+          git status --short
+        '''
+      }
+    }
+
+    stage('Agent preflight') {
+      steps {
+        withCredentials([
+          string(credentialsId: 'github-quality-loop', variable: 'GITHUB_TOKEN'),
+        ]) {
+          sh '''
+            set -eux
+            bash scripts/jenkins/bootstrap-agent-tools.sh "$PWD"
+            bash scripts/jenkins/agent-preflight.sh "$PWD"
+          '''
+        }
+      }
+    }
+
+    stage('Setup') {
+      steps {
+        sh '''
+          set -eux
+          if ! command -v node >/dev/null 2>&1 || ! node --version | grep -q '^v24'; then
+            ARCH="$(uname -m)"
+            case "$ARCH" in
+              x86_64) NODE_ARCH=linux-x64 ;;
+              aarch64|arm64) NODE_ARCH=linux-arm64 ;;
+              *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+            esac
+            mkdir -p "$NODE_HOME"
+            curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${NODE_ARCH}.tar.gz" \
+              | tar -xzf - --strip-components=1 -C "$NODE_HOME"
+          fi
+          node --version
+          npm install -g "pnpm@${PNPM_VERSION}"
+          pnpm --version
+        '''
+      }
+    }
+
+    stage('Install') {
+      steps {
+        sh '''
+          set -eux
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm run build:packages
+          npm rebuild better-sqlite3
+          node -e "require('better-sqlite3')"
+          pnpm run test:self-harness
+        '''
+      }
+    }
+
+    stage('Initialize full experiment') {
+      steps {
+        sh '''
+          set -eux
+          mkdir -p .dome-self-harness
+          EXPERIMENT_ID="jenkins-${BUILD_NUMBER}-$(date -u +%Y%m%dT%H%M%SZ)"
+          printf '%s\n' "$EXPERIMENT_ID" > .dome-self-harness/jenkins-experiment-id
+          pnpm self-harness:init -- \
+            --provider "$SELF_HARNESS_PROVIDER" \
+            --model "$SELF_HARNESS_MODEL" \
+            --id "$EXPERIMENT_ID" \
+            --base-sha "$(git rev-parse HEAD)" \
+            --rounds "$SELF_HARNESS_ROUNDS" \
+            --width "$SELF_HARNESS_WIDTH" \
+            --repeats "$SELF_HARNESS_REPEATS" \
+            --concurrency "$SELF_HARNESS_CONCURRENCY"
+        '''
+        script {
+          env.SELF_HARNESS_EXPERIMENT = readFile('.dome-self-harness/jenkins-experiment-id').trim()
+          currentBuild.description = "${env.SELF_HARNESS_MODEL} · ${env.SELF_HARNESS_EXPERIMENT}"
+        }
+      }
+    }
+
+    stage('Run full Self-Harness suite') {
+      steps {
+        withCredentials([
+          string(credentialsId: 'minimax-api-key', variable: 'MINIMAX_API_KEY'),
+        ]) {
+          sh '''
+            set -eu
+            export MINIMAX_BENCH_API_KEY="$MINIMAX_API_KEY"
+            bash scripts/jenkins/run-with-display.sh \
+              pnpm self-harness:run -- \
+                --experiment "$SELF_HARNESS_EXPERIMENT" \
+                --rounds "$SELF_HARNESS_ROUNDS" \
+                --width "$SELF_HARNESS_WIDTH" \
+                --repeats "$SELF_HARNESS_REPEATS"
+          '''
+        }
+      }
+    }
+
+    stage('Report and promotion decision') {
+      steps {
+        sh '''
+          set -eux
+          pnpm self-harness:report -- --experiment "$SELF_HARNESS_EXPERIMENT"
+          node scripts/jenkins/self-harness-ci-result.mjs \
+            --experiment "$SELF_HARNESS_EXPERIMENT" \
+            --output .dome-self-harness/jenkins-result.json \
+            --pr-body .dome-self-harness/jenkins-pr-body.md
+        '''
+        script {
+          def result = new groovy.json.JsonSlurperClassic().parseText(
+            readFile('.dome-self-harness/jenkins-result.json'),
+          )
+          env.SELF_HARNESS_HAS_PROMOTION = result.hasPromotion.toString()
+          env.SELF_HARNESS_BRANCH = result.branch ?: ''
+          currentBuild.description = result.hasPromotion
+            ? "winner · ${result.promotedEdits} edit(s) · ${result.experimentId}"
+            : "no winner · ${result.experimentId}"
+        }
+      }
+    }
+
+    stage('Create review branch') {
+      when {
+        expression { return env.SELF_HARNESS_HAS_PROMOTION == 'true' }
+      }
+      steps {
+        sh '''
+          set -eux
+          git config user.email "jenkins@dowi.es"
+          git config user.name "Jenkins Self-Harness"
+          pnpm self-harness:promote -- \
+            --experiment "$SELF_HARNESS_EXPERIMENT" \
+            --branch "$SELF_HARNESS_BRANCH"
+          test "$(git rev-list --count "$(git rev-parse HEAD)..$SELF_HARNESS_BRANCH")" -eq 1
+        '''
+      }
+    }
+
+    stage('Push PR and enable auto-merge') {
+      when {
+        expression { return env.SELF_HARNESS_HAS_PROMOTION == 'true' }
+      }
+      steps {
+        withCredentials([
+          string(credentialsId: 'github-quality-loop', variable: 'GITHUB_TOKEN'),
+        ]) {
+          sh '''
+            set -eux
+            JENKINS_GH_SETUP_GIT=1 bash scripts/jenkins/gh-auth-env.sh
+            git push --set-upstream origin "$SELF_HARNESS_BRANCH"
+            PR_URL="$(gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$SELF_HARNESS_BRANCH" \
+              --title "feat: Self-Harness improvement ${SELF_HARNESS_EXPERIMENT}" \
+              --body-file .dome-self-harness/jenkins-pr-body.md)"
+            printf '%s\n' "$PR_URL" | tee .dome-self-harness/jenkins-pr-url.txt
+            gh pr merge "$PR_URL" --repo "$GITHUB_REPOSITORY" --auto --squash
+          '''
+        }
+      }
+    }
+  }
+
+  post {
+    always {
+      sh '''
+        set +e
+        if [ -f .dome-self-harness/jenkins-experiment-id ]; then
+          EXPERIMENT_ID="$(cat .dome-self-harness/jenkins-experiment-id)"
+          pnpm self-harness:report -- --experiment "$EXPERIMENT_ID"
+          tar -czf .dome-self-harness/jenkins-experiment.tar.gz \
+            --exclude='profiles' \
+            -C .dome-self-harness/experiments "$EXPERIMENT_ID"
+        fi
+        git worktree prune
+      '''
+      archiveArtifacts(
+        artifacts: '.dome-self-harness/jenkins-experiment.tar.gz,.dome-self-harness/jenkins-result.json,.dome-self-harness/jenkins-pr-body.md,.dome-self-harness/jenkins-pr-url.txt,.dome-self-harness/experiments/*/report.md,.dome-self-harness/experiments/*/winning-lineage.patch',
+        allowEmptyArchive: true,
+        fingerprint: true,
+      )
+      cleanWs()
+    }
+  }
+}

--- a/docs/features/self-harness.md
+++ b/docs/features/self-harness.md
@@ -32,3 +32,16 @@ A candidate is accepted only when it improves at least one split without reducin
 The experiment manifest fixes the base commit, provider, model, split, seed, evaluator version, repeat count, concurrency, and budgets. `self-harness:resume` continues from the persisted state machine after an interruption.
 
 Use `pnpm run test:self-harness` for control-plane tests. Real experiments require the same provider credential variables used by the Dome bench.
+
+## Hourly Jenkins run
+
+[`Jenkinsfile.self-harness`](../../Jenkinsfile.self-harness) runs the complete default experiment every hour (`5` rounds, `4` candidates per round, `2` repetitions) against a detached checkout of `origin/main`. Concurrent executions are disabled, so a slow experiment cannot overlap another run.
+
+Configure a Pipeline from SCM using `Jenkinsfile.self-harness`. It reuses the repository's existing Jenkins string credentials:
+
+- `minimax-api-key` for the fixed `minimax/MiniMax-M2.7` proposer and benchmark runtime.
+- `github-quality-loop` for pushing the generated branch and operating the GitHub CLI.
+
+Every run archives its reproducibility bundle and report. A completed experiment with no accepted lineage does not create a branch or PR. When at least one candidate survives all static, held-in, and sealed held-out gates, Jenkins creates the review branch, pushes it, opens a PR against `main`, and requests squash auto-merge. GitHub branch protection and required CI checks remain authoritative; Jenkins never merges directly or bypasses them.
+
+The job is serialized and has a 24-hour timeout because the full suite may take longer than its one-hour trigger interval. Jenkins queues the next timer execution instead of running two experiments against the same worker concurrently.

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "self-harness:resume": "node scripts/self-harness/cli.mjs resume",
     "self-harness:report": "node scripts/self-harness/cli.mjs report",
     "self-harness:promote": "node scripts/self-harness/cli.mjs promote",
-    "test:self-harness": "node --test scripts/self-harness/__tests__/*.test.mjs",
+    "test:self-harness": "node --test scripts/self-harness/__tests__/*.test.mjs scripts/jenkins/__tests__/self-harness-ci-result.test.mjs",
     "clean": "bash scripts/clean.sh",
     "generate-icons": "tsx scripts/generate-icons.ts",
     "windows:startup-diag": "node scripts/windows-startup-diag.mjs",

--- a/scripts/jenkins/__tests__/self-harness-ci-result.test.mjs
+++ b/scripts/jenkins/__tests__/self-harness-ci-result.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCiResult, buildPrBody } from "../self-harness-ci-result.mjs";
+
+function fixture(lineage = []) {
+  return {
+    dir: "/repo/.dome-self-harness/experiments/jenkins-42",
+    manifest: {
+      id: "jenkins-42-20260718T220000Z",
+      provider: "minimax",
+      model: "MiniMax-M2.7",
+      baseSha: "abc123",
+      manifestHash: "manifest-hash",
+    },
+    state: { phase: "completed", round: 5, lineage },
+  };
+}
+
+test("completed experiment without a lineage does not request publication", () => {
+  const result = buildCiResult(fixture());
+  assert.equal(result.hasPromotion, false);
+  assert.equal(result.branch, null);
+  assert.equal(result.promotedEdits, 0);
+});
+
+test("winning lineage produces a deterministic feature branch and PR body", () => {
+  const result = buildCiResult({
+    ...fixture([{ proposalId: "r0-c2" }, { proposalId: "r3-c1" }]),
+    buildUrl: "https://jenkins.example/job/42/",
+  });
+  assert.equal(result.hasPromotion, true);
+  assert.equal(
+    result.branch,
+    "feat/self-harness-minimax-m2-7-jenkins-42-20260718t220000z",
+  );
+  assert.deepEqual(result.winningProposalIds, ["r0-c2", "r3-c1"]);
+  assert.match(
+    buildPrBody(result),
+    /GitHub branch protection remains authoritative/,
+  );
+  assert.match(buildPrBody(result), /https:\/\/jenkins\.example\/job\/42\//);
+});
+
+test("incomplete experiment cannot be published", () => {
+  assert.throws(
+    () =>
+      buildCiResult({
+        ...fixture(),
+        state: { phase: "failed", round: 1, lineage: [] },
+      }),
+    /expected completed/,
+  );
+});

--- a/scripts/jenkins/self-harness-ci-result.mjs
+++ b/scripts/jenkins/self-harness-ci-result.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { inspectExperiment } from "../self-harness/controller.mjs";
+import { sanitizeSlug, writeJson } from "../self-harness/io.mjs";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+export function buildCiResult({ manifest, state, dir, buildUrl = null }) {
+  if (state.phase !== "completed") {
+    throw new Error(
+      `Experiment ${manifest.id} is ${state.phase}; expected completed`,
+    );
+  }
+
+  const hasPromotion = state.lineage.length > 0;
+  const branch = hasPromotion
+    ? `feat/self-harness-${sanitizeSlug(manifest.model)}-${sanitizeSlug(manifest.id)}`
+    : null;
+  return {
+    schemaVersion: 1,
+    experimentId: manifest.id,
+    provider: manifest.provider,
+    model: manifest.model,
+    baseSha: manifest.baseSha,
+    manifestHash: manifest.manifestHash,
+    completedRounds: state.round,
+    promotedEdits: state.lineage.length,
+    winningProposalIds: state.lineage.map((entry) => entry.proposalId),
+    hasPromotion,
+    branch,
+    reportPath: path.relative(REPO_ROOT, path.join(dir, "report.md")),
+    buildUrl,
+  };
+}
+
+export function buildPrBody(result) {
+  const proposals = result.winningProposalIds
+    .map((id) => `- \`${id}\``)
+    .join("\n");
+  return `## Automated Self-Harness improvement
+
+Jenkins completed the sealed Self-Harness suite and found a non-regressive winning lineage.
+
+| Field | Value |
+|---|---|
+| Experiment | \`${result.experimentId}\` |
+| Model | \`${result.provider}/${result.model}\` |
+| Base commit | \`${result.baseSha}\` |
+| Completed rounds | ${result.completedRounds} |
+| Promoted edits | ${result.promotedEdits} |
+| Jenkins build | ${result.buildUrl ? `[open build](${result.buildUrl})` : "not available"} |
+
+### Winning proposals
+
+${proposals || "_None._"}
+
+Every promoted candidate passed the repository static gates plus repeated held-in and sealed held-out evaluation. Auto-merge is requested, but GitHub branch protection remains authoritative and will wait for all required checks.
+`;
+}
+
+function parseArgs(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const item = argv[index];
+    if (!item.startsWith("--")) continue;
+    const key = item.slice(2);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--"))
+      throw new Error(`Missing value for ${item}`);
+    result[key] = value;
+    index += 1;
+  }
+  return result;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.experiment) throw new Error("Missing --experiment");
+  const output = path.resolve(
+    args.output || ".dome-self-harness/jenkins-result.json",
+  );
+  const prBody = path.resolve(
+    args["pr-body"] || ".dome-self-harness/jenkins-pr-body.md",
+  );
+  const result = buildCiResult({
+    ...inspectExperiment(args.experiment),
+    buildUrl: process.env.BUILD_URL || null,
+  });
+  writeJson(output, result);
+  fs.mkdirSync(path.dirname(prBody), { recursive: true });
+  fs.writeFileSync(prBody, buildPrBody(result), "utf8");
+  console.log(JSON.stringify(result));
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[self-harness-ci-result] ${error.message}`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- add an hourly, serialized Jenkins pipeline for the complete Self-Harness suite
- archive reproducibility artifacts and publish only completed experiments with accepted lineage
- create a review branch and PR, then request squash auto-merge behind GitHub required checks
- add tested CI decision/PR metadata generation and setup documentation

## Validation

- `pnpm run test:self-harness` (11/11)
- `pnpm run typecheck`
- `pnpm run lint` (existing warnings only)
- `pnpm run build`
- `pnpm run check:ipc-inventory`
- `pnpm run check:sonar-patterns`
- `pnpm run check:sonar-patterns -- --diff=origin/main`
- `pnpm run depcruise`
- shell syntax validation for all 10 Jenkins `sh` blocks

The real paid 5x4x2 experiment is intentionally left to the Jenkins job using its sealed `minimax-api-key` credential.