### PR TITLE
fix(sonar): lower AccountStep handleNext cognitive complexity (S3776)

### DIFF
--- a/app/components/onboarding/steps/AccountStep.tsx
+++ b/app/components/onboarding/steps/AccountStep.tsx
@@ -35,6 +35,65 @@ const ERROR_CODE_TO_KEY: Record<string, string> = {
 
 const MIN_PASSWORD_LENGTH = 8;
 
+type AccountComplete = AccountStepProps['onComplete'];
+type NativeLoginResult = Awaited<ReturnType<NonNullable<typeof window.electron>['domeAuth']['nativeLogin']>>;
+
+/** Map native-login error codes to i18n keys — extracted for S3776. */
+function accountAuthErrorKey(errorCode: string | undefined): string {
+  if (!errorCode) return 'onboarding.account_error_generic';
+  return ERROR_CODE_TO_KEY[errorCode] ?? 'onboarding.account_error_generic';
+}
+
+/**
+ * Choice-view "Next": local complete or switch to login/register.
+ * Extracted so `handleNext` stays under Sonar S3776.
+ */
+function applyAccountChoice(
+  choice: AccountChoice | null,
+  onComplete: AccountComplete,
+  goToAuthSubView: (view: 'login' | 'register') => void,
+): void {
+  if (choice === 'local') {
+    onComplete({ mode: 'local' });
+    return;
+  }
+  if (choice === 'login' || choice === 'register') {
+    goToAuthSubView(choice);
+  }
+}
+
+/**
+ * Apply nativeLogin success / pending / error without nesting in `handleNext`.
+ * Extracted for S3776.
+ */
+function applyNativeLoginResult(
+  result: NativeLoginResult,
+  opts: {
+    trimmedEmail: string;
+    trimmedName: string;
+    isRegister: boolean;
+    onComplete: AccountComplete;
+    setError: (key: string) => void;
+    setPendingConfirmation: (value: boolean) => void;
+  },
+): void {
+  if (!result.success) {
+    opts.setError(accountAuthErrorKey(result.errorCode));
+    return;
+  }
+  if (result.pendingConfirmation) {
+    opts.setPendingConfirmation(true);
+    return;
+  }
+  opts.onComplete({
+    mode: 'account',
+    email: result.email ?? opts.trimmedEmail,
+    name: result.name ?? (opts.isRegister ? opts.trimmedName : undefined),
+    hadRemoteData: Boolean(result.hadRemoteData),
+    alreadyOnboarded: Boolean(result.alreadyOnboarded),
+  });
+}
+
 export default function AccountStep({ onComplete, onValidationChange, onSubViewChange }: AccountStepProps) {
   const { t } = useTranslation();
   const [subView, setSubView] = useState<SubView>('choice');
@@ -70,58 +129,37 @@ export default function AccountStep({ onComplete, onValidationChange, onSubViewC
 
   const handleNext = useCallback(async () => {
     if (subView === 'choice') {
-      if (choice === 'local') {
-        onComplete({ mode: 'local' });
-        return;
-      }
-      if (choice === 'login') {
-        setSubView('login');
+      applyAccountChoice(choice, onComplete, (view) => {
+        setSubView(view);
         setError(null);
-        return;
-      }
-      if (choice === 'register') {
-        setSubView('register');
-        setError(null);
-        return;
-      }
+      });
       return;
     }
 
     const isRegister = subView === 'register';
-    const formNameValid = isRegister ? nameValid : true;
-
-    if (!emailValid || !passwordValid || !formNameValid) {
+    if (!emailValid || !passwordValid || (isRegister && !nameValid)) {
       setTouched({ name: true, email: true, password: true });
       return;
     }
 
+    const trimmedEmail = email.trim();
+    const trimmedName = name.trim();
     setIsSubmitting(true);
     setError(null);
     try {
       const result = await window.electron.domeAuth.nativeLogin(
-        email.trim(),
+        trimmedEmail,
         password,
         isRegister,
-        isRegister ? name.trim() : undefined,
+        isRegister ? trimmedName : undefined,
       );
-      if (!result.success) {
-        setError(
-          result.errorCode
-            ? ERROR_CODE_TO_KEY[result.errorCode] ?? 'onboarding.account_error_generic'
-            : 'onboarding.account_error_generic',
-        );
-        return;
-      }
-      if (result.pendingConfirmation) {
-        setPendingConfirmation(true);
-        return;
-      }
-      onComplete({
-        mode: 'account',
-        email: result.email ?? email.trim(),
-        name: result.name ?? (isRegister ? name.trim() : undefined),
-        hadRemoteData: Boolean(result.hadRemoteData),
-        alreadyOnboarded: Boolean(result.alreadyOnboarded),
+      applyNativeLoginResult(result, {
+        trimmedEmail,
+        trimmedName,
+        isRegister,
+        onComplete,
+        setError,
+        setPendingConfirmation,
       });
     } catch {
       setError('onboarding.account_error_generic');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactor `handleNext` in `AccountStep.tsx` to drop cognitive complexity from 16 to ≤15 (Sonar `typescript:S3776`).
- Extract `applyAccountChoice`, `applyNativeLoginResult`, and `accountAuthErrorKey` — same control flow and outcomes as before (choice → local/login/register; login/register validation; nativeLogin success / pending / error).

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar

| Key | Rule | File | Issue |
| --- | --- | --- | --- |
| `e1b831ed-2a2a-43e6-9a09-53ca29c8ac6f` | typescript:S3776 | `app/components/onboarding/steps/AccountStep.tsx:71` | #946 |

Closes #946

## Why this is safe
- No onboarding UX rewrite: helpers preserve the previous branches and side effects (`setSubView` / `setError` / `setTouched` / `setPendingConfirmation` / `onComplete`).
- Validation condition is equivalent: `isRegister ? nameValid : true` → `(isRegister && !nameValid)` gated with the same email/password checks.
- Error key mapping is identical (`ERROR_CODE_TO_KEY` lookup with generic fallback).
- No new UI strings or IPC changes.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test:coverage` passes
- [x] i18n keys N/A (no new user-visible strings)
- [x] No hardcoded colors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eab1fa6f-1cc5-4d37-a776-cd9994042f21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eab1fa6f-1cc5-4d37-a776-cd9994042f21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

