### PR TITLE
fix(sonar): lower buildParams cognitive complexity (S3776)

### DIFF
--- a/packages/ai/src/providers/openai-completions-params.test.ts
+++ b/packages/ai/src/providers/openai-completions-params.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import type { Context, Model, Tool } from "../types.js";
+import { streamOpenAICompletions } from "./openai-completions.js";
+
+function baseModel(overrides: Partial<Model<"openai-completions">> = {}): Model<"openai-completions"> {
+	return {
+		id: "gpt-4o",
+		name: "GPT-4o",
+		api: "openai-completions",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+		...overrides,
+	};
+}
+
+function emptyContext(overrides: Partial<Context> = {}): Context {
+	return {
+		messages: [{ role: "user", content: "hi", timestamp: 1 }],
+		...overrides,
+	};
+}
+
+const echoTool: Tool = {
+	name: "echo",
+	description: "Echo",
+	parameters: { type: "object", properties: {} },
+};
+
+/** Capture ChatCompletion create params via onPayload, aborting before any network call. */
+async function captureBuildParams(
+	model: Model<"openai-completions">,
+	context: Context,
+	options: Parameters<typeof streamOpenAICompletions>[2] = {},
+): Promise<Record<string, unknown>> {
+	let captured: Record<string, unknown> | undefined;
+	const stream = streamOpenAICompletions(model, context, {
+		apiKey: "sk-test",
+		...options,
+		onPayload: (params) => {
+			captured = params as Record<string, unknown>;
+			throw new Error("abort-before-network");
+		},
+	});
+	await stream.result();
+	if (!captured) {
+		throw new Error("onPayload did not capture params");
+	}
+	return captured;
+}
+
+describe("buildParams (openai-completions request mapping)", () => {
+	it("sets stream_options.include_usage and store=false for standard OpenAI compat", async () => {
+		const params = await captureBuildParams(baseModel(), emptyContext());
+
+		expect(params.stream).toBe(true);
+		expect(params.store).toBe(false);
+		expect(params.stream_options).toEqual({ include_usage: true });
+		expect(params.model).toBe("gpt-4o");
+	});
+
+	it("uses max_completion_tokens by default and max_tokens when compat requests it", async () => {
+		const defaultField = await captureBuildParams(baseModel(), emptyContext(), { maxTokens: 128 });
+		expect(defaultField.max_completion_tokens).toBe(128);
+		expect(defaultField).not.toHaveProperty("max_tokens");
+
+		const legacyField = await captureBuildParams(
+			baseModel({
+				compat: { maxTokensField: "max_tokens" },
+			}),
+			emptyContext(),
+			{ maxTokens: 64 },
+		);
+		expect(legacyField.max_tokens).toBe(64);
+		expect(legacyField).not.toHaveProperty("max_completion_tokens");
+	});
+
+	it("sets prompt_cache_key for api.openai.com when retention is not none", async () => {
+		const withCache = await captureBuildParams(baseModel(), emptyContext(), {
+			sessionId: "session-abc",
+			cacheRetention: "short",
+		});
+		expect(withCache.prompt_cache_key).toBe("session-abc");
+		expect(withCache.prompt_cache_retention).toBeUndefined();
+
+		const none = await captureBuildParams(baseModel(), emptyContext(), {
+			sessionId: "session-abc",
+			cacheRetention: "none",
+		});
+		expect(none.prompt_cache_key).toBeUndefined();
+	});
+
+	it("sets prompt_cache_retention 24h only for long retention with long-cache support", async () => {
+		const longOk = await captureBuildParams(
+			baseModel({
+				baseUrl: "https://example.com/v1",
+				compat: { supportsLongCacheRetention: true },
+			}),
+			emptyContext(),
+			{ sessionId: "sess", cacheRetention: "long" },
+		);
+		expect(longOk.prompt_cache_key).toBe("sess");
+		expect(longOk.prompt_cache_retention).toBe("24h");
+
+		const longUnsupported = await captureBuildParams(
+			baseModel({
+				baseUrl: "https://example.com/v1",
+				compat: { supportsLongCacheRetention: false },
+			}),
+			emptyContext(),
+			{ sessionId: "sess", cacheRetention: "long" },
+		);
+		expect(longUnsupported.prompt_cache_key).toBeUndefined();
+		expect(longUnsupported.prompt_cache_retention).toBeUndefined();
+	});
+
+	it("forwards temperature, toolChoice, and converts tools", async () => {
+		const params = await captureBuildParams(baseModel(), emptyContext({ tools: [echoTool] }), {
+			temperature: 0.2,
+			toolChoice: "auto",
+		});
+
+		expect(params.temperature).toBe(0.2);
+		expect(params.tool_choice).toBe("auto");
+		expect(params.tools).toEqual([
+			{
+				type: "function",
+				function: {
+					name: "echo",
+					description: "Echo",
+					parameters: { type: "object", properties: {}, required: [] },
+					strict: false,
+				},
+			},
+		]);
+	});
+
+	it("sends empty tools array when conversation has tool history but no tools", async () => {
+		const params = await captureBuildParams(
+			baseModel(),
+			emptyContext({
+				messages: [
+					{
+						role: "assistant",
+						content: [{ type: "toolCall", id: "c1", name: "echo", arguments: {} }],
+						api: "openai-completions",
+						provider: "openai",
+						model: "gpt-4o",
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "toolUse",
+						timestamp: 1,
+					},
+					{
+						role: "toolResult",
+						toolCallId: "c1",
+						toolName: "echo",
+						content: [{ type: "text", text: "ok" }],
+						isError: false,
+						timestamp: 2,
+					},
+				],
+			}),
+		);
+
+		expect(params.tools).toEqual([]);
+	});
+});

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -519,6 +519,54 @@ function applyToolParams(
 	}
 }
 
