### PR TITLE
fix(sonar): lower compaction utils cognitive complexity (S3776, #1040)

### DIFF
--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -20,33 +20,45 @@ export function createFileOps(): FileOperations {
 	};
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isToolCallBlock(block: unknown): block is ToolCall {
+	if (!isRecord(block)) return false;
+	if (block.type !== "toolCall") return false;
+	if (typeof block.name !== "string") return false;
+	return isRecord(block.arguments);
+}
+
+function toolCallPath(args: Record<string, unknown>): string | undefined {
+	return typeof args.path === "string" ? args.path : undefined;
+}
+
+function recordToolCallFileOp(name: string, path: string, fileOps: FileOperations): void {
+	switch (name) {
+		case "read":
+			fileOps.read.add(path);
+			break;
+		case "write":
+			fileOps.written.add(path);
+			break;
+		case "edit":
+			fileOps.edited.add(path);
+			break;
+	}
+}
+
 /** Add file operations from assistant tool calls to an accumulator. */
 export function extractFileOpsFromMessage(message: AgentMessage, fileOps: FileOperations): void {
 	if (message.role !== "assistant") return;
 	if (!("content" in message) || !Array.isArray(message.content)) return;
 
 	for (const block of message.content) {
-		if (typeof block !== "object" || block === null) continue;
-		if (!("type" in block) || block.type !== "toolCall") continue;
-		if (!("arguments" in block) || !("name" in block)) continue;
-
-		const args = block.arguments as Record<string, unknown> | undefined;
-		if (!args) continue;
-
-		const path = typeof args.path === "string" ? args.path : undefined;
+		if (!isToolCallBlock(block)) continue;
+		const path = toolCallPath(block.arguments);
 		if (!path) continue;
-
-		switch (block.name) {
-			case "read":
-				fileOps.read.add(path);
-				break;
-			case "write":
-				fileOps.written.add(path);
-				break;
-			case "edit":
-				fileOps.edited.add(path);
-				break;
-		}
+		recordToolCallFileOp(block.name, path, fileOps);
 	}
 }
 
@@ -107,11 +119,17 @@ function serializeUserMessage(msg: Extract<Message, { role: "user" }>): string[]
 	return content ? [`[User]: ${content}`] : [];
 }
 
