### PR TITLE
fix: allow Self-Harness worktrees to fetch locked packages

### DIFF
--- a/docs/features/self-harness.md
+++ b/docs/features/self-harness.md
@@ -21,6 +21,8 @@ The proposer can search and read only declared harness paths and must submit a u
 
 Candidates run in detached temporary worktrees with isolated `DOME_PROFILE` and `DOME_BENCH_USER_DATA`. A candidate must pass the repository gates before benchmark evaluation.
 
+Worktree dependency installation uses the frozen lockfile and prefers the local pnpm store. If an exact locked tarball is absent, pnpm may fetch it from the configured registry; this avoids making a warm Jenkins cache a hidden prerequisite while preserving deterministic dependency versions.
+
 ## Promotion rule
 
 A candidate is accepted only when it improves at least one split without reducing pass count on either held-in or held-out. Errors and timeouts may not increase, no security violation is allowed, and total tokens and p95 duration may grow by at most 20%.

--- a/scripts/self-harness/__tests__/core.test.mjs
+++ b/scripts/self-harness/__tests__/core.test.mjs
@@ -6,6 +6,8 @@ import { isEditablePath, repoRead, validatePatch } from '../policy.mjs';
 import { createStratifiedSplit } from '../split.mjs';
 import { REPO_ROOT } from '../constants.mjs';
 import { SELF_HARNESS_SCHEMAS } from '../schema-catalog.mjs';
+import { DEPENDENCY_INSTALL_ARGS } from '../execution.mjs';
+import { describeGateFailure } from '../controller.mjs';
 
 const validPatch = `diff --git a/electron/agents/agent-runtime.cjs b/electron/agents/agent-runtime.cjs
 --- a/electron/agents/agent-runtime.cjs
@@ -99,4 +101,18 @@ test('schema catalog covers every persisted public artifact', () => {
   ]) {
     assert.equal(SELF_HARNESS_SCHEMAS[name].type, 'object');
   }
+});
+
+test('worktree install prefers cache but can fetch a missing locked tarball', () => {
+  assert.equal(DEPENDENCY_INSTALL_ARGS.includes('--frozen-lockfile'), true);
+  assert.equal(DEPENDENCY_INSTALL_ARGS.includes('--prefer-offline'), true);
+  assert.equal(DEPENDENCY_INSTALL_ARGS.includes('--offline'), false);
+});
+
+test('static gate failures include the failing command output', () => {
+  const message = describeGateFailure([
+    { name: 'install', code: 1, stdout: 'ERR_PNPM_NO_OFFLINE_TARBALL missing package' },
+  ]);
+  assert.match(message, /install exited with code 1/);
+  assert.match(message, /ERR_PNPM_NO_OFFLINE_TARBALL/);
 });

--- a/scripts/self-harness/controller.mjs
+++ b/scripts/self-harness/controller.mjs
@@ -133,6 +133,16 @@ function phase(dir, state, name, extra = {}) {
   return updateState(dir, state, { ...extra, phase: name, lastActivePhase: name });
 }
 
+export function describeGateFailure(results) {
+  const failed = results.find((result) => result.code !== 0);
+  if (!failed) return 'unknown static gate failure';
+  const output = String(failed.stderr || failed.stdout || '')
+    .trim()
+    .slice(-2_000);
+  const detail = output ? `: ${output}` : '';
+  return `${failed.name} exited with code ${failed.code}${detail}`;
+}
+
 export async function runExperiment(id, options = {}, injectedAdapters = {}) {
   const adapters = { ...DEFAULT_ADAPTERS, ...injectedAdapters };
   const loaded = loadExperiment(id);
@@ -161,7 +171,9 @@ export async function runExperiment(id, options = {}, injectedAdapters = {}) {
 
       const baselineGates = options.skipGates ? [{ name: 'skipped', code: 0 }] : await adapters.gates(activeWorktree, manifest);
       persistArtifact(dir, `rounds/${round}/baseline-gates.json`, baselineGates);
-      if (!gatesPassed(baselineGates)) throw new Error(`Active harness failed static gates in round ${round}`);
+      if (!gatesPassed(baselineGates)) {
+        throw new Error(`Active harness failed static gates in round ${round}: ${describeGateFailure(baselineGates)}`);
+      }
 
       const baselineRecords = await adapters.evaluate({
         worktree: activeWorktree, dir, manifest, candidateId: 'baseline', round, repeats,

--- a/scripts/self-harness/execution.mjs
+++ b/scripts/self-harness/execution.mjs
@@ -27,6 +27,13 @@ function runProcess(command, args, options = {}) {
   });
 }
 
+export const DEPENDENCY_INSTALL_ARGS = Object.freeze([
+  'install',
+  '--frozen-lockfile',
+  '--prefer-offline',
+  '--ignore-scripts',
+]);
+
 export function createWorktree({ baseSha, experimentId, label, patches = [] }) {
   const parent = ensureDir(path.join(os.tmpdir(), 'dome-self-harness-worktrees'));
   const worktree = fs.mkdtempSync(path.join(parent, `${sanitizeSlug(experimentId)}-${sanitizeSlug(label)}-`));
@@ -64,7 +71,7 @@ export function applyPatch(worktree, patch) {
 }
 
 export async function prepareDependencies(worktree, timeoutMs) {
-  return runProcess('pnpm', ['install', '--frozen-lockfile', '--offline', '--ignore-scripts'], {
+  return runProcess('pnpm', DEPENDENCY_INSTALL_ARGS, {
     cwd: worktree,
     timeoutMs,
   });


### PR DESCRIPTION
## Cause

Jenkins build #1 failed before baseline evaluation because the isolated worktree forced `pnpm install --offline`. Its pnpm store did not contain the exact tarball for `@base-ui-components/react@1.0.0-rc.0`, producing `ERR_PNPM_NO_OFFLINE_TARBALL`.

## Fix

- use `--prefer-offline` with the frozen lockfile so cached packages remain preferred while missing exact tarballs can be fetched
- include the failing gate name, exit code, and captured output in the Jenkins console error
- add regression tests for both behaviors

## Validation

- `pnpm run test:self-harness` (13/13)
- `pnpm run typecheck`
- `pnpm run lint` (existing warnings only)
- `pnpm run build`
- `pnpm run check:ipc-inventory`
- `pnpm run check:sonar-patterns`
- `pnpm run check:sonar-patterns -- --diff=origin/main`
- `pnpm run depcruise`