### PR TITLE
fix(sonar): lower useManySessionSync cognitive complexity (S3776, #953)

### DIFF
--- a/app/lib/many/useManySessionSync.ts
+++ b/app/lib/many/useManySessionSync.ts
@@ -16,6 +16,68 @@ import { syncManyDeletedIdsFromDb } from '@/lib/store/manySessionStorage';
 
 const SESSION_LOAD_RETRY_MS = [0, 250, 600, 1200] as const;
 
+type ManyThreadMessages = Awaited<ReturnType<typeof fetchManyMessagesFromThread>>;
+type ApplyThreadLoadResult = 'applied' | 'retry' | 'skip';
+
+function isManySessionLoadStale(
+  cancelled: boolean,
+  expectedSessionId: string,
+  currentSessionId: string | null,
+): boolean {
+  return cancelled || currentSessionId !== expectedSessionId;
+}
+
+/** Fetch JSONL messages; `null` means retry the next delay. */
+async function fetchManyThreadMessagesForLoad(
+  sessionId: string,
+): Promise<ManyThreadMessages | null> {
+  try {
+    return await fetchManyMessagesFromThread(sessionId);
+  } catch (error) {
+    console.warn('[Many] Could not load session from JSONL:', error);
+    return null;
+  }
+}
+
+/**
+ * Merge a thread snapshot into the store when safe.
+ * Extracted so `loadWithRetry` stays under Sonar S3776.
+ */
+function applyManyThreadMessagesToSession(
+  sessionId: string,
+  threadMessages: ManyThreadMessages,
+  hydrateSession: (session: ManyChatSession) => void,
+): ApplyThreadLoadResult {
+  if (threadMessages.length === 0) {
+    if (useManyStore.getState().messages.length > 0) return 'skip';
+    return 'retry';
+  }
+
+  const store = useManyStore.getState();
+  // Don't clobber an in-flight turn with a partial JSONL snapshot.
+  if (store.activeRunBySessionId[sessionId]) return 'skip';
+
+  const localMessages = store.messages;
+  if (localMessages.length > threadMessages.length) return 'skip';
+
+  const merged = mergeManySessionMessages(localMessages, threadMessages);
+  const localSession = store.sessions.find((s) => s.id === sessionId);
+  const firstUser = merged.find((m) => m.role === 'user')?.content ?? '';
+  hydrateSession({
+    id: sessionId,
+    title: deriveManySessionTitle({
+      storedTitle: localSession?.title,
+      messages: merged,
+      firstUser,
+    }),
+    messages: merged,
+    createdAt: localSession?.createdAt ?? merged[0]?.timestamp ?? Date.now(),
+    updatedAt: merged[merged.length - 1]?.timestamp ?? localSession?.updatedAt,
+    pinned: localSession?.pinned,
+  } satisfies ManyChatSession);
+  return 'applied';
+}
+
 export interface UseManySessionSyncOptions {
   chatProjectId: string;
   showHistory: boolean;
@@ -94,43 +156,14 @@ export function useManySessionSync({ chatProjectId, showHistory }: UseManySessio
     const loadWithRetry = async () => {
       for (const delay of SESSION_LOAD_RETRY_MS) {
         if (delay > 0) await new Promise((r) => setTimeout(r, delay));
-        if (cancelled || currentSessionIdRef.current !== sessionId) return;
+        if (isManySessionLoadStale(cancelled, sessionId, currentSessionIdRef.current)) return;
 
-        let threadMessages: Awaited<ReturnType<typeof fetchManyMessagesFromThread>> = [];
-        try {
-          threadMessages = await fetchManyMessagesFromThread(sessionId);
-        } catch (error) {
-          console.warn('[Many] Could not load session from JSONL:', error);
-          continue;
-        }
-        if (cancelled || currentSessionIdRef.current !== sessionId) return;
-        if (threadMessages.length === 0) {
-          if (useManyStore.getState().messages.length > 0) return;
-          continue;
-        }
+        const threadMessages = await fetchManyThreadMessagesForLoad(sessionId);
+        if (threadMessages === null) continue;
+        if (isManySessionLoadStale(cancelled, sessionId, currentSessionIdRef.current)) return;
 
-        const store = useManyStore.getState();
-        // Don't clobber an in-flight turn with a partial JSONL snapshot.
-        if (store.activeRunBySessionId[sessionId]) return;
-
-        const localMessages = store.messages;
-        if (localMessages.length > threadMessages.length) return;
-
-        const merged = mergeManySessionMessages(localMessages, threadMessages);
-        const localSession = store.sessions.find((s) => s.id === sessionId);
-        const firstUser = merged.find((m) => m.role === 'user')?.content ?? '';
-        hydrateSession({
-          id: sessionId,
-          title: deriveManySessionTitle({
-            storedTitle: localSession?.title,
-            messages: merged,
-            firstUser,
-          }),
-          messages: merged,
-          createdAt: localSession?.createdAt ?? merged[0]?.timestamp ?? Date.now(),
-          updatedAt: merged[merged.length - 1]?.timestamp ?? localSession?.updatedAt,
-          pinned: localSession?.pinned,
-        } satisfies ManyChatSession);
+        const result = applyManyThreadMessagesToSession(sessionId, threadMessages, hydrateSession);
+        if (result === 'retry') continue;
         return;
       }
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Extract `isManySessionLoadStale`, `fetchManyThreadMessagesForLoad`, and `applyManyThreadMessagesToSession` from `loadWithRetry` in `app/lib/many/useManySessionSync.ts` so Sonar S3776 cognitive complexity drops from 18 to ≤15.
- Behavior of Many session sync is unchanged: same retry delays, stale-session guards, empty-thread retry/skip, active-run protection, and merge/hydrate path.

## Type
- [x] Refactor

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| `cf79f5d9-0cef-4b2b-9131-99467f52d634` | typescript:S3776 | `app/lib/many/useManySessionSync.ts` (~L94) |

Closes #953

## Why this is safe
- Pure maintainability extract: control flow outcomes (`continue` / `return` / hydrate) map 1:1 onto helper return values (`retry` / `skip`|`applied` / hydrate+`applied`).
- No changes to IPC, store APIs, or Many UI.
- No new tests: this module had no dedicated suite; adjacent chat helpers already cover merge/title logic.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test:coverage` passes
- [x] No i18n / UI color changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-086fe84d-a57b-4e45-80ce-182e6f08eb33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-086fe84d-a57b-4e45-80ce-182e6f08eb33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

