### PR TITLE
fix(sonar): lower get_related_resources cognitive complexity (S3776)

### DIFF
--- a/app/lib/ai/tools/graph-tools.test.ts
+++ b/app/lib/ai/tools/graph-tools.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  collectRelatedResources,
+  createGraphTools,
+  rankRelatedResources,
+} from './graph-tools';
+
+describe('collectRelatedResources', () => {
+  it('aggregates relations and strength for the other endpoint', () => {
+    const related = collectRelatedResources(
+      [
+        { source: 'a', target: 'b', similarity: 0.4, relation_type: 'similar' },
+        { source: 'c', target: 'a', similarity: 0.5, relation_type: 'manual' },
+        { source: 'a', target: 'b', similarity: 0.3, relation_type: 'similar' },
+        { source: 'a', target: 'a', similarity: 0.9, relation_type: 'self' },
+      ],
+      'a',
+    );
+
+    expect(related.get('b')?.relations).toEqual(['similar']);
+    expect(related.get('b')?.strength).toBeCloseTo(0.7);
+    expect(related.get('c')).toEqual({ relations: ['manual'], strength: 0.5 });
+    expect(related.has('a')).toBe(false);
+  });
+
+  it('keeps distinct relation types on the same neighbor', () => {
+    const related = collectRelatedResources(
+      [
+        { source: 'a', target: 'b', similarity: 0.3, relation_type: 'similar' },
+        { source: 'a', target: 'b', similarity: 0.1, relation_type: 'manual' },
+      ],
+      'a',
+    );
+
+    expect(related.get('b')).toEqual({
+      relations: ['similar', 'manual'],
+      strength: 0.4,
+    });
+  });
+});
+
+describe('rankRelatedResources', () => {
+  it('sorts by strength descending and applies default limit 10', () => {
+    const rows = Array.from({ length: 12 }, (_, i) => ({
+      id: `r${i}`,
+      title: `T${i}`,
+      type: 'note',
+      relations: ['similar'],
+      strength: i,
+      updated_at: i,
+    }));
+
+    const ranked = rankRelatedResources(rows);
+    expect(ranked).toHaveLength(10);
+    expect(ranked[0]?.id).toBe('r11');
+    expect(ranked[9]?.id).toBe('r2');
+  });
+
+  it('respects an explicit limit', () => {
+    const rows = [
+      {
+        id: 'weak',
+        title: 'Weak',
+        type: 'note',
+        relations: ['similar'],
+        strength: 0.1,
+        updated_at: 1,
+      },
+      {
+        id: 'strong',
+        title: 'Strong',
+        type: 'note',
+        relations: ['manual'],
+        strength: 0.9,
+        updated_at: 2,
+      },
+    ];
+
+    expect(rankRelatedResources(rows, 1).map((r) => r.id)).toEqual(['strong']);
+  });
+});
+
+describe('get_related_resources tool', () => {
+  const getGraph = vi.fn();
+  const getById = vi.fn();
+
+  beforeEach(() => {
+    getGraph.mockReset();
+    getById.mockReset();
+    Object.defineProperty(window, 'electron', {
+      configurable: true,
+      writable: true,
+      value: {
+        invoke: vi.fn(),
+        on: vi.fn(() => vi.fn()),
+        db: {
+          semantic: { getGraph },
+          resources: { getById },
+        },
+      },
+    });
+  });
+
+  function getRelatedTool() {
+    const tool = createGraphTools().find((t) => t.name === 'get_related_resources');
+    expect(tool).toBeDefined();
+    return tool!;
+  }
+
+  it('returns ranked related resources from the semantic graph', async () => {
+    getGraph.mockResolvedValue({
+      success: true,
+      data: {
+        nodes: [],
+        edges: [
+          { source: 'focus', target: 'b', similarity: 0.4, relation_type: 'similar' },
+          { source: 'c', target: 'focus', similarity: 0.8, relation_type: 'manual' },
+        ],
+      },
+    });
+    getById.mockImplementation(async (id: string) => {
+      if (id === 'b') {
+        return {
+          success: true,
+          data: { id: 'b', title: 'Beta', type: 'note', updated_at: 10 },
+        };
+      }
+      if (id === 'c') {
+        return {
+          success: true,
+          data: { id: 'c', title: 'Gamma', type: 'pdf', updated_at: 20 },
+        };
+      }
+      return { success: false, error: 'missing' };
+    });
+
+    const result = await getRelatedTool().execute('tc-1', {
+      resource_id: 'focus',
+      min_weight: 0.3,
+      limit: 10,
+    });
+
+    expect(getGraph).toHaveBeenCalledWith('focus', 0.3);
+    expect(result.isError).toBeFalsy();
+    expect(result.details).toEqual({
+      status: 'success',
+      resource_id: 'focus',
+      related_count: 2,
+      related_resources: [
+        {
+          id: 'c',
+          title: 'Gamma',
+          type: 'pdf',
+          relations: ['manual'],
+          strength: 0.8,
+          updated_at: 20,
+        },
+        {
+          id: 'b',
+          title: 'Beta',
+          type: 'note',
+          relations: ['similar'],
+          strength: 0.4,
+          updated_at: 10,
+        },
+      ],
+    });
+  });
+
+  it('skips neighbors that fail resource lookup', async () => {
+    getGraph.mockResolvedValue({
+      success: true,
+      data: {
+        nodes: [],
+        edges: [
+          { source: 'focus', target: 'gone', similarity: 0.5, relation_type: 'similar' },
+          { source: 'focus', target: 'ok', similarity: 0.2, relation_type: 'similar' },
+        ],
+      },
+    });
+    getById.mockImplementation(async (id: string) => {
+      if (id === 'ok') {
+        return {
+          success: true,
+          data: { id: 'ok', title: 'Ok', type: 'note', updated_at: 1 },
+        };
+      }
+      return { success: false, error: 'not found' };
+    });
+
+    const result = await getRelatedTool().execute('tc-2', {
+      resource_id: 'focus',
+      limit: 5,
+    });
+
+    expect(result.details).toMatchObject({
+      status: 'success',
+      related_count: 1,
+      related_resources: [{ id: 'ok', title: 'Ok' }],
+    });
+  });
+
+  it('returns an error when getGraph fails', async () => {
+    getGraph.mockResolvedValue({ success: false, error: 'boom' });
+
+    const result = await getRelatedTool().execute('tc-3', { resource_id: 'focus' });
+
+    expect(result.isError).toBe(true);
+    expect(result.details).toMatchObject({ status: 'error', error: 'boom' });
+  });
+});

