### PR TITLE
fix(sonar): lower coerceWithJsonSchema cognitive complexity (S3776, #1044)

### DIFF
--- a/packages/ai/src/utils/validation.test.ts
+++ b/packages/ai/src/utils/validation.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import type { Tool, ToolCall } from "../types.js";
+import { validateToolArguments, validateToolCall } from "./validation.js";
+
+function plainJsonTool(name: string, parameters: Record<string, unknown>): Tool {
+	return {
+		name,
+		description: `${name} tool`,
+		parameters: parameters as Tool["parameters"],
+	};
+}
+
+function toolCall(name: string, args: Record<string, unknown>): ToolCall {
+	return {
+		type: "toolCall",
+		id: "call-1",
+		name,
+		arguments: args,
+	};
+}
+
+describe("validateToolCall", () => {
+	it("throws when the tool is missing", () => {
+		expect(() => validateToolCall([], toolCall("missing", {}))).toThrow('Tool "missing" not found');
+	});
+});
+
+describe("validateToolArguments", () => {
+	it("coerces plain JSON Schema string numbers to numbers", () => {
+		const tool = plainJsonTool("add", {
+			type: "object",
+			properties: {
+				a: { type: "number" },
+				b: { type: "number" },
+			},
+			required: ["a", "b"],
+			additionalProperties: false,
+		});
+
+		const result = validateToolArguments(tool, toolCall("add", { a: "3", b: "4" }));
+		expect(result).toEqual({ a: 3, b: 4 });
+	});
+
+	it("coerces nested object and array properties", () => {
+		const tool = plainJsonTool("nested", {
+			type: "object",
+			properties: {
+				meta: {
+					type: "object",
+					properties: {
+						count: { type: "integer" },
+					},
+					additionalProperties: false,
+				},
+				tags: {
+					type: "array",
+					items: { type: "string" },
+				},
+			},
+			required: ["meta", "tags"],
+			additionalProperties: false,
+		});
+
+		const result = validateToolArguments(
+			tool,
+			toolCall("nested", {
+				meta: { count: "2" },
+				tags: [1, true],
+			}),
+		);
+		expect(result).toEqual({
+			meta: { count: 2 },
+			tags: ["1", "true"],
+		});
+	});
+
+	it("applies allOf composition before validation", () => {
+		const tool = plainJsonTool("composed", {
+			type: "object",
+			allOf: [
+				{
+					type: "object",
+					properties: {
+						n: { type: "number" },
+					},
+				},
+			],
+			properties: {
+				n: { type: "number" },
+			},
+			required: ["n"],
+			additionalProperties: false,
+		});
+
+		const result = validateToolArguments(tool, toolCall("composed", { n: "9" }));
+		expect(result).toEqual({ n: 9 });
+	});
+
+	it("picks a matching anyOf branch after coercion", () => {
+		const tool = plainJsonTool("union", {
+			type: "object",
+			properties: {
+				value: {
+					anyOf: [{ type: "number" }, { type: "boolean" }],
+				},
+			},
+			required: ["value"],
+			additionalProperties: false,
+		});
+
+		const result = validateToolArguments(tool, toolCall("union", { value: "true" }));
+		expect(result).toEqual({ value: true });
+	});
+
+	it("throws a formatted error when validation fails", () => {
+		const tool = plainJsonTool("strict", {
+			type: "object",
+			properties: {
+				name: { type: "string" },
+			},
+			required: ["name"],
+			additionalProperties: false,
+		});
+
+		expect(() => validateToolArguments(tool, toolCall("strict", {}))).toThrow(
+			/Validation failed for tool "strict"/,
+		);
+	});
+});

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -202,7 +202,8 @@ function coerceWithUnionSchema(value: unknown, schemas: JsonSchemaObject[]): unk
 	return value;
 }
 
