### PR TITLE
fix: guard event card index before migration

### DIFF
--- a/electron/__tests__/social-event-cards-migration.test.mjs
+++ b/electron/__tests__/social-event-cards-migration.test.mjs
@@ -5,6 +5,7 @@ import { DatabaseSync } from 'node:sqlite';
 
 const require = createRequire(import.meta.url);
 const { applyMigrations, SCHEMA_HEAD } = require('../core/db/migrations.cjs');
+const { ensureSocialPostEventCardIndex } = require('../core/db/schema.cjs');
 
 describe('social event cards migration', () => {
   it('adds event card fields and advances SQLite to v70', () => {
@@ -15,10 +16,14 @@ describe('social event cards migration', () => {
       CREATE TABLE social_posts (id TEXT PRIMARY KEY, body TEXT NOT NULL DEFAULT '');
       INSERT INTO settings (key, value, updated_at) VALUES ('schema_version', '69', 0);
     `);
+    assert.doesNotThrow(() => ensureSocialPostEventCardIndex(db));
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'index' AND name = 'idx_social_posts_event_card'").get().count, 0);
     applyMigrations(db, 69);
+    ensureSocialPostEventCardIndex(db);
     const columns = db.prepare("PRAGMA table_info('social_posts')").all().map((column) => column.name);
     assert.ok(columns.includes('event_card_id'));
     assert.ok(columns.includes('event_card_public_url'));
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'index' AND name = 'idx_social_posts_event_card'").get().count, 1);
     assert.equal(Number(db.prepare("SELECT value FROM settings WHERE key = 'schema_version'").get().value), SCHEMA_HEAD);
     db.close();
   });

--- a/electron/core/db/schema.cjs
+++ b/electron/core/db/schema.cjs
@@ -42,6 +42,20 @@ function applyJournalMode(db) {
   }
 }
 
+function ensureSocialPostEventCardIndex(db) {
+  try {
+    const columns = db
+      .prepare(`PRAGMA table_info(social_posts)`)
+      .all()
+      .map((column) => column.name);
+    if (columns.includes('event_card_id')) {
+      db.exec('CREATE INDEX IF NOT EXISTS idx_social_posts_event_card ON social_posts(event_card_id)');
+    }
+  } catch (err) {
+    console.warn('[DB] Could not ensure idx_social_posts_event_card:', err?.message || err);
+  }
+}
+
 function createBaseSchema(db) {
   // Enable optimizations
   db.exec('PRAGMA foreign_keys = ON');
@@ -1840,7 +1854,8 @@ function createBaseSchema(db) {
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_social_posts_status ON social_posts(status, scheduled_at)
   `);
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_social_posts_event_card ON social_posts(event_card_id)`);
+  // Existing databases do not receive v70 columns until migrations run below.
+  ensureSocialPostEventCardIndex(db);
 
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_social_reports_created ON social_reports(created_at)
@@ -2132,4 +2147,4 @@ function createSyncTriggers(db) {
   `);
 }
 
-module.exports = { createBaseSchema, createSyncTriggers };
+module.exports = { createBaseSchema, createSyncTriggers, ensureSocialPostEventCardIndex };


### PR DESCRIPTION
## Cause
createBaseSchema ran CREATE INDEX for social_posts.event_card_id before migration v70 added that column to existing databases.

## Fix
- guard index creation by inspecting PRAGMA table_info
- retain index creation in migration v70
- add regression coverage for the pre-v70 initialization order

## Validation
- focused migration regression test
- typecheck
- lint (no errors)
- Sonar diff
- UI contracts