### PR TITLE
fix(sonar): lower convertToolResultGroup cognitive complexity (S3776)

### DIFF
--- a/packages/ai/src/providers/openai-completions-messages.test.ts
+++ b/packages/ai/src/providers/openai-completions-messages.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import type { Context, Model, OpenAICompletionsCompat, ToolResultMessage } from "../types.js";
+import { convertMessages } from "./openai-completions.js";
+
+type ResolvedCompat = Omit<Required<OpenAICompletionsCompat>, "cacheControlFormat"> & {
+	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
+};
+
+function baseCompat(overrides: Partial<ResolvedCompat> = {}): ResolvedCompat {
+	return {
+		supportsStore: true,
+		supportsDeveloperRole: false,
+		supportsReasoningEffort: true,
+		supportsUsageInStreaming: true,
+		maxTokensField: "max_completion_tokens",
+		requiresToolResultName: false,
+		requiresAssistantAfterToolResult: false,
+		requiresThinkingAsText: false,
+		requiresReasoningContentOnAssistantMessages: false,
+		thinkingFormat: "openai",
+		openRouterRouting: {},
+		vercelGatewayRouting: {},
+		zaiToolStream: false,
+		supportsStrictMode: true,
+		cacheControlFormat: undefined,
+		sendSessionAffinityHeaders: false,
+		supportsLongCacheRetention: true,
+		...overrides,
+	};
+}
+
+function visionModel(overrides: Partial<Model<"openai-completions">> = {}): Model<"openai-completions"> {
+	return {
+		id: "gpt-4o",
+		name: "GPT-4o",
+		api: "openai-completions",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+		...overrides,
+	};
+}
+
+function toolResult(partial: Partial<ToolResultMessage> & Pick<ToolResultMessage, "content">): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "call-1",
+		toolName: "screenshot",
+		isError: false,
+		timestamp: 1,
+		...partial,
+	};
+}
+
+describe("convertMessages toolResult mapping", () => {
+	it("maps text-only tool results without a follow-up user image message", () => {
+		const context: Context = {
+			messages: [
+				toolResult({
+					content: [{ type: "text", text: "done" }],
+				}),
+			],
+		};
+
+		const params = convertMessages(visionModel(), context, baseCompat());
+
+		expect(params).toEqual([
+			{
+				role: "tool",
+				content: "done",
+				tool_call_id: "call-1",
+			},
+		]);
+	});
+
+	it("uses image placeholder text and attaches images on a follow-up user message", () => {
+		const context: Context = {
+			messages: [
+				toolResult({
+					content: [{ type: "image", mimeType: "image/png", data: "abc123" }],
+				}),
+			],
+		};
+
+		const params = convertMessages(visionModel(), context, baseCompat());
+
+		expect(params).toEqual([
+			{
+				role: "tool",
+				content: "(see attached image)",
+				tool_call_id: "call-1",
+			},
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "Attached image(s) from tool result:" },
+					{
+						type: "image_url",
+						image_url: { url: "data:image/png;base64,abc123" },
+					},
+				],
+			},
+		]);
+	});
+
+	it("includes tool name and assistant bridge when compat requires them", () => {
+		const context: Context = {
+			messages: [
+				toolResult({
+					toolName: "capture",
+					content: [
+						{ type: "text", text: "shot" },
+						{ type: "image", mimeType: "image/jpeg", data: "img" },
+					],
+				}),
+				{ role: "user", content: "what do you see?", timestamp: 2 },
+			],
+		};
+
+		const params = convertMessages(
+			visionModel(),
+			context,
+			baseCompat({
+				requiresToolResultName: true,
+				requiresAssistantAfterToolResult: true,
+			}),
+		);
+
+		expect(params[0]).toEqual({
+			role: "tool",
+			content: "shot",
+			tool_call_id: "call-1",
+			name: "capture",
+		});
+		expect(params[1]).toEqual({
+			role: "assistant",
+			content: "I have processed the tool results.",
+		});
+		expect(params[2]).toMatchObject({
+			role: "user",
+			content: expect.arrayContaining([
+				{ type: "text", text: "Attached image(s) from tool result:" },
+				{
+					type: "image_url",
+					image_url: { url: "data:image/jpeg;base64,img" },
+				},
+			]),
+		});
+		// lastRole becomes "user" after the image follow-up, so no second bridge.
+		expect(params.at(-1)).toEqual({
+			role: "user",
+			content: "what do you see?",
+		});
+	});
+
+	it("skips collecting images when the model does not accept image input", () => {
+		const context: Context = {
+			messages: [
+				toolResult({
+					content: [{ type: "image", mimeType: "image/png", data: "abc123" }],
+				}),
+			],
+		};
+
+		const params = convertMessages(visionModel({ input: ["text"] }), context, baseCompat());
+
+		expect(params).toEqual([
+			{
+				role: "tool",
+				content: "(tool image omitted: model does not support images)",
+				tool_call_id: "call-1",
+			},
+		]);
+	});
+});

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -962,63 +962,60 @@ function convertAssistantMessage(
 	return assistantMsg;
 }
 
