### PR TITLE
fix(sonar): lower branch-summarization cognitive complexity (S3776, #990)

### DIFF
--- a/packages/agent-core/src/harness/compaction/branch-summarization.ts
+++ b/packages/agent-core/src/harness/compaction/branch-summarization.ts
@@ -121,22 +121,31 @@ function getMessageFromEntry(entry: SessionTreeEntry): AgentMessage | undefined 
 	}
 }
 
+/** Append paths from one list into a file-ops set when the list is an array. */
+function appendPathsToSet(target: Set<string>, paths: unknown): void {
+	if (!Array.isArray(paths)) return;
+	for (const path of paths as string[]) target.add(path);
+}
+
 /** Append the read/modified file lists from a branch-summary entry into the accumulator. */
 function appendBranchSummaryFiles(fileOps: FileOperations, details: BranchSummaryDetails): void {
-	if (Array.isArray(details.readFiles)) {
-		for (const f of details.readFiles) fileOps.read.add(f);
-	}
-	if (Array.isArray(details.modifiedFiles)) {
-		for (const f of details.modifiedFiles) {
-			fileOps.edited.add(f);
-		}
-	}
+	appendPathsToSet(fileOps.read, details.readFiles);
+	appendPathsToSet(fileOps.edited, details.modifiedFiles);
 }
 
 /** Collect read/modified files reported on non-hook branch-summary entries. */
 function collectBranchSummaryFiles(entry: SessionTreeEntry, fileOps: FileOperations): void {
 	if (entry.type !== "branch_summary" || entry.fromHook || !entry.details) return;
 	appendBranchSummaryFiles(fileOps, entry.details as BranchSummaryDetails);
+}
+
+/** Seed file-ops from prior non-hook branch-summary details on the abandoned branch. */
+function accumulateBranchFileOps(entries: SessionTreeEntry[]): FileOperations {
+	const fileOps = createFileOps();
+	for (const entry of entries) {
+		collectBranchSummaryFiles(entry, fileOps);
+	}
+	return fileOps;
 }
 
 /** Decide whether a candidate message fits in the remaining token budget. */
@@ -155,15 +164,32 @@ function evaluateBudgetEntry(
 	return { include: isPinnedSummary && fitsHeadroom, stop: true, tokens };
 }
 