--- a/app/lib/ai/tools/graph-tools.ts
+++ b/app/lib/ai/tools/graph-tools.ts
@@ -104,7 +104,17 @@ type RelatedGraphEdge = {
 
 type RelatedResourceInfo = { relations: string[]; strength: number };
 
-function collectRelatedResources(
+type RelatedResourceRow = {
+  id: string;
+  title: string;
+  type: string;
+  relations: string[];
+  strength: number;
+  updated_at: number;
+};
+
+/** @internal Exported for unit tests (S3776 helpers). */
+export function collectRelatedResources(
   edges: RelatedGraphEdge[],
   resourceId: string,
 ): Map<string, RelatedResourceInfo> {
@@ -120,6 +130,38 @@ function collectRelatedResources(
     related.set(other, info);
   }
   return related;
+}
+
+function toolErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}
+
+async function hydrateRelatedResources(
+  related: Map<string, RelatedResourceInfo>,
+): Promise<RelatedResourceRow[]> {
+  const relatedResources: RelatedResourceRow[] = [];
+  for (const [rid, info] of related) {
+    const result = await window.electron.db.resources.getById(rid);
+    if (!result.success || !result.data) continue;
+    relatedResources.push({
+      id: result.data.id,
+      title: result.data.title,
+      type: result.data.type,
+      relations: info.relations,
+      strength: info.strength,
+      updated_at: result.data.updated_at,
+    });
+  }
+  return relatedResources;
+}
+
+/** @internal Exported for unit tests (S3776 helpers). */
+export function rankRelatedResources(
+  relatedResources: RelatedResourceRow[],
+  limit?: number,
+): RelatedResourceRow[] {
+  relatedResources.sort((a, b) => b.strength - a.strength);
+  return relatedResources.slice(0, limit || 10);
 }
 
 function createGetRelatedResourcesTool(): AnyAgentTool {
@@ -159,32 +201,8 @@ function createGetRelatedResourcesTool(): AnyAgentTool {
         }
         const edges = res.data.edges as RelatedGraphEdge[];
         const related = collectRelatedResources(edges, args.resource_id);
-
-        const relatedResources: Array<{
-          id: string;
-          title: string;
-          type: string;
-          relations: string[];
-          strength: number;
-          updated_at: number;
-        }> = [];
-
-        for (const [rid, info] of related) {
-          const result = await window.electron.db.resources.getById(rid);
-          if (result.success && result.data) {
-            relatedResources.push({
-              id: result.data.id,
-              title: result.data.title,
-              type: result.data.type,
-              relations: info.relations,
-              strength: info.strength,
-              updated_at: result.data.updated_at,
-            });
-          }
-        }
-
-        relatedResources.sort((a, b) => b.strength - a.strength);
-        const limited = relatedResources.slice(0, args.limit || 10);
+        const relatedResources = await hydrateRelatedResources(related);
+        const limited = rankRelatedResources(relatedResources, args.limit);
 
         return jsonResult({
           status: 'success',
@@ -193,9 +211,7 @@ function createGetRelatedResourcesTool(): AnyAgentTool {
           related_resources: limited,
         });
       } catch (error) {
-        return errorResult(
-          `Failed to get related resources: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        );
+        return errorResult(`Failed to get related resources: ${toolErrorMessage(error)}`);
       }
     },
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors the `get_related_resources` `execute` path in `app/lib/ai/tools/graph-tools.ts` to drop Sonar cognitive complexity (typescript:S3776) from 16 to ≤15.
- Extracts `hydrateRelatedResources`, `rankRelatedResources`, and `toolErrorMessage` — same semantic graph lookup, resource hydration, ranking, and error messages.
- Leaves `generate_knowledge_graph`, `link_resources`, and analyze-graph helpers untouched.
- Adds unit tests covering relation aggregation, ranking/limit, successful execute, skipped missing resources, and getGraph failures.

## Type
- [ ] New feature
- [x] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| bd49fcb4-49b9-4554-a6be-90a15872ebc1 | typescript:S3776 | `app/lib/ai/tools/graph-tools.ts` (~L123 / `get_related_resources` execute) |

Closes #1015

## Why this is safe
Helpers preserve the previous control flow: identical edge → neighbor aggregation (`collectRelatedResources`), the same `resources.getById` hydration (skip when `!success || !data`), strength-desc sort with default limit 10, and the same catch message shape. No changes to other graph tools or IPC contracts. Source of truth is `app/lib/ai/tools/graph-tools.ts` (no generated counterpart).

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] i18n N/A
- [x] No hardcoded colors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02de47eb-62ae-425d-8104-3e362efa385f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02de47eb-62ae-425d-8104-3e362efa385f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

