### PR TITLE
fix(sonar): lower formatVolatileSourceContext complexity (S3776)

### DIFF
--- a/shared/prompt-assembler/index.cjs
+++ b/shared/prompt-assembler/index.cjs
@@ -139,7 +139,8 @@ ${lines}`);
   }
 }
 function formatActiveResourceLine(activeResource) {
-  if (!activeResource?.id) return null;
+  if (!activeResource?.id)
+    return null;
   const type = activeResource.type ? ` / ${activeResource.type}` : "";
   return `**active-resource** \u2014 ${activeResource.id}${type}
 "${activeResource.title}". Call resource_get_active() to read content when needed.`;
@@ -171,7 +172,8 @@ function formatVolatileSourceContext(opts = {}) {
     formatPinnedResourceLine
   );
   const activeLine = formatActiveResourceLine(opts.activeResource);
-  if (activeLine) blocks.push(activeLine);
+  if (activeLine)
+    blocks.push(activeLine);
   blocks.push(`Task: ${defaultTaskLine(opts.taskLine)}`);
   return blocks.join("\n\n");
 }

--- a/shared/prompt-assembler/index.ts
+++ b/shared/prompt-assembler/index.ts
@@ -99,6 +99,12 @@ const VOICE_LANGUAGE_NAMES: Record<string, string> = {
   pt: 'Portuguese',
 };
 
+const PINNED_SOURCE_TOOL_HINTS: Record<string, string> = {
+  social_post: ' → social_post_get',
+  email: ' → email_read',
+  issue: ' → github_get_issue',
+};
+
 const CORE_SECTION_KEYS_LIST: (keyof CorePromptSections)[] = [
   'constraintsLanguage',
   'appContext',
@@ -112,6 +118,10 @@ const CORE_SECTION_KEYS_LIST: (keyof CorePromptSections)[] = [
 ];
 
 export const CORE_SECTION_KEYS = CORE_SECTION_KEYS_LIST;
+
+type PinnedPerson = NonNullable<VolatileSourceOptions['pinnedPeople']>[number];
+type PinnedSource = NonNullable<VolatileSourceOptions['pinnedSources']>[number];
+type PinnedResource = NonNullable<VolatileSourceOptions['pinnedResources']>[number];
 
 export function buildCoreToolsBlock(sections: CorePromptSections): string {
   const parts: string[] = [];
@@ -146,98 +156,103 @@ You are speaking aloud in a live voice conversation. Follow these rules:
 - Respond in ${langName}.`;
 }
 
