### PR TITLE
fix(sonar): S3776 cognitive complexity in toolResultHighlights (#1007)

### DIFF
--- a/app/lib/chat/toolResultHighlights.tsx
+++ b/app/lib/chat/toolResultHighlights.tsx
@@ -11,7 +11,24 @@ type TFunction = (key: string, opts?: Record<string, unknown> & { defaultValue?:
 
 type CalendarHighlight = NonNullable<ReturnType<typeof extractCalendarEventFromToolResult>>;
 
+/** True when a tool payload reports success via either convention. */
+function isSuccessPayload(parsed: Record<string, unknown>): boolean {
+  return parsed.success === true || parsed.status === 'success';
+}
+
+/** Narrow a truthy object-like value (same guard as the pre-refactor `&& typeof === 'object'`). */
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object') return null;
+  return value as Record<string, unknown>;
+}
+
+function calendarTimeLabel(cal: CalendarHighlight): string {
+  if (!cal.endLabel || cal.endLabel === cal.startLabel) return cal.startLabel;
+  return `${cal.startLabel} → ${cal.endLabel}`;
+}
+
 function renderCalendarHighlight(cal: CalendarHighlight, t: TFunction): ReactNode {
+  const title = cal.title || t('chat.calendar_event_untitled', { defaultValue: 'Evento' });
   return (
     <div
       className="rounded-md border p-2.5 flex flex-col gap-y-1"
@@ -22,12 +39,11 @@ function renderCalendarHighlight(cal: CalendarHighlight, t: TFunction): ReactNod
     >
       <div className="flex items-center gap-2 text-xs font-semibold text-foreground">
         <HugeiconsIcon icon={Calendar03Icon} className="size-3.5 shrink-0 text-primary" aria-hidden />
-        <span className="truncate">{cal.title || t('chat.calendar_event_untitled', { defaultValue: 'Evento' })}</span>
+        <span className="truncate">{title}</span>
       </div>
       {cal.startLabel ? (
         <p className="text-[12px] text-muted-foreground">
-          {cal.startLabel}
-          {cal.endLabel && cal.endLabel !== cal.startLabel ? ` → ${cal.endLabel}` : ''}
+          {calendarTimeLabel(cal)}
         </p>
       ) : null}
       {cal.location ? (
@@ -103,6 +119,33 @@ function renderImageHighlight(parsed: Record<string, unknown>): ReactNode | null
   );
 }
 
+function tryFlashcardHighlight(
+  toolName: string,
+  parsed: Record<string, unknown>,
+  t: TFunction,
+): ReactNode | null {
+  if (toolName !== 'flashcard_create') return null;
+  if (!isSuccessPayload(parsed)) return null;
+  const deck = asRecord(parsed.deck);
+  if (!deck) return null;
+  return renderFlashcardHighlight(deck, t);
+}
+
+function tryResourceHighlight(
+  toolName: string,
+  parsed: Record<string, unknown>,
+): ReactNode | null {
+  if (toolName !== 'resource_create') return null;
+  if (!isSuccessPayload(parsed)) return null;
+  const resource = asRecord(parsed.resource);
+  if (!resource) return null;
+  return renderResourceHighlight(resource);
+}
+
+/**
+ * Inline success card for calendar / flashcard / resource / image tool results.
+ * Dispatch only — per-type rendering lives in helpers (S3776).
+ */
 export function renderToolSuccessHighlight(
   toolName: string,
   rawResult: unknown,
@@ -114,16 +157,12 @@ export function renderToolSuccessHighlight(
   const parsed = unwrapToolResultPayload(rawResult);
   if (!parsed) return null;
 
-  const n = (toolName || '').toLowerCase();
-  const ok = parsed.success === true || parsed.status === 'success';
+  const n = toolName.toLowerCase();
+  const flashcard = tryFlashcardHighlight(n, parsed, t);
+  if (flashcard) return flashcard;
 
-  if (n === 'flashcard_create' && ok && parsed.deck && typeof parsed.deck === 'object') {
-    return renderFlashcardHighlight(parsed.deck as Record<string, unknown>, t);
-  }
-
-  if (n === 'resource_create' && ok && parsed.resource && typeof parsed.resource === 'object') {
-    return renderResourceHighlight(parsed.resource as Record<string, unknown>);
-  }
+  const resource = tryResourceHighlight(n, parsed);
+  if (resource) return resource;
 
   return renderImageHighlight(parsed);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Lowers `typescript:S3776` cognitive complexity in `app/lib/chat/toolResultHighlights.tsx` by splitting `renderToolSuccessHighlight` into thin `tryFlashcardHighlight` / `tryResourceHighlight` dispatchers plus shared `isSuccessPayload` / `asRecord` / `calendarTimeLabel` helpers.
- Preserves the same calendar / flashcard / resource / image success highlight UI and branching (no behavior rewrite).

## Sonar

| Key | Rule | File | GitHub |
| --- | --- | --- | --- |
| `bfa5047f-27c9-4d4a-85ff-83951b9641c9` | typescript:S3776 | `app/lib/chat/toolResultHighlights.tsx` | Closes #1007 |

## Why this is safe
- Markup, styles, i18n keys, and success predicates match the previous helpers.
- Compound `&&` chains moved into early-return helpers so Sonar complexity on the entry function drops well below the 15 threshold (not a 1-point trim).
- No chat rendering redesign; only maintainability extraction.

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs / config

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [ ] `pnpm run build` passes (not required for this Sonar acceptance; CI will run)
- [x] `pnpm run test:coverage` passes locally
- [ ] i18n keys added in all 4 languages (en, es, fr, pt) if new user-visible strings — N/A
- [x] No hardcoded colors (CSS variables only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2a1d4e9-4b36-4164-bad8-2d887ddee8ea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2a1d4e9-4b36-4164-bad8-2d887ddee8ea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

