### PR TITLE
fix: prepare Electron runtime in Self-Harness worktrees

### DIFF
--- a/docs/features/self-harness.md
+++ b/docs/features/self-harness.md
@@ -23,6 +23,8 @@ Candidates run in detached temporary worktrees with isolated `DOME_PROFILE` and 
 
 Worktree dependency installation uses the frozen lockfile and prefers the local pnpm store. If an exact locked tarball is absent, pnpm may fetch it from the configured registry; this avoids making a warm Jenkins cache a hidden prerequisite while preserving deterministic dependency versions.
 
+General dependency lifecycle scripts remain disabled. The controller explicitly materializes the locked Electron binary and then runs Dome's trusted `rebuild:natives` command so `better-sqlite3` and the other approved native runtimes match Electron's ABI before any benchmark starts.
+
 ## Promotion rule
 
 A candidate is accepted only when it improves at least one split without reducing pass count on either held-in or held-out. Errors and timeouts may not increase, no security violation is allowed, and total tokens and p95 duration may grow by at most 20%.

--- a/scripts/self-harness/__tests__/core.test.mjs
+++ b/scripts/self-harness/__tests__/core.test.mjs
@@ -6,7 +6,7 @@ import { isEditablePath, repoRead, validatePatch } from '../policy.mjs';
 import { createStratifiedSplit } from '../split.mjs';
 import { REPO_ROOT } from '../constants.mjs';
 import { SELF_HARNESS_SCHEMAS } from '../schema-catalog.mjs';
-import { DEPENDENCY_INSTALL_ARGS } from '../execution.mjs';
+import { DEPENDENCY_INSTALL_ARGS, RUNTIME_PREPARATION_COMMANDS } from '../execution.mjs';
 import { describeGateFailure } from '../controller.mjs';
 
 const validPatch = `diff --git a/electron/agents/agent-runtime.cjs b/electron/agents/agent-runtime.cjs
@@ -107,6 +107,16 @@ test('worktree install prefers cache but can fetch a missing locked tarball', ()
   assert.equal(DEPENDENCY_INSTALL_ARGS.includes('--frozen-lockfile'), true);
   assert.equal(DEPENDENCY_INSTALL_ARGS.includes('--prefer-offline'), true);
   assert.equal(DEPENDENCY_INSTALL_ARGS.includes('--offline'), false);
+});
+
+test('worktree preparation materializes Electron and its native ABI dependencies', () => {
+  assert.deepEqual(
+    RUNTIME_PREPARATION_COMMANDS.map(({ name, args }) => ({ name, args: [...args] })),
+    [
+      { name: 'rebuild:electron', args: ['rebuild', 'electron'] },
+      { name: 'rebuild:natives', args: ['run', 'rebuild:natives'] },
+    ],
+  );
 });
 
 test('static gate failures include the failing command output', () => {

--- a/scripts/self-harness/execution.mjs
+++ b/scripts/self-harness/execution.mjs
@@ -34,6 +34,19 @@ export const DEPENDENCY_INSTALL_ARGS = Object.freeze([
   '--ignore-scripts',
 ]);
 
+export const RUNTIME_PREPARATION_COMMANDS = Object.freeze([
+  Object.freeze({
+    name: 'rebuild:electron',
+    command: 'pnpm',
+    args: Object.freeze(['rebuild', 'electron']),
+  }),
+  Object.freeze({
+    name: 'rebuild:natives',
+    command: 'pnpm',
+    args: Object.freeze(['run', 'rebuild:natives']),
+  }),
+]);
+
 export function createWorktree({ baseSha, experimentId, label, patches = [] }) {
   const parent = ensureDir(path.join(os.tmpdir(), 'dome-self-harness-worktrees'));
   const worktree = fs.mkdtempSync(path.join(parent, `${sanitizeSlug(experimentId)}-${sanitizeSlug(label)}-`));
@@ -71,17 +84,25 @@ export function applyPatch(worktree, patch) {
 }
 
 export async function prepareDependencies(worktree, timeoutMs) {
-  return runProcess('pnpm', DEPENDENCY_INSTALL_ARGS, {
+  const results = [];
+  const install = await runProcess('pnpm', DEPENDENCY_INSTALL_ARGS, {
     cwd: worktree,
     timeoutMs,
   });
+  results.push({ name: 'install', ...install });
+  if (install.code !== 0) return results;
+
+  for (const step of RUNTIME_PREPARATION_COMMANDS) {
+    const result = await runProcess(step.command, step.args, { cwd: worktree, timeoutMs });
+    results.push({ name: step.name, ...result });
+    if (result.code !== 0) break;
+  }
+  return results;
 }
 
 export async function runStaticGates(worktree, { timeoutMs, gates = DEFAULT_GATES } = {}) {
-  const results = [];
-  const install = await prepareDependencies(worktree, timeoutMs);
-  results.push({ name: 'install', ...install });
-  if (install.code !== 0) return results;
+  const results = await prepareDependencies(worktree, timeoutMs);
+  if (!gatesPassed(results)) return results;
 
   const buildPackages = await runProcess('pnpm', ['run', 'build:packages'], { cwd: worktree, timeoutMs });
   results.push({ name: 'build:packages', ...buildPackages });


### PR DESCRIPTION
## Cause

Self-Harness worktrees intentionally install with lifecycle scripts disabled. The static gates passed, but the benchmark could not start because Electron's postinstall had not materialized its binary. The next failure would also have been `better-sqlite3` built for the wrong ABI.

## Fix

- keep general dependency lifecycle scripts disabled
- explicitly run the approved Electron rebuild after the frozen install
- run Dome's trusted `rebuild:natives` command so `better-sqlite3` and other native modules match Electron's ABI
- persist both preparation steps as named static gates
- add regression coverage and operational documentation

## Validation

- `pnpm run test:self-harness` (14/14)
- clean isolated worktree install + Electron rebuild + native rebuild
- real Electron headless dry-run of `web_search.basic`, including SQLite initialization
- `pnpm run typecheck`
- `pnpm run check:ipc-inventory`
- `pnpm run check:sonar-patterns`
- `pnpm run check:sonar-patterns -- --diff=origin/main`
- `pnpm run depcruise`