+function formatPinnedPersonLine(person: PinnedPerson): string {
+  const identities = (person.identities || [])
+    .map((identity) => `${identity.source}:${identity.displayLabel || identity.externalId}`)
+    .join(', ');
+  return identities
+    ? `- ${person.id}: ${person.title} (${identities})`
+    : `- ${person.id}: ${person.title}`;
+}
+
+function formatPinnedSourceLine(src: PinnedSource): string {
+  const repo =
+    src.kind === 'issue' && typeof src.meta?.fullName === 'string'
+      ? ` repo=${src.meta.fullName}`
+      : '';
+  const folder =
+    src.kind === 'email' && typeof src.meta?.folder === 'string'
+      ? ` folder=${src.meta.folder}`
+      : '';
+  const provider =
+    src.kind === 'social_post' && typeof src.meta?.provider === 'string'
+      ? ` provider=${src.meta.provider}`
+      : '';
+  const status =
+    src.kind === 'social_post' && typeof src.meta?.status === 'string'
+      ? ` status=${src.meta.status}`
+      : '';
+  const body =
+    typeof src.meta?.body === 'string' && src.meta.body.trim()
+      ? `\n  body: ${src.meta.body.trim().slice(0, 2000)}`
+      : '';
+  const toolHint = PINNED_SOURCE_TOOL_HINTS[src.kind] || '';
+  return `- [${src.kind}] ${src.id}: ${src.title}${repo}${folder}${provider}${status}${toolHint}${body}`;
+}
+
+function formatPinnedResourceLine(r: PinnedResource): string {
+  return `- ${r.id}: ${r.title} (${r.type})`;
+}
+
+function pushVolatileLabel(blocks: string[], header: string, value: string | undefined): void {
+  if (typeof value === 'string' && value.trim()) {
+    blocks.push(`${header}\n${value.trim()}`);
+  }
+}
+
+function pushVolatileListBlock<T>(
+  blocks: string[],
+  header: string,
+  items: T[] | undefined,
+  lineFn: (item: T) => string,
+): void {
+  if (items?.length) {
+    const lines = items.map(lineFn).join('\n');
+    blocks.push(`${header}\n${lines}`);
+  }
+}
+
+function formatActiveResourceLine(
+  activeResource: VolatileSourceOptions['activeResource'],
+): string | null {
+  if (!activeResource?.id) return null;
+  const type = activeResource.type ? ` / ${activeResource.type}` : '';
+  return `**active-resource** — ${activeResource.id}${type}\n"${activeResource.title}". Call resource_get_active() to read content when needed.`;
+}
+
+function defaultTaskLine(taskLine: string | undefined): string {
+  return (
+    taskLine?.trim() ||
+    'Respond to the user message using the sources above only when relevant.'
+  );
+}
+
 export function formatVolatileSourceContext(opts: VolatileSourceOptions = {}): string {
-  const blocks: string[] = [];
-  blocks.push('Source (session):');
-
-  if (opts.dateLine?.trim()) {
-    blocks.push(`**session-date**\n${opts.dateLine.trim()}`);
-  }
-
-  if (opts.uiContext?.trim()) {
-    blocks.push(`**ui-context**\n${opts.uiContext.trim()}`);
-  }
-
-  if (opts.userMemory?.trim()) {
-    blocks.push(`**user-memory**\n${opts.userMemory.trim()}`);
-  }
-
-  if (opts.pinnedPeople && opts.pinnedPeople.length > 0) {
-    const lines = opts.pinnedPeople
-      .map((person) => {
-        const identities = (person.identities || [])
-          .map((identity) => `${identity.source}:${identity.displayLabel || identity.externalId}`)
-          .join(', ');
-        return identities
-          ? `- ${person.id}: ${person.title} (${identities})`
-          : `- ${person.id}: ${person.title}`;
-      })
-      .join('\n');
-    blocks.push(
-      `**mentioned-people** — ${opts.pinnedPeople.length} person(s). Resolve identities for email/GitHub/social tools; do not invent handles.\n${lines}`,
-    );
-  }
-
-  if (opts.pinnedSources && opts.pinnedSources.length > 0) {
-    const lines = opts.pinnedSources
-      .map((src) => {
-        const repo =
-          src.kind === 'issue' && typeof src.meta?.fullName === 'string'
-            ? ` repo=${src.meta.fullName}`
-            : '';
-        const folder =
-          src.kind === 'email' && typeof src.meta?.folder === 'string'
-            ? ` folder=${src.meta.folder}`
-            : '';
-        const provider =
-          src.kind === 'social_post' && typeof src.meta?.provider === 'string'
-            ? ` provider=${src.meta.provider}`
-            : '';
-        const status =
-          src.kind === 'social_post' && typeof src.meta?.status === 'string'
-            ? ` status=${src.meta.status}`
-            : '';
-        const body =
-          typeof src.meta?.body === 'string' && src.meta.body.trim()
-            ? `\n  body: ${src.meta.body.trim().slice(0, 2000)}`
-            : '';
-        const toolHint =
-          src.kind === 'social_post'
-            ? ' → social_post_get'
-            : src.kind === 'email'
-              ? ' → email_read'
-              : src.kind === 'issue'
-                ? ' → github_get_issue'
-                : '';
-        return `- [${src.kind}] ${src.id}: ${src.title}${repo}${folder}${provider}${status}${toolHint}${body}`;
-      })
-      .join('\n');
-    blocks.push(
-      `**mentioned-sources** — ${opts.pinnedSources.length} item(s). Content may be inlined below each id. Use the domain get tool (social_post_get / email_read / github_get_issue) before claiming a pin is missing.\n${lines}`,
-    );
-  }
-
-  if (opts.pinnedResources && opts.pinnedResources.length > 0) {
-    const lines = opts.pinnedResources
-      .map((r) => `- ${r.id}: ${r.title} (${r.type})`)
-      .join('\n');
-    blocks.push(
-      `**pinned-resources** — ${opts.pinnedResources.length} item(s). Use resource_get_pinned(id); do not search by title.\n${lines}`,
-    );
-  }
-
-  if (opts.activeResource?.id) {
-    const type = opts.activeResource.type ? ` / ${opts.activeResource.type}` : '';
-    blocks.push(
-      `**active-resource** — ${opts.activeResource.id}${type}\n"${opts.activeResource.title}". Call resource_get_active() to read content when needed.`,
-    );
-  }
-
-  const task =
-    opts.taskLine?.trim() ||
-    'Respond to the user message using the sources above only when relevant.';
-  blocks.push(`Task: ${task}`);
-
+  const blocks: string[] = ['Source (session):'];
+  pushVolatileLabel(blocks, '**session-date**', opts.dateLine);
+  pushVolatileLabel(blocks, '**ui-context**', opts.uiContext);
+  pushVolatileLabel(blocks, '**user-memory**', opts.userMemory);
+  pushVolatileListBlock(
+    blocks,
+    `**mentioned-people** — ${opts.pinnedPeople?.length || 0} person(s). Resolve identities for email/GitHub/social tools; do not invent handles.`,
+    opts.pinnedPeople,
+    formatPinnedPersonLine,
+  );
+  pushVolatileListBlock(
+    blocks,
+    `**mentioned-sources** — ${opts.pinnedSources?.length || 0} item(s). Content may be inlined below each id. Use the domain get tool (social_post_get / email_read / github_get_issue) before claiming a pin is missing.`,
+    opts.pinnedSources,
+    formatPinnedSourceLine,
+  );
+  pushVolatileListBlock(
+    blocks,
+    `**pinned-resources** — ${opts.pinnedResources?.length || 0} item(s). Use resource_get_pinned(id); do not search by title.`,
+    opts.pinnedResources,
+    formatPinnedResourceLine,
+  );
+  const activeLine = formatActiveResourceLine(opts.activeResource);
+  if (activeLine) blocks.push(activeLine);
+  blocks.push(`Task: ${defaultTaskLine(opts.taskLine)}`);
   return blocks.join('\n\n');
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Closes [#1235](https://github.com/maxprain12/dome/issues/1235) — SonarQube `javascript:S3776` (cognitive complexity 16 → under 15) on `shared/prompt-assembler/index.cjs`.
- Ported the helper extraction for `formatVolatileSourceContext` into the TypeScript source of truth (`shared/prompt-assembler/index.ts`) and rebuilt `index.cjs`, so `pnpm run build:prompt-assembler` cannot regress the fix.

## Sonar

| Key | Rule | File | Change |
|-----|------|------|--------|
| `b4cd458f-e0c6-4ca5-a58e-29f08cbc63a7` | javascript:S3776 | `shared/prompt-assembler/index.cjs` | Extract label/list/active/task helpers out of `formatVolatileSourceContext` |

## Why it is safe
- Pure maintainability refactor: same strings for session date, UI context, memory, pinned people/sources/resources, active resource, and default task line.
- Local parity checks: output of `formatVolatileSourceContext` matches both current `main` and the pre-helper revision for representative fixtures (empty, labels-only, full pins, empty collections).
- `pnpm run typecheck`, `pnpm run lint`, and `pnpm run test:coverage` pass locally.

## Type
- [x] Refactor

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test:coverage` passes
- [ ] N/A — no new user-visible strings / no UI colors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40dfa550-4bb7-4171-a4e2-5288a9d6bee6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40dfa550-4bb7-4171-a4e2-5288a9d6bee6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

