### PR TITLE
fix(sonar): lower formatVolatileSourceContext complexity (S3776, #986)

### DIFF
--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -13,6 +13,6 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "test": "echo \"@dome/prompts: no tests yet\" && exit 0"
+    "test": "tsc -b && node --test test/*.test.mjs"
   }
 }

--- a/packages/prompts/src/assembler.ts
+++ b/packages/prompts/src/assembler.ts
@@ -25,6 +25,12 @@ const VOICE_LANGUAGE_NAMES: Record<string, string> = {
   pt: 'Portuguese',
 };
 
+const PINNED_SOURCE_TOOL_HINTS: Record<string, string> = {
+  social_post: ' → social_post_get',
+  email: ' → email_read',
+  issue: ' → github_get_issue',
+};
+
 const CORE_SECTION_KEYS_LIST: (keyof CorePromptSections)[] = [
   'constraintsLanguage',
   'appContext',
@@ -38,6 +44,10 @@ const CORE_SECTION_KEYS_LIST: (keyof CorePromptSections)[] = [
 ];
 
 export const CORE_SECTION_KEYS = CORE_SECTION_KEYS_LIST;
+
+type PinnedPerson = NonNullable<VolatileSourceOptions['pinnedPeople']>[number];
+type PinnedSource = NonNullable<VolatileSourceOptions['pinnedSources']>[number];
+type PinnedResource = NonNullable<VolatileSourceOptions['pinnedResources']>[number];
 
 export function buildCoreToolsBlock(sections: CorePromptSections): string {
   const parts: string[] = [];
@@ -72,104 +82,125 @@ You are speaking aloud in a live voice conversation. Follow these rules:
 - Respond in ${langName}.`;
 }
 
+function formatPinnedPersonLine(person: PinnedPerson): string {
+  const identities = (person.identities || [])
+    .map((identity) => `${identity.source}:${identity.displayLabel || identity.externalId}`)
+    .join(', ');
+  return identities
+    ? `- ${person.id}: ${person.title} (${identities})`
+    : `- ${person.id}: ${person.title}`;
+}
+
+/** Meta string field when present; otherwise null (keeps empty-string semantics). */
+function pinnedMetaString(
+  meta: PinnedSource['meta'],
+  key: string,
+): string | null {
+  const value = meta?.[key];
+  return typeof value === 'string' ? value : null;
+}
+
+/** ` key=value` attr for a pinned source of a given kind; empty when missing. */
+function pinnedSourceKindAttr(
+  src: PinnedSource,
+  kind: PinnedSource['kind'],
+  key: string,
+  attr: string,
+): string {
+  if (src.kind !== kind) return '';
+  const value = pinnedMetaString(src.meta, key);
+  return value === null ? '' : ` ${attr}=${value}`;
+}
+
+/**
+ * Bound-clone working-copy line for issue pins. The run's tools are already
+ * scoped to this root, so the model must not guess a path.
+ */
+function pinnedSourceWorkspace(src: PinnedSource): string {
+  if (src.kind !== 'issue') return '';
+  const localPath = pinnedMetaString(src.meta, 'localPath')?.trim();
+  if (!localPath) return '';
+  return `\n  working copy: ${localPath} — the file, shell and git tools are already scoped to it; use relative paths.`;
+}
+
+function pinnedSourceBody(src: PinnedSource): string {
+  const body = pinnedMetaString(src.meta, 'body')?.trim();
+  if (!body) return '';
+  return `\n  body: ${body.slice(0, 2000)}`;
+}
+
+function formatPinnedSourceLine(src: PinnedSource): string {
+  const repo = pinnedSourceKindAttr(src, 'issue', 'fullName', 'repo');
+  const folder = pinnedSourceKindAttr(src, 'email', 'folder', 'folder');
+  const provider = pinnedSourceKindAttr(src, 'social_post', 'provider', 'provider');
+  const status = pinnedSourceKindAttr(src, 'social_post', 'status', 'status');
+  const toolHint = PINNED_SOURCE_TOOL_HINTS[src.kind] || '';
+  return `- [${src.kind}] ${src.id}: ${src.title}${repo}${folder}${provider}${status}${toolHint}${pinnedSourceWorkspace(src)}${pinnedSourceBody(src)}`;
+}
+
+function formatPinnedResourceLine(r: PinnedResource): string {
+  return `- ${r.id}: ${r.title} (${r.type})`;
+}
+
+function pushVolatileLabel(blocks: string[], header: string, value: string | undefined): void {
+  if (typeof value === 'string' && value.trim()) {
+    blocks.push(`${header}\n${value.trim()}`);
+  }
+}
+
+function pushVolatileListBlock<T>(
+  blocks: string[],
+  header: string,
+  items: T[] | undefined,
+  lineFn: (item: T) => string,
+): void {
+  if (items && items.length > 0) {
+    const lines = items.map(lineFn).join('\n');
+    blocks.push(`${header}\n${lines}`);
+  }
+}
+
+function formatActiveResourceLine(
+  activeResource: VolatileSourceOptions['activeResource'],
+): string | null {
+  if (!activeResource?.id) return null;
+  const type = activeResource.type ? ` / ${activeResource.type}` : '';
+  return `**active-resource** — ${activeResource.id}${type}\n"${activeResource.title}". Call resource_get_active() to read content when needed.`;
+}
+
+function defaultTaskLine(taskLine: string | undefined): string {
+  return (
+    taskLine?.trim() ||
+    'Respond to the user message using the sources above only when relevant.'
+  );
+}
+
 export function formatVolatileSourceContext(opts: VolatileSourceOptions = {}): string {
-  const blocks: string[] = [];
-  blocks.push('Source (session):');
-
-  if (opts.dateLine?.trim()) {
-    blocks.push(`**session-date**\n${opts.dateLine.trim()}`);
-  }
-
-  if (opts.uiContext?.trim()) {
-    blocks.push(`**ui-context**\n${opts.uiContext.trim()}`);
-  }
-
-  if (opts.userMemory?.trim()) {
-    blocks.push(`**user-memory**\n${opts.userMemory.trim()}`);
-  }
-
-  if (opts.pinnedPeople && opts.pinnedPeople.length > 0) {
-    const lines = opts.pinnedPeople
-      .map((person) => {
-        const identities = (person.identities || [])
-          .map((identity) => `${identity.source}:${identity.displayLabel || identity.externalId}`)
-          .join(', ');
-        return identities
-          ? `- ${person.id}: ${person.title} (${identities})`
-          : `- ${person.id}: ${person.title}`;
-      })
-      .join('\n');
-    blocks.push(
-      `**mentioned-people** — ${opts.pinnedPeople.length} person(s). Resolve identities for email/GitHub/social tools; do not invent handles.\n${lines}`,
-    );
-  }
-
-  if (opts.pinnedSources && opts.pinnedSources.length > 0) {
-    const lines = opts.pinnedSources
-      .map((src) => {
-        const repo =
-          src.kind === 'issue' && typeof src.meta?.fullName === 'string'
-            ? ` repo=${src.meta.fullName}`
-            : '';
-        const folder =
-          src.kind === 'email' && typeof src.meta?.folder === 'string'
-            ? ` folder=${src.meta.folder}`
-            : '';
-        const provider =
-          src.kind === 'social_post' && typeof src.meta?.provider === 'string'
-            ? ` provider=${src.meta.provider}`
-            : '';
-        const status =
-          src.kind === 'social_post' && typeof src.meta?.status === 'string'
-            ? ` status=${src.meta.status}`
-            : '';
-        // A bound clone turns the pin into a coding task: the run's tools are
-        // already scoped to this root, so the model must not guess a path.
-        const workspace =
-          src.kind === 'issue' && typeof src.meta?.localPath === 'string' && src.meta.localPath.trim()
-            ? `\n  working copy: ${src.meta.localPath.trim()} — the file, shell and git tools are already scoped to it; use relative paths.`
-            : '';
-        const body =
-          typeof src.meta?.body === 'string' && src.meta.body.trim()
-            ? `\n  body: ${src.meta.body.trim().slice(0, 2000)}`
-            : '';
-        const toolHint =
-          src.kind === 'social_post'
-            ? ' → social_post_get'
-            : src.kind === 'email'
-              ? ' → email_read'
-              : src.kind === 'issue'
-                ? ' → github_get_issue'
-                : '';
-        return `- [${src.kind}] ${src.id}: ${src.title}${repo}${folder}${provider}${status}${toolHint}${workspace}${body}`;
-      })
-      .join('\n');
-    blocks.push(
-      `**mentioned-sources** — ${opts.pinnedSources.length} item(s). Content may be inlined below each id. Use the domain get tool (social_post_get / email_read / github_get_issue) before claiming a pin is missing.\n${lines}`,
-    );
-  }
-
-  if (opts.pinnedResources && opts.pinnedResources.length > 0) {
-    const lines = opts.pinnedResources
-      .map((r) => `- ${r.id}: ${r.title} (${r.type})`)
-      .join('\n');
-    blocks.push(
-      `**pinned-resources** — ${opts.pinnedResources.length} item(s). Use resource_get_pinned(id); do not search by title.\n${lines}`,
-    );
-  }
-
-  if (opts.activeResource?.id) {
-    const type = opts.activeResource.type ? ` / ${opts.activeResource.type}` : '';
-    blocks.push(
-      `**active-resource** — ${opts.activeResource.id}${type}\n"${opts.activeResource.title}". Call resource_get_active() to read content when needed.`,
-    );
-  }
-
-  const task =
-    opts.taskLine?.trim() ||
-    'Respond to the user message using the sources above only when relevant.';
-  blocks.push(`Task: ${task}`);
-
+  const blocks: string[] = ['Source (session):'];
+  pushVolatileLabel(blocks, '**session-date**', opts.dateLine);
+  pushVolatileLabel(blocks, '**ui-context**', opts.uiContext);
+  pushVolatileLabel(blocks, '**user-memory**', opts.userMemory);
+  pushVolatileListBlock(
+    blocks,
+    `**mentioned-people** — ${opts.pinnedPeople?.length || 0} person(s). Resolve identities for email/GitHub/social tools; do not invent handles.`,
+    opts.pinnedPeople,
+    formatPinnedPersonLine,
+  );
+  pushVolatileListBlock(
+    blocks,
+    `**mentioned-sources** — ${opts.pinnedSources?.length || 0} item(s). Content may be inlined below each id. Use the domain get tool (social_post_get / email_read / github_get_issue) before claiming a pin is missing.`,
+    opts.pinnedSources,
+    formatPinnedSourceLine,
+  );
+  pushVolatileListBlock(
+    blocks,
+    `**pinned-resources** — ${opts.pinnedResources?.length || 0} item(s). Use resource_get_pinned(id); do not search by title.`,
+    opts.pinnedResources,
+    formatPinnedResourceLine,
+  );
+  const activeLine = formatActiveResourceLine(opts.activeResource);
+  if (activeLine) blocks.push(activeLine);
+  blocks.push(`Task: ${defaultTaskLine(opts.taskLine)}`);
   return blocks.join('\n\n');
 }
 

--- a/packages/prompts/test/assembler.test.mjs
+++ b/packages/prompts/test/assembler.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * Locks formatVolatileSourceContext output for pinned sources (incl. workspace).
+ * Run: pnpm --filter @dome/prompts test  (requires dist build first)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatVolatileSourceContext } from '../dist/assembler.js';
+
+test('formatVolatileSourceContext — empty opts yields session + default task', () => {
+  assert.equal(
+    formatVolatileSourceContext({}),
+    'Source (session):\n\nTask: Respond to the user message using the sources above only when relevant.',
+  );
+});
+
+test('formatVolatileSourceContext — labels trim and task override', () => {
+  assert.equal(
+    formatVolatileSourceContext({
+      dateLine: '  Friday  ',
+      uiContext: 'Library',
+      userMemory: ' Prefers ES ',
+      taskLine: 'Do X',
+    }),
+    [
+      'Source (session):',
+      '**session-date**\nFriday',
+      '**ui-context**\nLibrary',
+      '**user-memory**\nPrefers ES',
+      'Task: Do X',
+    ].join('\n\n'),
+  );
+});
+
+test('formatVolatileSourceContext — people, resources, active resource', () => {
+  const out = formatVolatileSourceContext({
+    pinnedPeople: [
+      {
+        id: 'p1',
+        title: 'Ada',
+        identities: [{ source: 'github', externalId: 'ada', displayLabel: 'Ada L' }],
+      },
+      { id: 'p2', title: 'Bob' },
+    ],
+    pinnedResources: [{ id: 'r1', title: 'Doc', type: 'pdf' }],
+    activeResource: { id: 'ar1', title: 'Active', type: 'note' },
+  });
+  assert.match(out, /\*\*mentioned-people\*\* — 2 person\(s\)/);
+  assert.match(out, /- p1: Ada \(github:Ada L\)/);
+  assert.match(out, /- p2: Bob/);
+  assert.match(out, /\*\*pinned-resources\*\* — 1 item\(s\)/);
+  assert.match(out, /- r1: Doc \(pdf\)/);
+  assert.match(out, /\*\*active-resource\*\* — ar1 \/ note\n"Active"/);
+});
+
+test('formatVolatileSourceContext — pinned sources attrs, tool hints, workspace, body', () => {
+  const out = formatVolatileSourceContext({
+    pinnedSources: [
+      {
+        kind: 'issue',
+        id: '42',
+        title: 'Bug',
+        meta: { fullName: 'org/repo', localPath: ' /tmp/ws ', body: '  hello  ' },
+      },
+      { kind: 'email', id: 'e1', title: 'Hi', meta: { folder: 'INBOX' } },
+      {
+        kind: 'social_post',
+        id: 's1',
+        title: 'Post',
+        meta: { provider: 'x', status: 'draft' },
+      },
+      { kind: 'issue', id: '43', title: 'No meta' },
+      { kind: 'issue', id: '44', title: 'Empty path', meta: { localPath: '   ', body: '' } },
+    ],
+  });
+
+  assert.match(out, /\*\*mentioned-sources\*\* — 5 item\(s\)/);
+  assert.match(
+    out,
+    /- \[issue\] 42: Bug repo=org\/repo → github_get_issue\n {2}working copy: \/tmp\/ws — the file, shell and git tools are already scoped to it; use relative paths\.\n {2}body: hello/,
+  );
+  assert.match(out, /- \[email\] e1: Hi folder=INBOX → email_read/);
+  assert.match(out, /- \[social_post\] s1: Post provider=x status=draft → social_post_get/);
+  assert.match(out, /- \[issue\] 43: No meta → github_get_issue/);
+  assert.match(out, /- \[issue\] 44: Empty path → github_get_issue/);
+  assert.doesNotMatch(out, /working copy:.*Empty path|Empty path[\s\S]*working copy/);
+});
+
+test('formatVolatileSourceContext — empty collections and blank active id omit blocks', () => {
+  assert.equal(
+    formatVolatileSourceContext({
+      pinnedPeople: [],
+      pinnedSources: [],
+      pinnedResources: [],
+      dateLine: '   ',
+      uiContext: '',
+      activeResource: { id: '', title: 'x' },
+    }),
+    'Source (session):\n\nTask: Respond to the user message using the sources above only when relevant.',
+  );
+});

--- a/scripts/test-dome-prompts.mjs
+++ b/scripts/test-dome-prompts.mjs
@@ -141,3 +141,52 @@ for (const c of EDITOR_CASES) {
     assert.equal(got, want);
   });
 }
+
+// ---------------------------------------------------------------------------
+// formatVolatileSourceContext — parity for shared-compatible shapes (no
+// packages-only workspace/localPath field — that is covered in
+// packages/prompts/test/assembler.test.mjs).
+// ---------------------------------------------------------------------------
+
+const VOLATILE_CASES = [
+  {
+    name: 'formatVolatileSourceContext — empty',
+    opts: {},
+  },
+  {
+    name: 'formatVolatileSourceContext — labels + people + sources + resources',
+    opts: {
+      dateLine: 'Monday',
+      uiContext: 'Library',
+      userMemory: 'Prefers ES',
+      taskLine: 'Summarize',
+      pinnedPeople: [
+        {
+          id: 'p1',
+          title: 'Ada',
+          identities: [{ source: 'github', externalId: 'ada', displayLabel: 'Ada L' }],
+        },
+      ],
+      pinnedSources: [
+        { kind: 'issue', id: '1', title: 'Bug', meta: { fullName: 'org/repo', body: 'details' } },
+        { kind: 'email', id: 'e1', title: 'Hi', meta: { folder: 'INBOX' } },
+        {
+          kind: 'social_post',
+          id: 's1',
+          title: 'Post',
+          meta: { provider: 'x', status: 'draft' },
+        },
+      ],
+      pinnedResources: [{ id: 'r1', title: 'Doc', type: 'pdf' }],
+      activeResource: { id: 'ar1', title: 'Active', type: 'note' },
+    },
+  },
+];
+
+for (const c of VOLATILE_CASES) {
+  test(c.name, () => {
+    const got = pkg.formatVolatileSourceContext(c.opts);
+    const want = legacy.formatVolatileSourceContext(c.opts);
+    assert.equal(got, want);
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Extract real helpers from the pinned-sources `.map` in `packages/prompts/src/assembler.ts` (Sonar `typescript:S3776` at L109, complexity 16 → allowed 15).
- Replace nested tool-hint ternaries with `PINNED_SOURCE_TOOL_HINTS`, and split meta attrs / workspace / body into named helpers so complexity drops meaningfully (not a 1-point shuffle).
- Preserve byte-identical `formatVolatileSourceContext` output (incl. issue `localPath` workspace lines). Add unit + parity tests.

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File | Issue |
| --- | --- | --- | --- |
| `b95cd8c4-e730-4d51-a87a-2440ba61fdf5` | typescript:S3776 | `packages/prompts/src/assembler.ts` | Closes #986 |

## Why safe
- Pure refactor of string assembly helpers; no prompt-assembly redesign.
- Golden tests lock pinned-source lines (attrs, tool hints, workspace, body).
- Parity tests vs `shared/prompt-assembler` for shared-compatible shapes (no `localPath`).
- Did not touch `shared/prompt-assembler`, `packages/agent-core` branch-summarization, or re-filed issues #1243–#1249.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] i18n N/A
- [x] No hardcoded colors N/A

Auto-merge (squash) enabled.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-176ca624-fb92-41f7-817e-8f02eea6b210?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-176ca624-fb92-41f7-817e-8f02eea6b210&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

