### PR TITLE
fix: run Electron bench in Jenkins Docker

### DIFF
--- a/Jenkinsfile.self-harness
+++ b/Jenkinsfile.self-harness
@@ -25,6 +25,7 @@ pipeline {
     SELF_HARNESS_WIDTH = '4'
     SELF_HARNESS_REPEATS = '2'
     SELF_HARNESS_CONCURRENCY = '1'
+    DOME_BENCH_NO_SANDBOX = '1'
   }
 
   stages {

--- a/docs/features/self-harness.md
+++ b/docs/features/self-harness.md
@@ -49,3 +49,5 @@ Configure a Pipeline from SCM using `Jenkinsfile.self-harness`. It reuses the re
 Every run archives its reproducibility bundle and report. A completed experiment with no accepted lineage does not create a branch or PR. When at least one candidate survives all static, held-in, and sealed held-out gates, Jenkins creates the review branch, pushes it, opens a PR against `main`, and requests squash auto-merge. GitHub branch protection and required CI checks remain authoritative; Jenkins never merges directly or bypasses them.
 
 The job is serialized and has a 24-hour timeout because the full suite may take longer than its one-hour trigger interval. Jenkins queues the next timer execution instead of running two experiments against the same worker concurrently.
+
+The Docker job opts the benchmark process into `DOME_BENCH_NO_SANDBOX=1`. This adds Chromium's `--no-sandbox` flags only to the Linux Electron benchmark launched inside the isolated Jenkins container, where the SUID helper cannot be owned by root. Normal Dome and local benchmark launches retain Electron's sandbox.

--- a/electron/__tests__/bench-self-harness-options.test.mjs
+++ b/electron/__tests__/bench-self-harness-options.test.mjs
@@ -6,6 +6,7 @@ const require = createRequire(import.meta.url);
 const { parseBenchArgs } = require('../bench/parse-args.cjs');
 const { loadCaseFiles } = require('../bench/runner.cjs');
 const { validateBehavior } = require('../bench/validators.cjs');
+const { buildElectronLaunchArgs } = require('../bench/electron-launch-args.cjs');
 
 test('bench parses Self-Harness control-plane flags', () => {
   const args = parseBenchArgs([
@@ -37,4 +38,34 @@ test('behavior verifier rejects repeated tools and premature finalization', () =
     { type: 'done' },
   ]);
   assert.match(premature.reason, /no final text/);
+});
+
+test('Electron sandbox bypass is Linux CI opt-in only', () => {
+  const regular = buildElectronLaunchArgs({
+    benchMain: '/repo/electron/bench/main.cjs',
+    flags: ['--dry-run'],
+    platform: 'linux',
+    env: {},
+  });
+  assert.deepEqual(regular, ['/repo/electron/bench/main.cjs', '--dry-run']);
+
+  const dockerCi = buildElectronLaunchArgs({
+    benchMain: '/repo/electron/bench/main.cjs',
+    flags: ['--dry-run'],
+    platform: 'linux',
+    env: { DOME_BENCH_NO_SANDBOX: '1' },
+  });
+  assert.deepEqual(dockerCi, [
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '/repo/electron/bench/main.cjs',
+    '--dry-run',
+  ]);
+
+  const localMac = buildElectronLaunchArgs({
+    benchMain: '/repo/electron/bench/main.cjs',
+    platform: 'darwin',
+    env: { DOME_BENCH_NO_SANDBOX: '1' },
+  });
+  assert.deepEqual(localMac, ['/repo/electron/bench/main.cjs']);
 });

--- a/electron/bench/electron-launch-args.cjs
+++ b/electron/bench/electron-launch-args.cjs
@@ -1,0 +1,9 @@
+'use strict';
+
+function buildElectronLaunchArgs({ benchMain, flags = [], env = process.env, platform = process.platform }) {
+  const disableSandbox = platform === 'linux' && env.DOME_BENCH_NO_SANDBOX === '1';
+  const sandboxFlags = disableSandbox ? ['--no-sandbox', '--disable-setuid-sandbox'] : [];
+  return [...sandboxFlags, benchMain, ...flags];
+}
+
+module.exports = { buildElectronLaunchArgs };

--- a/scripts/bench/run.mjs
+++ b/scripts/bench/run.mjs
@@ -4,9 +4,12 @@
  * Usage: pnpm run bench:run -- [--grep web] [--grep 'studio|ui|file'] [--category studio,ui,file]
  */
 import { spawn } from 'child_process';
+import { createRequire } from 'module';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+const require = createRequire(import.meta.url);
+const { buildElectronLaunchArgs } = require('../../electron/bench/electron-launch-args.cjs');
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, '../..');
 
@@ -16,10 +19,11 @@ const benchMain = path.join(ROOT, 'electron', 'bench', 'main.cjs');
 const extraArgs = process.argv.slice(2);
 const dash = extraArgs.indexOf('--');
 const flags = dash >= 0 ? extraArgs.slice(dash + 1) : extraArgs;
+const electronArgs = buildElectronLaunchArgs({ benchMain, flags });
 
 const child = spawn(
   process.execPath,
-  [electronBin, benchMain, ...flags],
+  [electronBin, ...electronArgs],
   {
     cwd: ROOT,
     stdio: 'inherit',


### PR DESCRIPTION
## Summary
- opt the Jenkins Self-Harness benchmark into Chromium no-sandbox mode on Linux Docker
- keep Electron sandboxing enabled for normal Dome and local benchmark runs
- cover launch argument selection with a platform and environment regression test

## Cause
The Jenkins container runs as an unprivileged user, so Electron cannot use a root-owned mode-4755 SUID sandbox helper inside the ephemeral Self-Harness worktree. Electron aborts before producing benchmark results.

## Validation
- `node --test electron/__tests__/bench-self-harness-options.test.mjs`
- `pnpm run test:self-harness`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run check:ipc-inventory`
- `pnpm run check:sonar-patterns`
- `pnpm run check:sonar-patterns -- --diff=origin/main`
- `pnpm run depcruise`