-/**
- * Convert a run of consecutive toolResult messages starting at startIndex.
- * Returns the converted messages (tool results plus, when images are present,
- * an optional synthetic assistant bridge and a user message carrying the
- * images), the index of the last consumed message, and the effective lastRole.
- */
-function convertToolResultGroup(
-	transformedMessages: Message[],
-	startIndex: number,
-	model: Model<"openai-completions">,
+type ToolResultImageBlock = { type: "image_url"; image_url: { url: string } };
+
+/** Build a single OpenAI tool-role message from a Dome toolResult. */
+function buildToolResultMessage(
+	toolMsg: ToolResultMessage,
 	compat: ResolvedOpenAICompletionsCompat,
-): { messages: ChatCompletionMessageParam[]; endIndex: number; lastRole: "user" | "toolResult" } {
-	const messages: ChatCompletionMessageParam[] = [];
-	const imageBlocks: Array<{ type: "image_url"; image_url: { url: string } }> = [];
-	let j = startIndex;
-
-	for (; j < transformedMessages.length && transformedMessages[j].role === "toolResult"; j++) {
-		const toolMsg = transformedMessages[j] as ToolResultMessage;
-
-		// Extract text and image content
-		const textResult = toolMsg.content
-			.filter(isTextContentBlock)
-			.map((block) => block.text)
-			.join("\n");
-		const hasImages = toolMsg.content.some((c) => c.type === "image");
-
-		// Always send tool result with text (or placeholder if only images)
-		const hasText = textResult.length > 0;
-		// Some providers require the 'name' field in tool results
-		const toolResultMsg: ChatCompletionToolMessageParam = {
-			role: "tool",
-			content: sanitizeSurrogates(hasText ? textResult : "(see attached image)"),
-			tool_call_id: toolMsg.toolCallId,
-		};
-		if (compat.requiresToolResultName && toolMsg.toolName) {
-			(toolResultMsg as any).name = toolMsg.toolName;
-		}
-		messages.push(toolResultMsg);
-
-		if (hasImages && model.input.includes("image")) {
-			for (const block of toolMsg.content) {
-				if (isImageContentBlock(block)) {
-					imageBlocks.push({
-						type: "image_url",
-						image_url: {
-							url: `data:${block.mimeType};base64,${block.data}`,
-						},
-					});
-				}
-			}
-		}
+): ChatCompletionToolMessageParam {
+	const textResult = toolMsg.content
+		.filter(isTextContentBlock)
+		.map((block) => block.text)
+		.join("\n");
+	// Always send tool result with text (or placeholder if only images)
+	const hasText = textResult.length > 0;
+	const toolResultMsg: ChatCompletionToolMessageParam = {
+		role: "tool",
+		content: sanitizeSurrogates(hasText ? textResult : "(see attached image)"),
+		tool_call_id: toolMsg.toolCallId,
+	};
+	// Some providers require the 'name' field in tool results
+	if (compat.requiresToolResultName && toolMsg.toolName) {
+		(toolResultMsg as { name?: string }).name = toolMsg.toolName;
 	}
+	return toolResultMsg;
+}
 
-	if (imageBlocks.length === 0) {
-		return { messages, endIndex: j - 1, lastRole: "toolResult" };
+/** Collect image parts from a tool result when the model accepts image input. */
+function appendImagesFromToolResult(
+	toolMsg: ToolResultMessage,
+	model: Model<"openai-completions">,
+	imageBlocks: ToolResultImageBlock[],
+): void {
+	if (!toolMsg.content.some((c) => c.type === "image")) return;
+	if (!model.input.includes("image")) return;
+	for (const block of toolMsg.content) {
+		if (!isImageContentBlock(block)) continue;
+		imageBlocks.push({
+			type: "image_url",
+			image_url: {
+				url: `data:${block.mimeType};base64,${block.data}`,
+			},
+		});
 	}
+}
 
+/**
+ * When tool results included images, optionally bridge with a synthetic
+ * assistant turn and attach the images on a follow-up user message.
+ */
+function appendToolResultImageFollowUp(
+	messages: ChatCompletionMessageParam[],
+	imageBlocks: ToolResultImageBlock[],
+	compat: ResolvedOpenAICompletionsCompat,
+): "user" | "toolResult" {
+	if (imageBlocks.length === 0) return "toolResult";
 	if (compat.requiresAssistantAfterToolResult) {
 		messages.push({
 			role: "assistant",
@@ -1035,7 +1032,33 @@ function convertToolResultGroup(
 			...imageBlocks,
 		],
 	});
-	return { messages, endIndex: j - 1, lastRole: "user" };
+	return "user";
+}
+
+/**
+ * Convert a run of consecutive toolResult messages starting at startIndex.
+ * Returns the converted messages (tool results plus, when images are present,
+ * an optional synthetic assistant bridge and a user message carrying the
+ * images), the index of the last consumed message, and the effective lastRole.
+ */
+function convertToolResultGroup(
+	transformedMessages: Message[],
+	startIndex: number,
+	model: Model<"openai-completions">,
+	compat: ResolvedOpenAICompletionsCompat,
+): { messages: ChatCompletionMessageParam[]; endIndex: number; lastRole: "user" | "toolResult" } {
+	const messages: ChatCompletionMessageParam[] = [];
+	const imageBlocks: ToolResultImageBlock[] = [];
+	let j = startIndex;
+
+	for (; j < transformedMessages.length && transformedMessages[j].role === "toolResult"; j++) {
+		const toolMsg = transformedMessages[j] as ToolResultMessage;
+		messages.push(buildToolResultMessage(toolMsg, compat));
+		appendImagesFromToolResult(toolMsg, model, imageBlocks);
+	}
+
+	const lastRole = appendToolResultImageFollowUp(messages, imageBlocks, compat);
+	return { messages, endIndex: j - 1, lastRole };
 }
 
 function addSystemPrompt(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `convertToolResultGroup` in `packages/ai/src/providers/openai-completions.ts` to drop Sonar cognitive complexity (typescript:S3776) from 18 to ≤15.
- Extracts `buildToolResultMessage`, `appendImagesFromToolResult`, and `appendToolResultImageFollowUp` — same streaming/request mapping behavior, no provider rewrite.
- Adds unit tests covering text-only tool results, image follow-up messages, compat name/bridge flags, and non-vision models.

## Type
- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| e36c44c4-7605-4034-908c-5c4c09cfd01b | typescript:S3776 | `packages/ai/src/providers/openai-completions.ts` (~L1033 / `convertToolResultGroup`) |

Closes #1025

## Why this is safe
Helpers preserve the previous control flow: tool-role messages (optional `name`), image collection only when the model accepts images, optional assistant bridge when `requiresAssistantAfterToolResult`, and the same user follow-up with `Attached image(s) from tool result:`. No changes to streaming, tool-call assembly, or other OpenAI completions paths. Issue #1021 (`buildParams` / other hotspot) is intentionally out of scope.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] i18n N/A
- [x] No hardcoded colors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2276f130-6578-4a67-887f-36f82ee0e290?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2276f130-6578-4a67-887f-36f82ee0e290&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

