### PR TITLE
fix(sonar): lower SocialQueueSection cognitive complexity (S3776, #969)

### DIFF
--- a/app/components/social/SocialQueueSection.tsx
+++ b/app/components/social/SocialQueueSection.tsx
@@ -10,6 +10,99 @@ import { SocialPostRow } from './SocialPostRow';
 const INITIAL_VISIBLE = 30;
 const LOAD_MORE = 30;
 
+/** Empty queue body — extracted for S3776. */
+function SocialQueueEmpty({
+  emptyText,
+  emptyActionLabel,
+  onEmptyAction,
+}: {
+  emptyText?: string;
+  emptyActionLabel?: string;
+  onEmptyAction?: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 px-2 py-2">
+      <p className="text-xs text-muted-foreground">{emptyText || t('social.agent_queue_empty')}</p>
+      {emptyActionLabel && onEmptyAction ? (
+        <Button
+          type="button"
+          variant="link"
+          size="xs"
+          className="h-auto px-0"
+          onClick={onEmptyAction}
+        >
+          {emptyActionLabel}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+/** Non-empty queue body (hint, rows, load-more) — extracted for S3776. */
+function SocialQueueFilled({
+  slice,
+  remaining,
+  selectedId,
+  onOpen,
+  compact,
+  footerHint,
+  footerActionLabel,
+  onFooterAction,
+  onLoadMore,
+}: {
+  slice: SocialPost[];
+  remaining: number;
+  selectedId?: string | null;
+  onOpen: (post: SocialPost) => void;
+  compact?: boolean;
+  footerHint?: string;
+  footerActionLabel?: string;
+  onFooterAction?: () => void;
+  onLoadMore: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <>
+      {footerHint ? (
+        <div className="flex flex-wrap items-center gap-2 px-2 pb-1">
+          <p className="text-xs text-muted-foreground">{footerHint}</p>
+          {footerActionLabel && onFooterAction ? (
+            <Button type="button" size="xs" variant="ghost" onClick={onFooterAction}>
+              {footerActionLabel}
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+      {slice.map((post) => (
+        <SocialPostRow
+          key={post.id}
+          post={post}
+          active={selectedId === post.id}
+          onOpen={() => onOpen(post)}
+          compact={compact}
+        />
+      ))}
+      {remaining > 0 ? (
+        <div className="px-2 py-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="w-full"
+            onClick={onLoadMore}
+          >
+            {t('social.agent_show_more', {
+              count: Math.min(remaining, LOAD_MORE),
+              total: remaining,
+            })}
+          </Button>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
 export function SocialQueueSection({
   queueId,
   title,
@@ -70,58 +163,23 @@ export function SocialQueueSection({
       </CardHeader>
       <CardContent className={compact ? 'flex flex-col gap-0.5 px-1 pb-2' : 'flex flex-col gap-0.5 px-2 pb-2'}>
         {posts.length === 0 ? (
-          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 px-2 py-2">
-            <p className="text-xs text-muted-foreground">{emptyText || t('social.agent_queue_empty')}</p>
-            {emptyActionLabel && onEmptyAction ? (
-              <Button
-                type="button"
-                variant="link"
-                size="xs"
-                className="h-auto px-0"
-                onClick={onEmptyAction}
-              >
-                {emptyActionLabel}
-              </Button>
-            ) : null}
-          </div>
+          <SocialQueueEmpty
+            emptyText={emptyText}
+            emptyActionLabel={emptyActionLabel}
+            onEmptyAction={onEmptyAction}
+          />
         ) : (
-          <>
-            {footerHint ? (
-              <div className="flex flex-wrap items-center gap-2 px-2 pb-1">
-                <p className="text-xs text-muted-foreground">{footerHint}</p>
-                {footerActionLabel && onFooterAction ? (
-                  <Button type="button" size="xs" variant="ghost" onClick={onFooterAction}>
-                    {footerActionLabel}
-                  </Button>
-                ) : null}
-              </div>
-            ) : null}
-            {slice.map((post) => (
-              <SocialPostRow
-                key={post.id}
-                post={post}
-                active={selectedId === post.id}
-                onOpen={() => onOpen(post)}
-                compact={compact}
-              />
-            ))}
-            {remaining > 0 ? (
-              <div className="px-2 py-1">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="xs"
-                  className="w-full"
-                  onClick={() => setVisible((v) => v + LOAD_MORE)}
-                >
-                  {t('social.agent_show_more', {
-                    count: Math.min(remaining, LOAD_MORE),
-                    total: remaining,
-                  })}
-                </Button>
-              </div>
-            ) : null}
-          </>
+          <SocialQueueFilled
+            slice={slice}
+            remaining={remaining}
+            selectedId={selectedId}
+            onOpen={onOpen}
+            compact={compact}
+            footerHint={footerHint}
+            footerActionLabel={footerActionLabel}
+            onFooterAction={onFooterAction}
+            onLoadMore={() => setVisible((v) => v + LOAD_MORE)}
+          />
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Extract `SocialQueueEmpty` and `SocialQueueFilled` from `SocialQueueSection` so the exported function drops under Sonar typescript:S3776 (16 → ≤15) without changing queue UI or behavior.
- `SocialCampaignSection` is untouched.

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| `c308bfd2-747d-4849-a51c-638fe5c0c6a7` | typescript:S3776 | `app/components/social/SocialQueueSection.tsx:13` |

Closes #969

## Type
- [x] Refactor

## Why this is safe
- Pure maintainability split: same props, same early-return when empty without `forceShow`, same pagination (`INITIAL_VISIBLE` / `LOAD_MORE`), same empty/footer/load-more markup and handlers.
- No new i18n keys, no IPC, no social-queue redesign.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] No new user-visible strings
- [x] No hardcoded colors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8c5bd28-52ba-4fe5-8edc-5a7c23368d2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8c5bd28-52ba-4fe5-8edc-5a7c23368d2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

