### PR TITLE
fix(ai): unblock package build after Electron 41.10 types

### DIFF
--- a/packages/ai/src/utils/node-http-proxy.ts
+++ b/packages/ai/src/utils/node-http-proxy.ts
@@ -117,7 +117,7 @@ export function createHttpProxyAgentsForTarget(targetUrl: string | URL): NodeHtt
 	}
 
 	return {
-		httpAgent: new HttpProxyAgent(proxyUrl),
+		httpAgent: new HttpProxyAgent(proxyUrl) as unknown as HttpAgent,
 		httpsAgent: new HttpsProxyAgent(proxyUrl) as unknown as HttpsAgent,
 	};
 }


### PR DESCRIPTION
## Summary
- `HttpProxyAgent` from `http-proxy-agent` is not assignable to `node:http` `Agent` after Electron 41.10.3 / protobufjs landed.
- Apply the same `as unknown as Agent` assertion already used for the HTTPS agent so `pnpm run electron:dev` can build `@dome/ai`.

## Test plan
- [x] `pnpm --filter @dome/ai run build`
- [ ] `pnpm run electron:dev` starts locally