-/** Prepare branch entries for summarization within an optional token budget. */
-export function prepareBranchEntries(entries: SessionTreeEntry[], tokenBudget: number = 0): BranchPreparation {
-	const messages: AgentMessage[] = [];
-	const fileOps = createFileOps();
-	let totalTokens = 0;
-
-	for (const entry of entries) {
-		collectBranchSummaryFiles(entry, fileOps);
+/** Apply one budget decision: maybe keep the message (newest-first) and stop when over budget. */
+function applyBudgetDecision(
+	decision: { include: boolean; stop: boolean; tokens: number },
+	message: AgentMessage,
+	messages: AgentMessage[],
+	totalTokens: number,
+): { totalTokens: number; stop: boolean } {
+	let nextTotal = totalTokens;
+	if (decision.include) {
+		messages.unshift(message);
+		nextTotal += decision.tokens;
 	}
+	return { totalTokens: nextTotal, stop: decision.stop };
+}
+
+/**
+ * Walk entries newest→oldest, extract tool file-ops, and keep messages that fit the budget.
+ * Pinned compaction/branch_summary messages may still be kept once under 90% headroom.
+ */
+function selectMessagesWithinBudget(
+	entries: SessionTreeEntry[],
+	fileOps: FileOperations,
+	tokenBudget: number,
+): { messages: AgentMessage[]; totalTokens: number } {
+	const messages: AgentMessage[] = [];
+	let totalTokens = 0;
 
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const entry = entries[i];
@@ -172,13 +198,18 @@ export function prepareBranchEntries(entries: SessionTreeEntry[], tokenBudget: n
 		extractFileOpsFromMessage(message, fileOps);
 
 		const decision = evaluateBudgetEntry(message, entry, tokenBudget, totalTokens);
-		if (decision.include) {
-			messages.unshift(message);
-			totalTokens += decision.tokens;
-		}
-		if (decision.stop) break;
+		const applied = applyBudgetDecision(decision, message, messages, totalTokens);
+		totalTokens = applied.totalTokens;
+		if (applied.stop) break;
 	}
 
+	return { messages, totalTokens };
+}
+
+/** Prepare branch entries for summarization within an optional token budget. */
+export function prepareBranchEntries(entries: SessionTreeEntry[], tokenBudget: number = 0): BranchPreparation {
+	const fileOps = accumulateBranchFileOps(entries);
+	const { messages, totalTokens } = selectMessagesWithinBudget(entries, fileOps, tokenBudget);
 	return { messages, fileOps, totalTokens };
 }
 
@@ -216,6 +247,55 @@ Use this EXACT format:
 
 Keep each section concise. Preserve exact file paths, function names, and error messages.`;
 
+/** Resolve summarization instructions from default prompt + optional custom focus. */
+function resolveBranchSummaryInstructions(
+	customInstructions: string | undefined,
+	replaceInstructions: boolean | undefined,
+): string {
+	if (replaceInstructions && customInstructions) return customInstructions;
+	if (customInstructions) return `${BRANCH_SUMMARY_PROMPT}\n\nAdditional focus: ${customInstructions}`;
+	return BRANCH_SUMMARY_PROMPT;
+}
+
+/** Join text blocks from a model response. */
+function textFromAssistantContent(content: Array<{ type: string; text?: string }>): string {
+	return content
+		.filter((c): c is { type: "text"; text: string } => c.type === "text")
+		.map((c) => c.text)
+		.join("\n");
+}
+
+/** Map aborted/error stop reasons to a BranchSummaryError; otherwise null. */
+function branchSummaryStopError(
+	stopReason: string,
+	errorMessage: string | undefined,
+): BranchSummaryError | null {
+	if (stopReason === "aborted") {
+		return new BranchSummaryError("aborted", errorMessage || "Branch summary aborted");
+	}
+	if (stopReason === "error") {
+		return new BranchSummaryError(
+			"summarization_failed",
+			`Branch summary failed: ${errorMessage || "Unknown error"}`,
+		);
+	}
+	return null;
+}
+
+/** Assemble the final BranchSummaryResult from model text + accumulated file ops. */
+function buildBranchSummaryResult(
+	rawSummary: string,
+	fileOps: FileOperations,
+): BranchSummaryResult {
+	const { readFiles, modifiedFiles } = computeFileLists(fileOps);
+	const summary = BRANCH_SUMMARY_PREAMBLE + rawSummary + formatFileOperations(readFiles, modifiedFiles);
+	return {
+		summary: summary || "No summary generated",
+		readFiles,
+		modifiedFiles,
+	};
+}
+
 /** Generate a summary for abandoned branch entries. */
 export async function generateBranchSummary(
 	entries: SessionTreeEntry[],
@@ -232,14 +312,7 @@ export async function generateBranchSummary(
 	}
 	const llmMessages = convertToLlm(messages);
 	const conversationText = serializeConversation(llmMessages);
-	let instructions: string;
-	if (replaceInstructions && customInstructions) {
-		instructions = customInstructions;
-	} else if (customInstructions) {
-		instructions = `${BRANCH_SUMMARY_PROMPT}\n\nAdditional focus: ${customInstructions}`;
-	} else {
-		instructions = BRANCH_SUMMARY_PROMPT;
-	}
+	const instructions = resolveBranchSummaryInstructions(customInstructions, replaceInstructions);
 	const promptText = `<conversation>\n${conversationText}\n</conversation>\n\n${instructions}`;
 
 	const summarizationMessages = [
@@ -254,29 +327,8 @@ export async function generateBranchSummary(
 		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
 		{ apiKey, headers, signal, maxTokens: 2048 },
 	);
-	if (response.stopReason === "aborted") {
-		return err(new BranchSummaryError("aborted", response.errorMessage || "Branch summary aborted"));
-	}
-	if (response.stopReason === "error") {
-		return err(
-			new BranchSummaryError(
-				"summarization_failed",
-				`Branch summary failed: ${response.errorMessage || "Unknown error"}`,
-			),
-		);
-	}
+	const stopError = branchSummaryStopError(response.stopReason, response.errorMessage);
+	if (stopError) return err(stopError);
 
-	let summary = response.content
-		.filter((c): c is { type: "text"; text: string } => c.type === "text")
-		.map((c) => c.text)
-		.join("\n");
-	summary = BRANCH_SUMMARY_PREAMBLE + summary;
-	const { readFiles, modifiedFiles } = computeFileLists(fileOps);
-	summary += formatFileOperations(readFiles, modifiedFiles);
-
-	return ok({
-		summary: summary || "No summary generated",
-		readFiles,
-		modifiedFiles,
-	});
+	return ok(buildBranchSummaryResult(textFromAssistantContent(response.content), fileOps));
 }

--- a/packages/agent-core/test/branch-summarization.test.ts
+++ b/packages/agent-core/test/branch-summarization.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { prepareBranchEntries } from '../src/harness/compaction/branch-summarization.js';
+import type { SessionTreeEntry } from '../src/harness/types.js';
+import type { AgentMessage } from '../src/types.js';
+
+const ts = '2026-01-01T00:00:00.000Z';
+
+function userEntry(id: string, text: string): SessionTreeEntry {
+  return {
+    type: 'message',
+    id,
+    parentId: null,
+    timestamp: ts,
+    message: { role: 'user', content: text, timestamp: 1 } as AgentMessage,
+  };
+}
+
+function toolResultEntry(id: string): SessionTreeEntry {
+  return {
+    type: 'message',
+    id,
+    parentId: null,
+    timestamp: ts,
+    message: {
+      role: 'toolResult',
+      toolCallId: 't1',
+      toolName: 'read',
+      content: [{ type: 'text', text: 'ok' }],
+      isError: false,
+      timestamp: 1,
+    } as AgentMessage,
+  };
+}
+
+function assistantWithRead(id: string, path: string): SessionTreeEntry {
+  return {
+    type: 'message',
+    id,
+    parentId: null,
+    timestamp: ts,
+    message: {
+      role: 'assistant',
+      content: [{ type: 'toolCall', id: 'c1', name: 'read', arguments: { path } }],
+      api: 'openai-completions',
+      provider: 'openai',
+      model: 'test',
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: 'toolUse',
+      timestamp: 1,
+    } as AgentMessage,
+  };
+}
+
+function branchSummaryEntry(
+  id: string,
+  details: { readFiles?: string[]; modifiedFiles?: string[] } | undefined,
+  fromHook = false,
+): SessionTreeEntry {
+  return {
+    type: 'branch_summary',
+    id,
+    parentId: null,
+    timestamp: ts,
+    fromId: 'from-1',
+    summary: 'prior branch',
+    details,
+    fromHook,
+  };
+}
+
+function compactionEntry(id: string, summary: string): SessionTreeEntry {
+  return {
+    type: 'compaction',
+    id,
+    parentId: null,
+    timestamp: ts,
+    summary,
+    firstKeptEntryId: 'kept',
+    tokensBefore: 100,
+  };
+}
+
+describe('prepareBranchEntries', () => {
+  it('returns empty messages for an empty entry list', () => {
+    const prepared = prepareBranchEntries([]);
+    expect(prepared.messages).toEqual([]);
+    expect(prepared.totalTokens).toBe(0);
+    expect([...prepared.fileOps.read]).toEqual([]);
+  });
+
+  it('skips toolResult messages and label/meta entries', () => {
+    const prepared = prepareBranchEntries([
+      toolResultEntry('tr'),
+      { type: 'label', id: 'l1', parentId: null, timestamp: ts, targetId: 'x', label: 'L' },
+      userEntry('u1', 'hello'),
+    ]);
+    expect(prepared.messages).toHaveLength(1);
+    expect(prepared.messages[0]?.role).toBe('user');
+  });
+
+  it('merges non-hook branch_summary details into fileOps and ignores fromHook', () => {
+    const prepared = prepareBranchEntries([
+      branchSummaryEntry('bs1', { readFiles: ['from-summary.ts'], modifiedFiles: ['edited.ts'] }),
+      branchSummaryEntry('bs-hook', { readFiles: ['hook-only.ts'] }, true),
+      assistantWithRead('a1', 'from-tool.ts'),
+    ]);
+    expect([...prepared.fileOps.read].sort((a, b) => a.localeCompare(b))).toEqual([
+      'from-summary.ts',
+      'from-tool.ts',
+    ]);
+    expect([...prepared.fileOps.edited]).toEqual(['edited.ts']);
+  });
+
+  it('keeps chronological order when tokenBudget is 0 (unlimited)', () => {
+    const prepared = prepareBranchEntries(
+      [userEntry('u1', 'aaa'), userEntry('u2', 'bbb'), userEntry('u3', 'ccc')],
+      0,
+    );
+    expect(prepared.messages.map((m) => (m as { content: string }).content)).toEqual([
+      'aaa',
+      'bbb',
+      'ccc',
+    ]);
+  });
+
+  it('drops older messages once the token budget is exceeded', () => {
+    // estimateTokens(user) = ceil(chars/4); "xxxx" => 1 token each
+    const prepared = prepareBranchEntries(
+      [userEntry('u1', 'xxxx'), userEntry('u2', 'xxxx'), userEntry('u3', 'xxxx')],
+      2,
+    );
+    expect(prepared.messages).toHaveLength(2);
+    expect(prepared.totalTokens).toBe(2);
+  });
+
+  it('keeps a pinned compaction summary when over budget but under 90% headroom', () => {
+    // Newest user: 16 chars => 4 tokens. Budget 5 => after user, headroom 4 < 4.5.
+    // Compaction summary length 40 => 10 tokens, exceeds remaining budget but is pinned.
+    const prepared = prepareBranchEntries(
+      [compactionEntry('c1', 'x'.repeat(40)), userEntry('u1', 'x'.repeat(16))],
+      5,
+    );
+    expect(prepared.messages.some((m) => m.role === 'user')).toBe(true);
+    expect(prepared.messages.some((m) => m.role === 'compactionSummary')).toBe(true);
+  });
+
+  it('does not keep a pinned summary when headroom is already at or above 90%', () => {
+    // Newest user fills budget exactly (4 tokens, budget 4) => headroom 4 < 3.6 is false.
+    const prepared = prepareBranchEntries(
+      [compactionEntry('c1', 'x'.repeat(40)), userEntry('u1', 'x'.repeat(16))],
+      4,
+    );
+    expect(prepared.messages).toHaveLength(1);
+    expect(prepared.messages[0]?.role).toBe('user');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reduce SonarQube `typescript:S3776` cognitive complexity on `prepareBranchEntries` (issue key `d0294057-1d88-4694-95d8-f61a339af799`) by finishing the incomplete helper split from the quality-loop batch (#989).
- Preserve branch-summarization / compaction selection behavior exactly; add unit tests for budget + file-ops edges.

## What changed
In `packages/agent-core/src/harness/compaction/branch-summarization.ts` only (plus tests):
- `appendPathsToSet` / `accumulateBranchFileOps` — seed file-ops from non-hook branch summaries
- `selectMessagesWithinBudget` / `applyBudgetDecision` — newest→oldest budget walk (pinned compaction/branch_summary headroom unchanged)
- `resolveBranchSummaryInstructions`, `textFromAssistantContent`, `branchSummaryStopError`, `buildBranchSummaryResult` — thin `generateBranchSummary` orchestration
- `prepareBranchEntries` is now a two-call composition (complexity well under 15)

## Why it is safe
- Same entry filtering (`toolResult` / meta skipped via `getMessageFromEntry`)
- Same token budget and 90% pinned-summary headroom rules
- Same prompt preamble/instructions and aborted/error mapping
- No IPC, i18n, or public API signature changes

## Sonar
| Key | Rule | File | GitHub |
| --- | --- | --- | --- |
| `d0294057-1d88-4694-95d8-f61a339af799` | typescript:S3776 | `packages/agent-core/src/harness/compaction/branch-summarization.ts` | Closes #990 |

## Type
- [x] Refactor

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] No new user-visible strings
- [x] No hardcoded colors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f191d5ad-d338-494d-8fb4-89ea0908165a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f191d5ad-d338-494d-8fb4-89ea0908165a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