-function coerceWithJsonSchema(value: unknown, schema: JsonSchemaObject): unknown {
+/** Apply allOf / anyOf / oneOf composition before type-level coercion. */
+function applyCompositionCoercion(value: unknown, schema: JsonSchemaObject): unknown {
 	let nextValue = value;
 
 	if (Array.isArray(schema.allOf)) {
@@ -219,28 +220,49 @@ function coerceWithJsonSchema(value: unknown, schema: JsonSchemaObject): unknown
 		nextValue = coerceWithUnionSchema(nextValue, schema.oneOf);
 	}
 
-	const schemaTypes = getSchemaTypes(schema);
+	return nextValue;
+}
+
+/** Coerce a value to the first schema type that changes it, unless it already matches a union member. */
+function coerceValueToSchemaTypes(value: unknown, schemaTypes: string[]): unknown {
 	const matchesUnionMember =
-		schemaTypes.length > 1 && schemaTypes.some((schemaType) => matchesJsonType(nextValue, schemaType));
-	if (schemaTypes.length > 0 && !matchesUnionMember) {
-		for (const schemaType of schemaTypes) {
-			const candidate = coercePrimitiveByType(nextValue, schemaType);
-			if (candidate !== nextValue) {
-				nextValue = candidate;
-				break;
-			}
+		schemaTypes.length > 1 && schemaTypes.some((schemaType) => matchesJsonType(value, schemaType));
+	if (schemaTypes.length === 0 || matchesUnionMember) {
+		return value;
+	}
+
+	for (const schemaType of schemaTypes) {
+		const candidate = coercePrimitiveByType(value, schemaType);
+		if (candidate !== value) {
+			return candidate;
 		}
 	}
 
-	if (schemaTypes.includes("object") && isRecord(nextValue) && !Array.isArray(nextValue)) {
-		applySchemaObjectCoercion(nextValue, schema);
+	return value;
+}
+
+/** Mutate object/array values in place according to schema structure. */
+function applyStructuralCoercion(
+	value: unknown,
+	schema: JsonSchemaObject,
+	schemaTypes: string[],
+): unknown {
+	if (schemaTypes.includes("object") && isRecord(value) && !Array.isArray(value)) {
+		applySchemaObjectCoercion(value, schema);
 	}
 
-	if (schemaTypes.includes("array") && Array.isArray(nextValue)) {
-		applySchemaArrayCoercion(nextValue, schema);
+	if (schemaTypes.includes("array") && Array.isArray(value)) {
+		applySchemaArrayCoercion(value, schema);
 	}
 
-	return nextValue;
+	return value;
+}
+
+function coerceWithJsonSchema(value: unknown, schema: JsonSchemaObject): unknown {
+	const afterComposition = applyCompositionCoercion(value, schema);
+	const schemaTypes = getSchemaTypes(schema);
+	const afterTypes = coerceValueToSchemaTypes(afterComposition, schemaTypes);
+	return applyStructuralCoercion(afterTypes, schema, schemaTypes);
 }
 
 function getValidator(schema: Tool["parameters"]): ReturnType<typeof Compile> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `coerceWithJsonSchema` in `packages/ai/src/utils/validation.ts` to drop Sonar cognitive complexity from 18 to ≤15 (rule `typescript:S3776`, issue key `b732657c-784e-4511-8ca7-a9fcbb335488`).
- Extracts three helpers with identical control flow: `applyCompositionCoercion` (`allOf`/`anyOf`/`oneOf`), `coerceValueToSchemaTypes`, and `applyStructuralCoercion` (object/array). Behavior of `validateToolArguments` is unchanged.
- Adds `packages/ai/src/utils/validation.test.ts` covering plain JSON Schema coercion (primitives, nested object/array, `allOf`, `anyOf`) and error formatting.

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs / config

## Why this is safe
- Pure maintainability extract: same coercion order and branches, moved into named helpers.
- No API/IPC/schema changes; source of truth is the TypeScript file (no generated counterpart).
- New unit tests lock the coercion/validation paths that previously lived only inside the complex function.

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| `b732657c-784e-4511-8ca7-a9fcbb335488` | typescript:S3776 | `packages/ai/src/utils/validation.ts` |

Closes #1044

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes (including new `@dome/ai` validation tests)
- [x] i18n keys — N/A
- [x] No hardcoded colors — N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5157427-07f8-4113-9597-ab5a567c323b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5157427-07f8-4113-9597-ab5a567c323b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

