### PR TITLE
fix(sonar): lower applyReasoningParams cognitive complexity (S3776)

### DIFF
--- a/packages/ai/src/providers/openai-completions-params.test.ts
+++ b/packages/ai/src/providers/openai-completions-params.test.ts
@@ -176,3 +176,167 @@ describe("buildParams (openai-completions request mapping)", () => {
 		expect(params.tools).toEqual([]);
 	});
 });
+
+describe("applyReasoningParams (openai-completions thinkingFormat mapping)", () => {
+	function reasoningModel(
+		overrides: Partial<Model<"openai-completions">> = {},
+	): Model<"openai-completions"> {
+		return baseModel({
+			reasoning: true,
+			thinkingLevelMap: { off: "none", low: "low", medium: "medium", high: "high" },
+			...overrides,
+		});
+	}
+
+	it("sets enable_thinking for zai/qwen formats", async () => {
+		const zaiOn = await captureBuildParams(
+			reasoningModel({ compat: { thinkingFormat: "zai" } }),
+			emptyContext(),
+			{ reasoningEffort: "medium" },
+		);
+		expect(zaiOn.enable_thinking).toBe(true);
+
+		const qwenOff = await captureBuildParams(
+			reasoningModel({ compat: { thinkingFormat: "qwen" } }),
+			emptyContext(),
+		);
+		expect(qwenOff.enable_thinking).toBe(false);
+	});
+
+	it("sets chat_template_kwargs for qwen-chat-template", async () => {
+		const params = await captureBuildParams(
+			reasoningModel({ compat: { thinkingFormat: "qwen-chat-template" } }),
+			emptyContext(),
+			{ reasoningEffort: "low" },
+		);
+		expect(params.chat_template_kwargs).toEqual({
+			enable_thinking: true,
+			preserve_thinking: true,
+		});
+	});
+
+	it("maps deepseek thinking + optional reasoning_effort", async () => {
+		const withEffort = await captureBuildParams(
+			reasoningModel({
+				compat: { thinkingFormat: "deepseek", supportsReasoningEffort: true },
+			}),
+			emptyContext(),
+			{ reasoningEffort: "high" },
+		);
+		expect(withEffort.thinking).toEqual({ type: "enabled" });
+		expect(withEffort.reasoning_effort).toBe("high");
+
+		const disabled = await captureBuildParams(
+			reasoningModel({
+				compat: { thinkingFormat: "deepseek", supportsReasoningEffort: true },
+			}),
+			emptyContext(),
+		);
+		expect(disabled.thinking).toEqual({ type: "disabled" });
+		expect(disabled).not.toHaveProperty("reasoning_effort");
+	});
+
+	it("maps openrouter nested reasoning and off fallback", async () => {
+		const on = await captureBuildParams(
+			reasoningModel({ compat: { thinkingFormat: "openrouter" } }),
+			emptyContext(),
+			{ reasoningEffort: "low" },
+		);
+		expect(on.reasoning).toEqual({ effort: "low" });
+
+		const off = await captureBuildParams(
+			reasoningModel({
+				compat: { thinkingFormat: "openrouter" },
+				thinkingLevelMap: { off: "none" },
+			}),
+			emptyContext(),
+		);
+		expect(off.reasoning).toEqual({ effort: "none" });
+	});
+
+	it("maps ant-ling via thinkingLevelMap and falls back without effort", async () => {
+		const mapped = await captureBuildParams(
+			reasoningModel({
+				compat: { thinkingFormat: "ant-ling", supportsReasoningEffort: true },
+				thinkingLevelMap: { medium: "ant-medium", off: "none" },
+			}),
+			emptyContext(),
+			{ reasoningEffort: "medium" },
+		);
+		expect(mapped.reasoning).toEqual({ effort: "ant-medium" });
+
+		const fallthrough = await captureBuildParams(
+			reasoningModel({
+				compat: { thinkingFormat: "ant-ling", supportsReasoningEffort: true },
+				thinkingLevelMap: { off: "none", medium: "ant-medium" },
+			}),
+			emptyContext(),
+		);
+		expect(fallthrough.reasoning_effort).toBe("none");
+		expect(fallthrough).not.toHaveProperty("reasoning");
+	});
+
+	it("maps together and string-thinking formats", async () => {
+		const together = await captureBuildParams(
+			reasoningModel({
+				compat: { thinkingFormat: "together", supportsReasoningEffort: true },
+			}),
+			emptyContext(),
+			{ reasoningEffort: "medium" },
+		);
+		expect(together.reasoning).toEqual({ enabled: true });
+		expect(together.reasoning_effort).toBe("medium");
+
+		const stringThinking = await captureBuildParams(
+			reasoningModel({
+				compat: { thinkingFormat: "string-thinking" },
+				thinkingLevelMap: { high: "think-hard", off: "none" },
+			}),
+			emptyContext(),
+			{ reasoningEffort: "high" },
+		);
+		expect(stringThinking.thinking).toBe("think-hard");
+	});
+
+	it("applies generic reasoning_effort for openai format", async () => {
+		const on = await captureBuildParams(
+			reasoningModel({
+				compat: { thinkingFormat: "openai", supportsReasoningEffort: true },
+			}),
+			emptyContext(),
+			{ reasoningEffort: "medium" },
+		);
+		expect(on.reasoning_effort).toBe("medium");
+
+		const off = await captureBuildParams(
+			reasoningModel({
+				compat: { thinkingFormat: "openai", supportsReasoningEffort: true },
+				thinkingLevelMap: { off: "minimal" },
+			}),
+			emptyContext(),
+		);
+		expect(off.reasoning_effort).toBe("minimal");
+
+		const unsupported = await captureBuildParams(
+			reasoningModel({
+				compat: { thinkingFormat: "openai", supportsReasoningEffort: false },
+			}),
+			emptyContext(),
+			{ reasoningEffort: "medium" },
+		);
+		expect(unsupported).not.toHaveProperty("reasoning_effort");
+	});
+
+	it("skips reasoning params when model.reasoning is false", async () => {
+		const params = await captureBuildParams(
+			baseModel({
+				reasoning: false,
+				compat: { thinkingFormat: "zai" },
+			}),
+			emptyContext(),
+			{ reasoningEffort: "medium" },
+		);
+		expect(params).not.toHaveProperty("enable_thinking");
+		expect(params).not.toHaveProperty("reasoning_effort");
+	});
+});

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -607,6 +607,150 @@ function buildParams(
 	return params;
 }
 