+/** Resolve OpenAI prompt-cache request fields from model URL + retention policy. */
+function resolvePromptCacheParams(
+	model: Model<"openai-completions">,
+	compat: ResolvedOpenAICompletionsCompat,
+	cacheRetention: CacheRetention,
+	sessionId?: string,
+): Pick<
+	OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	"prompt_cache_key" | "prompt_cache_retention"
+> {
+	const usePromptCacheKey =
+		(model.baseUrl.includes("api.openai.com") && cacheRetention !== "none") ||
+		(cacheRetention === "long" && compat.supportsLongCacheRetention);
+	const useLongRetention = cacheRetention === "long" && compat.supportsLongCacheRetention;
+
+	return {
+		prompt_cache_key: usePromptCacheKey ? clampOpenAIPromptCacheKey(sessionId) : undefined,
+		prompt_cache_retention: useLongRetention ? "24h" : undefined,
+	};
+}
+
+/** Apply streaming usage + store flags that depend on provider compat. */
+function applyStreamCompatParams(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	compat: ResolvedOpenAICompletionsCompat,
+): void {
+	if (compat.supportsUsageInStreaming !== false) {
+		(params as { stream_options?: { include_usage: boolean } }).stream_options = { include_usage: true };
+	}
+	if (compat.supportsStore) {
+		params.store = false;
+	}
+}
+
+/** Map maxTokens onto either max_tokens or max_completion_tokens per compat. */
+function applyMaxTokensParam(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	maxTokens: number | undefined,
+	compat: ResolvedOpenAICompletionsCompat,
+): void {
+	if (!maxTokens) return;
+	if (compat.maxTokensField === "max_tokens") {
+		(params as { max_tokens?: number }).max_tokens = maxTokens;
+	} else {
+		params.max_completion_tokens = maxTokens;
+	}
+}
+
 function buildParams(
 	model: Model<"openai-completions">,
 	context: Context,
@@ -533,29 +581,11 @@ function buildParams(
 		model: model.id,
 		messages,
 		stream: true,
-		prompt_cache_key:
-			(model.baseUrl.includes("api.openai.com") && cacheRetention !== "none") ||
-			(cacheRetention === "long" && compat.supportsLongCacheRetention)
-				? clampOpenAIPromptCacheKey(options?.sessionId)
-				: undefined,
-		prompt_cache_retention: cacheRetention === "long" && compat.supportsLongCacheRetention ? "24h" : undefined,
+		...resolvePromptCacheParams(model, compat, cacheRetention, options?.sessionId),
 	};
 
-	if (compat.supportsUsageInStreaming !== false) {
-		(params as any).stream_options = { include_usage: true };
-	}
-
-	if (compat.supportsStore) {
-		params.store = false;
-	}
-
-	if (options?.maxTokens) {
-		if (compat.maxTokensField === "max_tokens") {
-			(params as any).max_tokens = options.maxTokens;
-		} else {
-			params.max_completion_tokens = options.maxTokens;
-		}
-	}
+	applyStreamCompatParams(params, compat);
+	applyMaxTokensParam(params, options?.maxTokens, compat);
 
 	if (options?.temperature !== undefined) {
 		params.temperature = options.temperature;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `buildParams` in `packages/ai/src/providers/openai-completions.ts` to drop Sonar cognitive complexity (typescript:S3776) from 19 to ≤15.
- Extracts `resolvePromptCacheParams`, `applyStreamCompatParams`, and `applyMaxTokensParam` — same Chat Completions request mapping, no provider rewrite.
- Leaves `applyToolParams` / `convertToolResultGroup` (#1025) untouched.
- Adds unit tests covering prompt-cache fields, maxTokens field selection, stream/store compat, tools/toolChoice/temperature, and empty-tools-on-history.

## Type
- [ ] New feature
- [x] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| ef6b3e8d-7002-4b2b-ac19-685a84b92000 | typescript:S3776 | `packages/ai/src/providers/openai-completions.ts` (~L506 / `buildParams`) |

Closes #1021

## Why this is safe
Helpers preserve the previous control flow: identical `prompt_cache_key` / `prompt_cache_retention` conditions, the same `stream_options` / `store` flags, and the same `max_tokens` vs `max_completion_tokens` branch. Temperature, tools, cache-control, toolChoice, reasoning, and provider routing still run in the same order inside `buildParams`. No changes to streaming, message conversion, or the #1025 tool-result path.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] i18n N/A
- [x] No hardcoded colors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f03bc7c-bea3-4073-b865-a328ec3be510?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f03bc7c-bea3-4073-b865-a328ec3be510&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

