### PR TITLE
fix(sonar): lower parseAgentsConfig cognitive complexity (S3776, #998)

### DIFF
--- a/app/lib/agents/api.test.ts
+++ b/app/lib/agents/api.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { exportAgentsConfig, parseAgentsConfig } from './api';
+import type { ManyAgent } from '@/types';
+
+vi.mock('@/lib/utils', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/utils')>('@/lib/utils');
+  return {
+    ...actual,
+    generateId: vi.fn(() => 'id-fixed'),
+  };
+});
+
+describe('exportAgentsConfig', () => {
+  it('pretty-prints agents as JSON', () => {
+    const agents: ManyAgent[] = [
+      {
+        id: 'a1',
+        projectId: 'default',
+        name: 'Alpha',
+        description: '',
+        systemInstructions: '',
+        toolIds: [],
+        mcpServerIds: [],
+        iconIndex: 1,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    expect(JSON.parse(exportAgentsConfig(agents))).toEqual(agents);
+  });
+});
+
+describe('parseAgentsConfig', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+  });
+
+  it('parses a single agent object and assigns a new id', () => {
+    const result = parseAgentsConfig(
+      JSON.stringify({
+        name: ' Researcher ',
+        description: 'd',
+        systemInstructions: 'sys',
+        toolIds: ['t1'],
+        mcpServerIds: ['m1'],
+        skillIds: ['s1'],
+        iconIndex: 5,
+        folderId: 'fold-1',
+        favorite: true,
+        projectId: 'proj-a',
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toEqual({
+      id: 'id-fixed',
+      projectId: 'proj-a',
+      name: 'Researcher',
+      description: 'd',
+      systemInstructions: 'sys',
+      toolIds: ['t1'],
+      mcpServerIds: ['m1'],
+      skillIds: ['s1'],
+      iconIndex: 5,
+      folderId: 'fold-1',
+      favorite: true,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    });
+  });
+
+  it('parses an array and skips non-object entries', () => {
+    const result = parseAgentsConfig(
+      JSON.stringify([{ name: 'One' }, null, 'x', { name: 'Two', favorite: false }]),
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.map((a) => a.name)).toEqual(['One', 'Two']);
+    expect(result.data[1]?.favorite).toBe(false);
+    expect(result.data[1]?.folderId).toBeUndefined();
+    expect(result.data[0]?.projectId).toBe('default');
+    expect(result.data[0]?.iconIndex).toBe(1);
+  });
+
+  it('rejects an agent missing a name', () => {
+    const result = parseAgentsConfig(JSON.stringify([{ name: '  ' }, { name: 'Ok' }]));
+    expect(result).toEqual({
+      success: false,
+      error: 'Agente 1: falta el nombre',
+    });
+  });
+
+  it('rejects when no valid agents remain', () => {
+    expect(parseAgentsConfig(JSON.stringify([null, 1, true]))).toEqual({
+      success: false,
+      error: 'No se encontraron agentes válidos en el archivo',
+    });
+  });
+
+  it('rejects invalid JSON', () => {
+    const result = parseAgentsConfig('{');
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.length).toBeGreaterThan(0);
+  });
+
+  it('clamps iconIndex outside 1..18 to 1', () => {
+    const low = parseAgentsConfig(JSON.stringify({ name: 'A', iconIndex: 0 }));
+    const high = parseAgentsConfig(JSON.stringify({ name: 'B', iconIndex: 99 }));
+    expect(low.success && low.data[0]?.iconIndex).toBe(1);
+    expect(high.success && high.data[0]?.iconIndex).toBe(1);
+  });
+});

--- a/app/lib/agents/api.ts
+++ b/app/lib/agents/api.ts
@@ -107,6 +107,10 @@ export function exportAgentsConfig(agents: ManyAgent[]): string {
   return JSON.stringify(agents, null, 2);
 }
 
+type ParseAgentsResult =
+  | { success: true; data: ManyAgent[] }
+  | { success: false; error: string };
+
 type ParsedAgentResult =
   | { kind: 'skip' }
   | { kind: 'agent'; agent: ManyAgent }
@@ -134,7 +138,36 @@ function readStringArrayField(raw: Record<string, unknown>, key: string): string
 
 function readIconIndexField(raw: Record<string, unknown>): number {
   const value = raw.iconIndex;
-  return typeof value === 'number' && value >= 1 && value <= 18 ? value : 1;
+  if (typeof value !== 'number') return 1;
+  if (value < 1 || value > 18) return 1;
+  return value;
+}
+
+/** Build a ManyAgent from a validated import record (no branching beyond field defaults). */
+function buildImportedAgent(
+  record: Record<string, unknown>,
+  name: string,
+  now: number,
+): ManyAgent {
+  const agent: ManyAgent = {
+    id: generateId(),
+    projectId: readTrimmedStringField(record, 'projectId') ?? 'default',
+    name,
+    description: readStringField(record, 'description'),
+    systemInstructions: readStringField(record, 'systemInstructions'),
+    toolIds: readStringArrayField(record, 'toolIds'),
+    mcpServerIds: readStringArrayField(record, 'mcpServerIds'),
+    skillIds: readStringArrayField(record, 'skillIds'),
+    iconIndex: readIconIndexField(record),
+    favorite: record.favorite === true,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const folderId = readTrimmedStringField(record, 'folderId');
+  if (folderId) {
+    agent.folderId = folderId;
+  }
+  return agent;
 }
 
 function parseAgentRecord(
@@ -150,38 +183,29 @@ function parseAgentRecord(
   if (!name) {
     return { kind: 'error', error: `Agente ${index + 1}: falta el nombre` };
   }
-  const folderId = readTrimmedStringField(record, 'folderId');
-  return {
-    kind: 'agent',
-    agent: {
-      id: generateId(),
-      projectId: readTrimmedStringField(record, 'projectId') ?? 'default',
-      name,
-      description: readStringField(record, 'description'),
-      systemInstructions: readStringField(record, 'systemInstructions'),
-      toolIds: readStringArrayField(record, 'toolIds'),
-      mcpServerIds: readStringArrayField(record, 'mcpServerIds'),
-      skillIds: readStringArrayField(record, 'skillIds'),
-      iconIndex: readIconIndexField(record),
-      ...(folderId ? { folderId } : {}),
-      favorite: record.favorite === true,
-      createdAt: now,
-      updatedAt: now,
-    },
-  };
+  return { kind: 'agent', agent: buildImportedAgent(record, name, now) };
 }
 
-function collectAgents(parsed: unknown): { success: true; data: ManyAgent[] } | { success: false; error: string } {
+/** Apply one parse result: push agent, ignore skip, or surface error. */
+function applyParsedAgent(
+  result: ParsedAgentResult,
+  agents: ManyAgent[],
+): string | null {
+  if (result.kind === 'error') return result.error;
+  if (result.kind === 'agent') {
+    agents.push(result.agent);
+  }
+  return null;
+}
+
+function collectAgents(parsed: unknown): ParseAgentsResult {
   const arr = Array.isArray(parsed) ? parsed : [parsed];
   const now = Date.now();
   const agents: ManyAgent[] = [];
   for (let i = 0; i < arr.length; i++) {
-    const result = parseAgentRecord(arr[i], i, now);
-    if (result.kind === 'error') {
-      return { success: false, error: result.error };
-    }
-    if (result.kind === 'agent') {
-      agents.push(result.agent);
+    const error = applyParsedAgent(parseAgentRecord(arr[i], i, now), agents);
+    if (error) {
+      return { success: false, error };
     }
   }
   if (agents.length === 0) {
@@ -190,12 +214,17 @@ function collectAgents(parsed: unknown): { success: true; data: ManyAgent[] } | 
   return { success: true, data: agents };
 }
 
+function parseAgentsConfigError(error: unknown): ParseAgentsResult {
+  const message = error instanceof Error ? error.message : 'JSON inválido';
+  return { success: false, error: message };
+}
+
 /** Validate and parse imported agent config. Returns validated agents with new IDs. */
-export function parseAgentsConfig(json: string): { success: true; data: ManyAgent[] } | { success: false; error: string } {
+export function parseAgentsConfig(json: string): ParseAgentsResult {
   try {
     return collectAgents(JSON.parse(json));
   } catch (e) {
-    return { success: false, error: e instanceof Error ? e.message : 'JSON inválido' };
+    return parseAgentsConfigError(e);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Decompose `parseAgentsConfig` / agent import parsing in `app/lib/agents/api.ts` so cognitive complexity stays at or under Sonar’s limit of 15 (typescript:S3776).
- Extract `buildImportedAgent`, `applyParsedAgent`, `parseAgentsConfigError`, and early-return field readers — same JSON → `ManyAgent[]` semantics as before (new ids, defaults, skip/error rules).
- Add `app/lib/agents/api.test.ts` locking export/parse edge cases.

| Sonar key | Rule | File | GitHub |
|-----------|------|------|--------|
| `c281d739-7e52-43f0-bf80-6f0483e52053` | typescript:S3776 | `app/lib/agents/api.ts` | Closes #998 |

## Why this is safe
- Public API unchanged: `exportAgentsConfig`, `parseAgentsConfig`, `importAgentsConfig`, and CRUD helpers keep the same signatures and return shapes.
- Behavior preserved: missing name still errors with `Agente N: falta el nombre`; non-objects are skipped; empty valid set fails; invalid JSON fails; `iconIndex` still clamps to 1..18; `folderId` / `favorite` / `projectId` defaults match the prior parser.
- No rewrite of the agents client/IPC path — maintainability-only split of the import parser.

## Local gates
- `pnpm run typecheck` — pass
- `pnpm run lint` — pass (0 errors)
- `pnpm run test:coverage` — pass (renderer 140 tests incl. new `api.test.ts`)

## Type
- [x] Refactor

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test:coverage` passes
- [x] i18n keys — N/A (no new user-facing strings)
- [x] No hardcoded colors — N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-faa278c3-4d42-407d-bd25-cfc2ad58046d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-faa278c3-4d42-407d-bd25-cfc2ad58046d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