+type ReasoningEffortLevel = NonNullable<OpenAICompletionsOptions["reasoningEffort"]>;
+
+function resolveMappedReasoningEffort(
+	model: Model<"openai-completions">,
+	requestedEffort: ReasoningEffortLevel | undefined,
+): string | undefined {
+	if (!requestedEffort) return undefined;
+	return model.thinkingLevelMap?.[requestedEffort] ?? requestedEffort;
+}
+
+function applyDeepseekThinkingParams(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	compat: ResolvedOpenAICompletionsCompat,
+	requestedEffort: ReasoningEffortLevel | undefined,
+	mappedEffort: string | undefined,
+): void {
+	(params as { thinking?: { type: string } }).thinking = {
+		type: requestedEffort ? "enabled" : "disabled",
+	};
+	if (requestedEffort && compat.supportsReasoningEffort) {
+		(params as { reasoning_effort?: string }).reasoning_effort = mappedEffort;
+	}
+}
+
+function applyOpenRouterThinkingParams(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	model: Model<"openai-completions">,
+	requestedEffort: ReasoningEffortLevel | undefined,
+	mappedEffort: string | undefined,
+): void {
+	// OpenRouter normalizes reasoning across providers via a nested reasoning object.
+	const openRouterParams = params as typeof params & { reasoning?: { effort?: string } };
+	if (requestedEffort) {
+		openRouterParams.reasoning = { effort: mappedEffort };
+	} else if (model.thinkingLevelMap?.off !== null) {
+		openRouterParams.reasoning = { effort: model.thinkingLevelMap?.off ?? "none" };
+	}
+}
+
+/** @returns false when ant-ling has no effort and must fall through to generic handling. */
+function tryApplyAntLingThinkingParams(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	model: Model<"openai-completions">,
+	requestedEffort: ReasoningEffortLevel | undefined,
+): boolean {
+	if (!requestedEffort) return false;
+	const effort = model.thinkingLevelMap?.[requestedEffort];
+	if (typeof effort === "string") {
+		(params as typeof params & { reasoning?: { effort: string } }).reasoning = { effort };
+	}
+	return true;
+}
+
+function applyTogetherThinkingParams(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	compat: ResolvedOpenAICompletionsCompat,
+	requestedEffort: ReasoningEffortLevel | undefined,
+	mappedEffort: string | undefined,
+): void {
+	const togetherParams = params as Omit<typeof params, "reasoning_effort"> & {
+		reasoning?: { enabled: boolean };
+		reasoning_effort?: string;
+	};
+	togetherParams.reasoning = { enabled: !!requestedEffort };
+	if (requestedEffort && compat.supportsReasoningEffort) {
+		togetherParams.reasoning_effort = mappedEffort;
+	}
+}
+
+function applyStringThinkingParams(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	model: Model<"openai-completions">,
+	requestedEffort: ReasoningEffortLevel | undefined,
+	mappedEffort: string | undefined,
+): void {
+	const stringThinkingParams = params as typeof params & { thinking?: string };
+	if (requestedEffort) {
+		stringThinkingParams.thinking = mappedEffort;
+	} else if (model.thinkingLevelMap?.off !== null) {
+		stringThinkingParams.thinking = model.thinkingLevelMap?.off ?? "none";
+	}
+}
+
+/**
+ * Apply a named thinkingFormat fully. Returns false when the format is unknown
+ * or ant-ling without effort — caller falls back to generic reasoning_effort.
+ */
+function tryApplyNamedThinkingFormat(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	model: Model<"openai-completions">,
+	compat: ResolvedOpenAICompletionsCompat,
+	requestedEffort: ReasoningEffortLevel | undefined,
+	mappedEffort: string | undefined,
+): boolean {
+	switch (compat.thinkingFormat) {
+		case "zai":
+		case "qwen":
+			(params as { enable_thinking?: boolean }).enable_thinking = !!requestedEffort;
+			return true;
+		case "qwen-chat-template":
+			(params as { chat_template_kwargs?: { enable_thinking: boolean; preserve_thinking: boolean } }).chat_template_kwargs =
+				{
+					enable_thinking: !!requestedEffort,
+					preserve_thinking: true,
+				};
+			return true;
+		case "deepseek":
+			applyDeepseekThinkingParams(params, compat, requestedEffort, mappedEffort);
+			return true;
+		case "openrouter":
+			applyOpenRouterThinkingParams(params, model, requestedEffort, mappedEffort);
+			return true;
+		case "ant-ling":
+			return tryApplyAntLingThinkingParams(params, model, requestedEffort);
+		case "together":
+			applyTogetherThinkingParams(params, compat, requestedEffort, mappedEffort);
+			return true;
+		case "string-thinking":
+			applyStringThinkingParams(params, model, requestedEffort, mappedEffort);
+			return true;
+		default:
+			return false;
+	}
+}
+
+/** Generic OpenAI-style reasoning_effort when no named thinkingFormat handled the request. */
+function applyGenericReasoningEffort(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	model: Model<"openai-completions">,
+	compat: ResolvedOpenAICompletionsCompat,
+	requestedEffort: ReasoningEffortLevel | undefined,
+	mappedEffort: string | undefined,
+): void {
+	if (!compat.supportsReasoningEffort) return;
+	if (requestedEffort) {
+		(params as { reasoning_effort?: string }).reasoning_effort = mappedEffort;
+		return;
+	}
+	const offValue = model.thinkingLevelMap?.off;
+	if (typeof offValue === "string") {
+		(params as { reasoning_effort?: string }).reasoning_effort = offValue;
+	}
+}
+
 /**
  * Map options.reasoningEffort onto the provider-specific thinking/reasoning
  * params. Each named thinkingFormat handles the request fully, except
@@ -621,77 +765,12 @@ function applyReasoningParams(
 ): void {
 	if (!model.reasoning) return;
 	const requestedEffort = options?.reasoningEffort;
-	const mappedEffort = requestedEffort ? (model.thinkingLevelMap?.[requestedEffort] ?? requestedEffort) : undefined;
+	const mappedEffort = resolveMappedReasoningEffort(model, requestedEffort);
 
-	switch (compat.thinkingFormat) {
-		case "zai":
-		case "qwen":
-			(params as any).enable_thinking = !!requestedEffort;
-			return;
-		case "qwen-chat-template":
-			(params as any).chat_template_kwargs = {
-				enable_thinking: !!requestedEffort,
-				preserve_thinking: true,
-			};
-			return;
-		case "deepseek":
-			(params as any).thinking = { type: requestedEffort ? "enabled" : "disabled" };
-			if (requestedEffort && compat.supportsReasoningEffort) {
-				(params as any).reasoning_effort = mappedEffort;
-			}
-			return;
-		case "openrouter": {
-			// OpenRouter normalizes reasoning across providers via a nested reasoning object.
-			const openRouterParams = params as typeof params & { reasoning?: { effort?: string } };
-			if (requestedEffort) {
-				openRouterParams.reasoning = { effort: mappedEffort };
-			} else if (model.thinkingLevelMap?.off !== null) {
-				openRouterParams.reasoning = { effort: model.thinkingLevelMap?.off ?? "none" };
-			}
-			return;
-		}
-		case "ant-ling": {
-			if (!requestedEffort) break; // falls back to generic reasoning_effort handling
-			const effort = model.thinkingLevelMap?.[requestedEffort];
-			if (typeof effort === "string") {
-				(params as typeof params & { reasoning?: { effort: string } }).reasoning = { effort };
-			}
-			return;
-		}
-		case "together": {
-			const togetherParams = params as Omit<typeof params, "reasoning_effort"> & {
-				reasoning?: { enabled: boolean };
-				reasoning_effort?: string;
-			};
-			togetherParams.reasoning = { enabled: !!requestedEffort };
-			if (requestedEffort && compat.supportsReasoningEffort) {
-				togetherParams.reasoning_effort = mappedEffort;
-			}
-			return;
-		}
-		case "string-thinking": {
-			const stringThinkingParams = params as typeof params & { thinking?: string };
-			if (requestedEffort) {
-				stringThinkingParams.thinking = mappedEffort;
-			} else if (model.thinkingLevelMap?.off !== null) {
-				stringThinkingParams.thinking = model.thinkingLevelMap?.off ?? "none";
-			}
-			return;
-		}
-		default:
-			break;
+	if (tryApplyNamedThinkingFormat(params, model, compat, requestedEffort, mappedEffort)) {
+		return;
 	}
-
-	// Generic OpenAI-style reasoning_effort
-	if (!compat.supportsReasoningEffort) return;
-	if (requestedEffort) {
-		(params as any).reasoning_effort = mappedEffort;
-	} else {
-		const offValue = model.thinkingLevelMap?.off;
-		if (typeof offValue === "string") {
-			(params as any).reasoning_effort = offValue;
-		}
-	}
+	applyGenericReasoningEffort(params, model, compat, requestedEffort, mappedEffort);
 }
 
 function applyProviderRoutingParams(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `applyReasoningParams` in `packages/ai/src/providers/openai-completions.ts` to drop Sonar cognitive complexity (typescript:S3776) from ~19 to ≤15.
- Extracts per-format helpers (`applyDeepseekThinkingParams`, `applyOpenRouterThinkingParams`, `tryApplyAntLingThinkingParams`, `applyTogetherThinkingParams`, `applyStringThinkingParams`), `tryApplyNamedThinkingFormat` dispatch, `resolveMappedReasoningEffort`, and `applyGenericReasoningEffort` — same Chat Completions request mapping, no provider rewrite.
- Leaves `buildParams` / `convertToolResultGroup` / `EmailView` untouched.
- Extends unit tests locking zai/qwen, qwen-chat-template, deepseek, openrouter, ant-ling (incl. no-effort fallthrough), together, string-thinking, generic openai, and `model.reasoning === false`.

## Type
- [ ] New feature
- [x] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| ef6b3e8d-7002-4b2b-ac19-685a84b92000 | typescript:S3776 | `packages/ai/src/providers/openai-completions.ts` (~L506 reported; hotspot is `applyReasoningParams` thinkingFormat switch) |

Closes #1262

## Why this is safe
Helpers preserve the previous control flow: identical enable_thinking / chat_template_kwargs / deepseek thinking object / openrouter nested reasoning / ant-ling map-or-fallthrough / together dual fields / string thinking / generic `reasoning_effort` (including off-map). `buildParams` still only calls `applyReasoningParams` once. No streaming or tool-result changes.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] i18n N/A
- [x] No hardcoded colors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-946ed01d-0fc7-4a2c-9022-98b1a1680b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-946ed01d-0fc7-4a2c-9022-98b1a1680b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