-function serializeAssistantMessage(msg: Extract<Message, { role: "assistant" }>): string[] {
+interface AssistantContentParts {
+	textParts: string[];
+	thinkingParts: string[];
+	toolCalls: string[];
+}
+
+function collectAssistantContentParts(content: Extract<Message, { role: "assistant" }>["content"]): AssistantContentParts {
 	const textParts: string[] = [];
 	const thinkingParts: string[] = [];
 	const toolCalls: string[] = [];
-	for (const block of msg.content) {
+	for (const block of content) {
 		switch (block.type) {
 			case "text":
 				textParts.push(block.text);
@@ -124,17 +142,25 @@ function serializeAssistantMessage(msg: Extract<Message, { role: "assistant" }>)
 				break;
 		}
 	}
-	const parts: string[] = [];
-	if (thinkingParts.length > 0) {
-		parts.push(`[Assistant thinking]: ${thinkingParts.join("\n")}`);
+	return { textParts, thinkingParts, toolCalls };
+}
+
+function formatAssistantContentParts(parts: AssistantContentParts): string[] {
+	const lines: string[] = [];
+	if (parts.thinkingParts.length > 0) {
+		lines.push(`[Assistant thinking]: ${parts.thinkingParts.join("\n")}`);
 	}
-	if (textParts.length > 0) {
-		parts.push(`[Assistant]: ${textParts.join("\n")}`);
+	if (parts.textParts.length > 0) {
+		lines.push(`[Assistant]: ${parts.textParts.join("\n")}`);
 	}
-	if (toolCalls.length > 0) {
-		parts.push(`[Assistant tool calls]: ${toolCalls.join("; ")}`);
+	if (parts.toolCalls.length > 0) {
+		lines.push(`[Assistant tool calls]: ${parts.toolCalls.join("; ")}`);
 	}
-	return parts;
+	return lines;
+}
+
+function serializeAssistantMessage(msg: Extract<Message, { role: "assistant" }>): string[] {
+	return formatAssistantContentParts(collectAssistantContentParts(msg.content));
 }
 
 function serializeToolResultMessage(msg: Extract<Message, { role: "toolResult" }>): string[] {

--- a/packages/agent-core/test/compaction-utils.test.ts
+++ b/packages/agent-core/test/compaction-utils.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '@dome/ai';
+import {
+  computeFileLists,
+  createFileOps,
+  extractFileOpsFromMessage,
+  formatFileOperations,
+  serializeConversation,
+} from '../src/harness/compaction/utils.js';
+import type { AgentMessage } from '../src/types.js';
+
+const assistant = (content: Extract<Message, { role: 'assistant' }>['content']): Message =>
+  ({
+    role: 'assistant',
+    content,
+    api: 'openai-completions',
+    provider: 'openai',
+    model: 'test',
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: 'stop',
+    timestamp: 1,
+  }) as Message;
+
+describe('extractFileOpsFromMessage / computeFileLists', () => {
+  it('records read/write/edit paths and classifies read-only vs modified', () => {
+    const fileOps = createFileOps();
+    extractFileOpsFromMessage(
+      assistant([
+        { type: 'toolCall', id: '1', name: 'read', arguments: { path: 'a.ts' } },
+        { type: 'toolCall', id: '2', name: 'write', arguments: { path: 'b.ts' } },
+        { type: 'toolCall', id: '3', name: 'edit', arguments: { path: 'c.ts' } },
+        { type: 'toolCall', id: '4', name: 'read', arguments: { path: 'b.ts' } },
+        { type: 'toolCall', id: '5', name: 'read', arguments: { other: true } },
+        { type: 'text', text: 'ignore' },
+      ]) as AgentMessage,
+      fileOps,
+    );
+    extractFileOpsFromMessage({ role: 'user', content: 'hi', timestamp: 1 } as AgentMessage, fileOps);
+
+    const { readFiles, modifiedFiles } = computeFileLists(fileOps);
+    expect(readFiles).toEqual(['a.ts']);
+    expect(modifiedFiles).toEqual(['b.ts', 'c.ts']);
+  });
+});
+
+describe('formatFileOperations', () => {
+  it('returns empty string when both lists are empty', () => {
+    expect(formatFileOperations([], [])).toBe('');
+  });
+
+  it('formats read and modified sections', () => {
+    expect(formatFileOperations(['a.ts'], ['b.ts'])).toBe(
+      '\n\n<read-files>\na.ts\n</read-files>\n\n<modified-files>\nb.ts\n</modified-files>',
+    );
+  });
+});
+
+describe('serializeConversation', () => {
+  it('serializes user, assistant, and toolResult messages with truncation', () => {
+    const longResult = 'x'.repeat(2100);
+    const text = serializeConversation([
+      { role: 'user', content: 'hello', timestamp: 1 },
+      { role: 'user', content: [{ type: 'text', text: 'typed' }], timestamp: 2 },
+      { role: 'user', content: '', timestamp: 3 },
+      assistant([
+        { type: 'thinking', thinking: 'plan' },
+        { type: 'text', text: 'answer' },
+        { type: 'toolCall', id: 't1', name: 'read', arguments: { path: 'f.ts', n: 1 } },
+      ]),
+      {
+        role: 'toolResult',
+        toolCallId: 't1',
+        toolName: 'read',
+        content: [{ type: 'text', text: longResult }],
+        isError: false,
+        timestamp: 4,
+      },
+      {
+        role: 'toolResult',
+        toolCallId: 't2',
+        toolName: 'read',
+        content: [],
+        isError: false,
+        timestamp: 5,
+      },
+    ]);
+
+    expect(text).toContain('[User]: hello');
+    expect(text).toContain('[User]: typed');
+    expect(text).toContain('[Assistant thinking]: plan');
+    expect(text).toContain('[Assistant]: answer');
+    expect(text).toContain('[Assistant tool calls]: read(path="f.ts", n=1)');
+    expect(text).toContain('[Tool result]: ');
+    expect(text).toContain('more characters truncated');
+    expect(text).not.toContain('[User]: \n\n[Assistant thinking]');
+  });
+
+  it('stringifies unserializable tool-call args safely', () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const text = serializeConversation([
+      assistant([{ type: 'toolCall', id: 't1', name: 'write', arguments: { path: 'x.ts', meta: cyclic } }]),
+    ]);
+    expect(text).toContain('[Assistant tool calls]: write(path="x.ts", meta=[unserializable])');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Lowers Sonar `typescript:S3776` cognitive complexity in `packages/agent-core/src/harness/compaction/utils.ts` (issue key `b76f1f72-d0d7-4f2c-a5be-b3825c399a53`, originally reported at 32 vs allowed 15 on `serializeConversation`).
- Extracts small helpers for tool-call file-ops (`isToolCallBlock`, `toolCallPath`, `recordToolCallFileOp`) and assistant serialization (`collectAssistantContentParts`, `formatAssistantContentParts`) so each function stays ≤15.
- Adds `packages/agent-core/test/compaction-utils.test.ts` locking `extractFileOpsFromMessage` / `computeFileLists` / `formatFileOperations` / `serializeConversation` (including truncation and unserializable args).

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs / config

## Why this is safe
- Pure maintainability extract: same control flow and string formats for compaction summarization prompts and file-op metadata.
- No compaction semantics, API, or IPC changes; TypeScript source is the source of truth (no generated counterpart).
- New unit tests pin the previously untested serialization and file-op paths.

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| `b76f1f72-d0d7-4f2c-a5be-b3825c399a53` | typescript:S3776 | `packages/agent-core/src/harness/compaction/utils.ts` |

Closes #1040

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes (including new `@dome/agent-core` compaction-utils tests)
- [x] i18n keys — N/A
- [x] No hardcoded colors — N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-876971b9-52be-4a78-b138-a718a370358e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-876971b9-52be-4a78-b138-a718a370358e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

