### PR TITLE
fix(sonar): lower ManyMessageView cognitive complexity (S3776)

### DIFF
--- a/app/components/many/conversation/ManyMessageView.tsx
+++ b/app/components/many/conversation/ManyMessageView.tsx
@@ -31,10 +31,14 @@ import ManyActionSuggestion from '@/components/many/conversation/ManyActionSugge
 import { PinnedResourceChipList } from '@/components/many/PinnedResourceChipList';
 import { getDateTimeLocaleTag } from '@/lib/i18n';
 import { stripArtifactBlocks } from '@/lib/chat/artifactSchemas';
-import { parseUserMessageVisualSegments } from '@/lib/chat/userMessageVisual';
+import {
+  parseUserMessageVisualSegments,
+  type UserMessageImageRef,
+  type UserMessageVisualSegment,
+} from '@/lib/chat/userMessageVisual';
 import { coalesceDuplicateToolCalls } from '@/lib/chat/coalesceToolCalls';
 import type { ToolDisplayBlock } from '@/lib/chat/groupToolCalls';
-import { interleaveMessageParts } from '@/lib/chat/interleaveMessageParts';
+import { interleaveMessageParts, type MessagePart } from '@/lib/chat/interleaveMessageParts';
 import { stripPinnedMentionTokens } from '@/lib/chat/pinLabels';
 import { extractActionSuggestions } from '@/lib/many/actionSuggestions';
 import { extractCitationNumbers } from '@/lib/utils/citations';
@@ -53,6 +57,17 @@ export interface ManyMessageViewProps {
   onClickCitation?: (citationNumber: number) => void;
   className?: string;
 }
+
+type KeyedUserVisualSegment = UserMessageVisualSegment & { reactKey: string };
+
+type SourceRef = {
+  number: number;
+  id: string;
+  title: string;
+  type: string;
+  pageLabel?: string;
+  nodeTitle?: string;
+};
 
 function toolBlockKey(block: ToolDisplayBlock, idx: number): string {
   if (block.type === 'tool') return block.call.id;
@@ -85,44 +100,454 @@ function ToolBlock({ block }: { block: ToolDisplayBlock }) {
   );
 }
 
-/**
- * One Many message. Asymmetric by design: the user speaks in a tinted bubble
- * on the right; Many answers as open prose on the panel surface, with tools,
- * reasoning and sources framed around it. Actions reveal on hover.
- */
-export default function ManyMessageView({
+/** Build keyed visual segments for a user message — extracted for S3776. */
+function buildKeyedUserVisualSegments(
+  messageId: string,
+  content: string | undefined,
+  pinnedResources: ManyMessageData['pinnedResources'],
+  images: UserMessageImageRef[] | undefined,
+): KeyedUserVisualSegment[] | null {
+  if (!content) return null;
+  const displayContent = stripPinnedMentionTokens(content, pinnedResources ?? []);
+  if (!displayContent.trim() && (pinnedResources?.length ?? 0) > 0) {
+    // Pins are rendered as chips; nothing left to show in the bubble.
+    return [];
+  }
+  const parsed = parseUserMessageVisualSegments(displayContent, images);
+  const counts = new Map<string, number>();
+  return parsed.map((seg) => {
+    const payload = seg.type === 'text' ? `text:${seg.value}` : `img:${seg.src}:${seg.alt ?? ''}`;
+    const h = stableStringHash(payload);
+    const ord = (counts.get(h) ?? 0) + 1;
+    counts.set(h, ord);
+    return { ...seg, reactKey: `${messageId}:uv:${h}:${ord}` };
+  });
+}
+
+/** Resolve the plain-text body shown in the user bubble — extracted for S3776. */
+function resolveUserBubbleText(
+  userVisualSegments: KeyedUserVisualSegment[] | null,
+  message: ManyMessageData,
+): string {
+  const pinned = message.pinnedResources ?? [];
+  if (userVisualSegments && userVisualSegments.length > 0) {
+    return userVisualSegments
+      .filter((seg) => seg.type === 'text')
+      .map((seg) => (seg.type === 'text' ? seg.value : ''))
+      .join('');
+  }
+  if (!message.content) return '';
+  return stripPinnedMentionTokens(stripArtifactBlocks(message.content), pinned);
+}
+
+/** Citation map → SourceReference rows — extracted for S3776. */
+function buildSourceReferences(message: ManyMessageData): SourceRef[] {
+  if (!message.citationMap || message.citationMap.size === 0 || !message.content) return [];
+  return extractCitationNumbers(message.content)
+    .filter((num) => message.citationMap!.has(num))
+    .map((num) => {
+      const citation = message.citationMap!.get(num)!;
+      return {
+        number: num,
+        id: citation.sourceId || '',
+        title: citation.sourceTitle || `Source ${num}`,
+        type: 'resource',
+        pageLabel: citation.pageLabel,
+        nodeTitle: citation.nodeTitle,
+      };
+    });
+}
+
+function formatMessageTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString(getDateTimeLocaleTag(), {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/** Open a citation via prop or default resource tab — extracted for S3776. */
+function openMessageCitation(
+  citationNumber: number,
+  message: ManyMessageData,
+  onClickCitation?: (citationNumber: number) => void,
+): void {
+  if (onClickCitation) {
+    onClickCitation(citationNumber);
+    return;
+  }
+  const citation = message.citationMap?.get(citationNumber);
+  if (!citation?.sourceId) return;
+  useTabStore
+    .getState()
+    .openResourceTab(citation.sourceId, citation.resourceType || 'url', 'Recurso');
+}
+
+/** Build PDF region handoff text, or null when meta/content is missing. */
+function buildMessagePdfHandoff(
+  message: ManyMessageData,
+  labels: {
+    contextIntro: string;
+    questionLabel: string;
+    answerLabel: string;
+    answerSourceNote: string;
+    followUpPrompt: string;
+  },
+): string | null {
+  const meta = message.pdfRegionMeta;
+  if (!meta || !message.content) return null;
+  return buildPdfRegionHandoff({
+    resourceId: meta.resourceId,
+    resourceTitle: meta.resourceTitle,
+    page: meta.page,
+    question: meta.question,
+    answer: message.content,
+    labels,
+  });
+}
+
+/** Live reasoning is the only visible content while streaming — extracted for S3776. */
+function isAssistantThinkingLive(message: ManyMessageData): boolean {
+  if (!message.isStreaming) return false;
+  if (!message.thinking) return false;
+  return !message.content?.trim();
+}
+
+function UserImageAttachments({
+  segments,
+  imageAlt,
+}: {
+  segments: KeyedUserVisualSegment[];
+  imageAlt: string;
+}) {
+  const images = segments.filter((seg) => seg.type === 'image');
+  if (images.length === 0) return null;
+  return (
+    <AttachmentGroup className="justify-end">
+      {images.map((seg) =>
+        seg.type === 'image' ? (
+          <Attachment key={seg.reactKey} state="done" size="sm">
+            <AttachmentMedia variant="image">
+              <img src={seg.src} alt={seg.alt || imageAlt} loading="lazy" />
+            </AttachmentMedia>
+            <AttachmentContent>
+              <AttachmentTitle>{seg.alt || imageAlt}</AttachmentTitle>
+            </AttachmentContent>
+          </Attachment>
+        ) : null,
+      )}
+    </AttachmentGroup>
+  );
+}
+
+function UserTurnFooter({
+  hasBody,
+  show,
+  copied,
+  formattedTime,
+  onCopy,
+  copyTitle,
+}: {
+  hasBody: boolean;
+  show: boolean;
+  copied: boolean;
+  formattedTime: string;
+  onCopy: () => void;
+  copyTitle: string;
+}) {
+  if (!show) return null;
+  return (
+    <MessageFooter className="gap-1 opacity-0 transition-opacity group-hover/turn:opacity-100 motion-reduce:transition-none">
+      {hasBody ? (
+        <Button type="button" size="icon-xs" variant="ghost" onClick={onCopy} title={copyTitle}>
+          <HugeiconsIcon icon={copied ? CheckmarkCircle02Icon : Copy01Icon} />
+        </Button>
+      ) : null}
+      <span className="text-xs tabular-nums text-muted-foreground">{formattedTime}</span>
+    </MessageFooter>
+  );
+}
+
+/** User turn (bubble + pins + attachments) — extracted for S3776. */
+function ManyUserMessageTurn({
   message,
-  isLastInGroup = true,
+  className,
+}: {
+  message: ManyMessageData;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(message.content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy:', error);
+    }
+  }, [message.content]);
+
+  const formattedTime = useMemo(() => formatMessageTime(message.timestamp), [message.timestamp]);
+
+  const userVisualSegments = useMemo(
+    () =>
+      buildKeyedUserVisualSegments(
+        message.id,
+        message.content,
+        message.pinnedResources,
+        message.attachments?.images,
+      ),
+    [message.id, message.content, message.attachments?.images, message.pinnedResources],
+  );
+
+  const userText = resolveUserBubbleText(userVisualSegments, message);
+  const hasBody = Boolean(userText.trim());
+  const pinned = message.pinnedResources ?? [];
+  const showFooter = hasBody || pinned.length > 0 || (userVisualSegments?.some((s) => s.type === 'image') ?? false);
+
+  return (
+    <div className={cn('group/turn flex min-w-0 flex-col items-end gap-1.5', className)}>
+      {pinned.length > 0 ? (
+        <PinnedResourceChipList resources={pinned} align="end" className="max-w-[88%]" />
+      ) : null}
+
+      {userVisualSegments ? (
+        <UserImageAttachments
+          segments={userVisualSegments}
+          imageAlt={t('chat.attachment_image_alt')}
+        />
+      ) : null}
+
+      {hasBody ? (
+        <Bubble variant="secondary" align="end" className="max-w-[88%]">
+          <BubbleContent>
+            <span className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+              {userText}
+            </span>
+          </BubbleContent>
+        </Bubble>
+      ) : null}
+
+      <UserTurnFooter
+        hasBody={hasBody}
+        show={showFooter}
+        copied={copied}
+        formattedTime={formattedTime}
+        onCopy={() => {
+          handleCopy().catch(() => {});
+        }}
+        copyTitle={t('chat.copy_message')}
+      />
+    </div>
+  );
+}
+
+function AssistantThinking({
+  thinking,
+  thinkingOpen,
+  thinkingIsLive,
+  onOpenChange,
+  label,
+}: {
+  thinking: string;
+  thinkingOpen: boolean;
+  thinkingIsLive: boolean;
+  onOpenChange: (open: boolean) => void;
+  label: string;
+}) {
+  return (
+    <Collapsible open={thinkingOpen} onOpenChange={onOpenChange} className="w-full min-w-0">
+      <CollapsibleTrigger className="flex cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted motion-reduce:transition-none">
+        <HugeiconsIcon
+          icon={ArrowRight01Icon}
+          className={cn('transition-transform motion-reduce:transition-none', thinkingOpen && 'rotate-90')}
+        />
+        <span className={cn(thinkingIsLive && 'shimmer')}>{label}</span>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="ml-1.5 border-l py-1 pl-3.5">
+        <div className="whitespace-pre-wrap break-words text-xs text-muted-foreground">
+          {thinking}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function AssistantStreamingStatus({ label }: { label: string }) {
+  return (
+    <Marker role="status">
+      <MarkerIcon>
+        <Spinner />
+      </MarkerIcon>
+      <MarkerContent className="shimmer">{label}</MarkerContent>
+    </Marker>
+  );
+}
+
+function AssistantMessageParts({
+  parts,
+  isStreaming,
+  citationMap,
+  onClickCitation,
+}: {
+  parts: MessagePart[];
+  isStreaming: boolean;
+  citationMap: ManyMessageData['citationMap'];
+  onClickCitation: (n: number) => void;
+}) {
+  return (
+    <>
+      {parts.map((part, partIdx) =>
+        part.type === 'tools' ? (
+          <div
+            key={`part:${partIdx}:tools`}
+            className="flex w-full min-w-0 flex-col gap-1.5"
+          >
+            {part.blocks.map((block, idx) => (
+              <ToolBlock key={toolBlockKey(block, idx)} block={block} />
+            ))}
+          </div>
+        ) : (
+          <div
+            key={`part:${partIdx}:text`}
+            className="min-w-0 w-full break-words text-sm leading-relaxed [overflow-wrap:anywhere]"
+          >
+            <MarkdownRenderer
+              content={part.text}
+              citationMap={citationMap}
+              onClickCitation={onClickCitation}
+            />
+            {isStreaming && partIdx === parts.length - 1 ? (
+              <span
+                aria-hidden
+                className="ml-0.5 inline-block h-4 w-0.5 animate-pulse bg-current motion-reduce:animate-none"
+              />
+            ) : null}
+          </div>
+        ),
+      )}
+    </>
+  );
+}
+
+function AssistantPdfRegionActions({
+  continueLabel,
+  copyLabel,
+  onContinue,
+  onCopy,
+}: {
+  continueLabel: string;
+  copyLabel: string;
+  onContinue: () => void;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button type="button" size="xs" onClick={onContinue}>
+        {continueLabel}
+      </Button>
+      <Button type="button" size="xs" variant="outline" onClick={onCopy}>
+        {copyLabel}
+      </Button>
+    </div>
+  );
+}
+
+function AssistantSources({
+  sources,
+  onClickSource,
+}: {
+  sources: SourceRef[];
+  onClickSource: (source: SourceRef) => void;
+}) {
+  return (
+    <div className="border-t pt-2">
+      <SourceReference sources={sources} onClickSource={onClickSource} />
+    </div>
+  );
+}
+
+function AssistantTurnFooter({
+  copied,
+  formattedTime,
+  onCopy,
+  onRegenerate,
+  copyTitle,
+  regenerateTitle,
+}: {
+  copied: boolean;
+  formattedTime: string;
+  onCopy: () => void;
+  onRegenerate?: () => void;
+  copyTitle: string;
+  regenerateTitle: string;
+}) {
+  return (
+    <MessageFooter className="gap-0.5 opacity-0 transition-opacity group-hover/turn:opacity-100 motion-reduce:transition-none">
+      <Button type="button" size="icon-xs" variant="ghost" onClick={onCopy} title={copyTitle}>
+        <HugeiconsIcon icon={copied ? CheckmarkCircle02Icon : Copy01Icon} />
+      </Button>
+      {onRegenerate ? (
+        <Button
+          type="button"
+          size="icon-xs"
+          variant="ghost"
+          onClick={onRegenerate}
+          title={regenerateTitle}
+        >
+          <HugeiconsIcon icon={RefreshIcon} />
+        </Button>
+      ) : null}
+      <span className="ml-auto text-xs tabular-nums text-muted-foreground">{formattedTime}</span>
+    </MessageFooter>
+  );
+}
+
+function ActionSuggestionsList({
+  suggestions,
+}: {
+  suggestions: ReturnType<typeof extractActionSuggestions>;
+}) {
+  if (suggestions.length === 0) return null;
+  return (
+    <div className="flex w-full min-w-0 flex-col gap-2">
+      {suggestions.map((suggestion) => (
+        <ManyActionSuggestion key={suggestion.id} suggestion={suggestion} />
+      ))}
+    </div>
+  );
+}
+
+/** Assistant / system turn — extracted for S3776. */
+function ManyAssistantMessageTurn({
+  message,
+  isLastInGroup,
   onRegenerate,
   onClickCitation,
   className,
-}: ManyMessageViewProps) {
+}: {
+  message: ManyMessageData;
+  isLastInGroup: boolean;
+  onRegenerate?: () => void;
+  onClickCitation?: (citationNumber: number) => void;
+  className?: string;
+}) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   // `null` = the user has not decided; follow the live heuristic below.
   const [thinkingOpenOverride, setThinkingOpenOverride] = useState<boolean | null>(null);
 
-  const isUser = message.role === 'user';
   const isAssistant = message.role === 'assistant';
 
   // While the model reasons and has written nothing, the reasoning *is* the
   // content — show it. Fold it away once the answer starts. Manual toggle wins.
-  const thinkingIsLive = Boolean(message.isStreaming && message.thinking && !message.content?.trim());
+  const thinkingIsLive = isAssistantThinkingLive(message);
   const thinkingOpen = thinkingOpenOverride ?? thinkingIsLive;
 
   const openCitation = useCallback(
-    (citationNumber: number) => {
-      if (onClickCitation) {
-        onClickCitation(citationNumber);
-        return;
-      }
-      const citation = message.citationMap?.get(citationNumber);
-      if (!citation?.sourceId) return;
-      useTabStore
-        .getState()
-        .openResourceTab(citation.sourceId, citation.resourceType || 'url', 'Recurso');
-    },
-    [message.citationMap, onClickCitation],
+    (citationNumber: number) => openMessageCitation(citationNumber, message, onClickCitation),
+    [message, onClickCitation],
   );
 
   const handleCopy = useCallback(async () => {
@@ -135,24 +560,17 @@ export default function ManyMessageView({
     }
   }, [message.content]);
 
-  const pdfHandoffText = useCallback(() => {
-    const meta = message.pdfRegionMeta;
-    if (!meta || !message.content) return null;
-    return buildPdfRegionHandoff({
-      resourceId: meta.resourceId,
-      resourceTitle: meta.resourceTitle,
-      page: meta.page,
-      question: meta.question,
-      answer: message.content,
-      labels: {
+  const pdfHandoffText = useCallback(
+    () =>
+      buildMessagePdfHandoff(message, {
         contextIntro: t('viewer.pdf_region_handoff_context_intro'),
         questionLabel: t('viewer.pdf_region_handoff_question_label'),
         answerLabel: t('viewer.pdf_region_handoff_answer_label'),
         answerSourceNote: t('viewer.pdf_region_handoff_answer_note'),
         followUpPrompt: t('viewer.pdf_region_handoff_follow_up'),
-      },
-    });
-  }, [message.content, message.pdfRegionMeta, t]);
+      }),
+    [message, t],
+  );
 
   const handlePdfRegionContinue = useCallback(() => {
     const text = pdfHandoffText();
@@ -172,53 +590,23 @@ export default function ManyMessageView({
     }
   }, [pdfHandoffText, t]);
 
-  const formattedTime = useMemo(
-    () =>
-      new Date(message.timestamp).toLocaleTimeString(getDateTimeLocaleTag(), {
-        hour: '2-digit',
-        minute: '2-digit',
-      }),
-    [message.timestamp],
+  const formattedTime = useMemo(() => formatMessageTime(message.timestamp), [message.timestamp]);
+
+  const assistantMarkdown = useMemo(
+    () => (message.content ? stripArtifactBlocks(message.content) : ''),
+    [message.content],
   );
-
-  const userVisualSegments = useMemo(() => {
-    if (!isUser || !message.content) return null;
-    const displayContent = stripPinnedMentionTokens(
-      message.content,
-      message.pinnedResources ?? [],
-    );
-    if (!displayContent.trim() && (message.pinnedResources?.length ?? 0) > 0) {
-      // Pins are rendered as chips; nothing left to show in the bubble.
-      return [];
-    }
-    const parsed = parseUserMessageVisualSegments(displayContent, message.attachments?.images);
-    const counts = new Map<string, number>();
-    return parsed.map((seg) => {
-      const payload = seg.type === 'text' ? `text:${seg.value}` : `img:${seg.src}:${seg.alt ?? ''}`;
-      const h = stableStringHash(payload);
-      const ord = (counts.get(h) ?? 0) + 1;
-      counts.set(h, ord);
-      return { ...seg, reactKey: `${message.id}:uv:${h}:${ord}` };
-    });
-  }, [isUser, message.content, message.attachments?.images, message.pinnedResources, message.id]);
-
-  const assistantMarkdown = useMemo(() => {
-    if (!message.content || isUser) return '';
-    return stripArtifactBlocks(message.content);
-  }, [message.content, isUser]);
 
   // The turn is rebuilt in emission order: prose, the tools run at that point,
   // more prose. Stored messages carry no offsets and degrade to tools-first.
   const messageParts = useMemo(
     () =>
-      isUser
-        ? []
-        : interleaveMessageParts(
-            assistantMarkdown,
-            coalesceDuplicateToolCalls(message.toolCalls ?? []),
-            t,
-          ),
-    [isUser, assistantMarkdown, message.toolCalls, t],
+      interleaveMessageParts(
+        assistantMarkdown,
+        coalesceDuplicateToolCalls(message.toolCalls ?? []),
+        t,
+      ),
+    [assistantMarkdown, message.toolCalls, t],
   );
 
   const actionSuggestions = useMemo(
@@ -226,120 +614,31 @@ export default function ManyMessageView({
     [message.toolCalls],
   );
 
-  const sourceReferences = useMemo(() => {
-    if (!message.citationMap || message.citationMap.size === 0 || !message.content) return [];
-    return extractCitationNumbers(message.content)
-      .filter((num) => message.citationMap!.has(num))
-      .map((num) => {
-        const citation = message.citationMap!.get(num)!;
-        return {
-          number: num,
-          id: citation.sourceId || '',
-          title: citation.sourceTitle || `Source ${num}`,
-          type: 'resource',
-          pageLabel: citation.pageLabel,
-          nodeTitle: citation.nodeTitle,
-        };
-      });
-  }, [message.content, message.citationMap]);
+  const sourceReferences = useMemo(
+    () => buildSourceReferences(message),
+    [message.content, message.citationMap],
+  );
 
-  const userImageSegments =
-    isUser && userVisualSegments ? userVisualSegments.filter((seg) => seg.type === 'image') : [];
+  const showThinking = isAssistant && Boolean(message.thinking);
+  const showStreamingStatus = Boolean(message.isStreaming && !message.content && isLastInGroup);
+  const showIdleExtras = isAssistant && !message.isStreaming;
+  const showPdfActions = showIdleExtras && Boolean(message.pdfRegionMeta);
+  const showSources = showIdleExtras && sourceReferences.length > 0;
+  const showFooter = showIdleExtras && isLastInGroup;
 
-  // ── User turn ──────────────────────────────────────────────────────────────
-  if (isUser) {
-    const pinned = message.pinnedResources ?? [];
-    const userText =
-      userVisualSegments && userVisualSegments.length > 0
-        ? userVisualSegments
-            .filter((seg) => seg.type === 'text')
-            .map((seg) => (seg.type === 'text' ? seg.value : ''))
-            .join('')
-        : message.content
-          ? stripPinnedMentionTokens(stripArtifactBlocks(message.content), pinned)
-          : '';
-    const hasBody = Boolean(userText.trim());
-    return (
-      <div className={cn('group/turn flex min-w-0 flex-col items-end gap-1.5', className)}>
-        {pinned.length > 0 ? (
-          <PinnedResourceChipList resources={pinned} align="end" className="max-w-[88%]" />
-        ) : null}
-
-        {userImageSegments.length > 0 ? (
-          <AttachmentGroup className="justify-end">
-            {userImageSegments.map((seg) =>
-              seg.type === 'image' ? (
-                <Attachment key={seg.reactKey} state="done" size="sm">
-                  <AttachmentMedia variant="image">
-                    <img src={seg.src} alt={seg.alt || t('chat.attachment_image_alt')} loading="lazy" />
-                  </AttachmentMedia>
-                  <AttachmentContent>
-                    <AttachmentTitle>{seg.alt || t('chat.attachment_image_alt')}</AttachmentTitle>
-                  </AttachmentContent>
-                </Attachment>
-              ) : null,
-            )}
-          </AttachmentGroup>
-        ) : null}
-
-        {hasBody ? (
-          <Bubble variant="secondary" align="end" className="max-w-[88%]">
-            <BubbleContent>
-              <span className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
-                {userText}
-              </span>
-            </BubbleContent>
-          </Bubble>
-        ) : null}
-
-        {hasBody || pinned.length > 0 || userImageSegments.length > 0 ? (
-          <MessageFooter className="gap-1 opacity-0 transition-opacity group-hover/turn:opacity-100 motion-reduce:transition-none">
-            {hasBody ? (
-              <Button
-                type="button"
-                size="icon-xs"
-                variant="ghost"
-                onClick={() => handleCopy()}
-                title={t('chat.copy_message')}
-              >
-                <HugeiconsIcon icon={copied ? CheckmarkCircle02Icon : Copy01Icon} />
-              </Button>
-            ) : null}
-            <span className="text-xs tabular-nums text-muted-foreground">{formattedTime}</span>
-          </MessageFooter>
-        ) : null}
-      </div>
-    );
-  }
-
-  // ── Assistant / system turn ─────────────────────────────────────────────────
   return (
     <div className={cn('group/turn flex min-w-0 w-full flex-col gap-2', className)}>
-      {isAssistant && message.thinking ? (
-        <Collapsible open={thinkingOpen} onOpenChange={setThinkingOpenOverride} className="w-full min-w-0">
-          <CollapsibleTrigger className="flex cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted motion-reduce:transition-none">
-            <HugeiconsIcon
-              icon={ArrowRight01Icon}
-              className={cn('transition-transform motion-reduce:transition-none', thinkingOpen && 'rotate-90')}
-            />
-            <span className={cn(thinkingIsLive && 'shimmer')}>{t('chat.reasoning')}</span>
-          </CollapsibleTrigger>
-          <CollapsibleContent className="ml-1.5 border-l py-1 pl-3.5">
-            <div className="whitespace-pre-wrap break-words text-xs text-muted-foreground">
-              {message.thinking}
-            </div>
-          </CollapsibleContent>
-        </Collapsible>
+      {showThinking && message.thinking ? (
+        <AssistantThinking
+          thinking={message.thinking}
+          thinkingOpen={thinkingOpen}
+          thinkingIsLive={thinkingIsLive}
+          onOpenChange={setThinkingOpenOverride}
+          label={t('chat.reasoning')}
+        />
       ) : null}
 
-
-      {actionSuggestions.length > 0 ? (
-        <div className="flex w-full min-w-0 flex-col gap-2">
-          {actionSuggestions.map((suggestion) => (
-            <ManyActionSuggestion key={suggestion.id} suggestion={suggestion} />
-          ))}
-        </div>
-      ) : null}
+      <ActionSuggestionsList suggestions={actionSuggestions} />
 
       {message.agentLabel ? (
         <span className="px-0.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
@@ -352,92 +651,74 @@ export default function ManyMessageView({
         a persisted partial reply and the live streaming message at once; both
         drawing the spinner is what produced the doubled "Thinking…".
       */}
-      {message.isStreaming && !message.content && isLastInGroup ? (
-        <Marker role="status">
-          <MarkerIcon>
-            <Spinner />
-          </MarkerIcon>
-          <MarkerContent className="shimmer">
-            {message.streamingLabel || t('chat.processing')}
-          </MarkerContent>
-        </Marker>
+      {showStreamingStatus ? (
+        <AssistantStreamingStatus label={message.streamingLabel || t('chat.processing')} />
       ) : null}
 
-      {messageParts.map((part, partIdx) =>
-        part.type === 'tools' ? (
-          <div
-            key={`part:${partIdx}:tools`}
-            className="flex w-full min-w-0 flex-col gap-1.5"
-          >
-            {part.blocks.map((block, idx) => (
-              <ToolBlock key={toolBlockKey(block, idx)} block={block} />
-            ))}
-          </div>
-        ) : (
-          <div
-            key={`part:${partIdx}:text`}
-            className="min-w-0 w-full break-words text-sm leading-relaxed [overflow-wrap:anywhere]"
-          >
-            <MarkdownRenderer
-              content={part.text}
-              citationMap={message.citationMap}
-              onClickCitation={openCitation}
-            />
-            {message.isStreaming && partIdx === messageParts.length - 1 ? (
-              <span
-                aria-hidden
-                className="ml-0.5 inline-block h-4 w-0.5 animate-pulse bg-current motion-reduce:animate-none"
-              />
-            ) : null}
-          </div>
-        ),
-      )}
+      <AssistantMessageParts
+        parts={messageParts}
+        isStreaming={Boolean(message.isStreaming)}
+        citationMap={message.citationMap}
+        onClickCitation={openCitation}
+      />
 
-      {isAssistant && !message.isStreaming && message.pdfRegionMeta ? (
-        <div className="flex flex-wrap gap-2">
-          <Button type="button" size="xs" onClick={handlePdfRegionContinue}>
-            {t('viewer.pdf_region_qa_continue_many')}
-          </Button>
-          <Button type="button" size="xs" variant="outline" onClick={() => handlePdfRegionCopy()}>
-            {t('viewer.pdf_region_qa_copy_handoff')}
-          </Button>
-        </div>
+      {showPdfActions ? (
+        <AssistantPdfRegionActions
+          continueLabel={t('viewer.pdf_region_qa_continue_many')}
+          copyLabel={t('viewer.pdf_region_qa_copy_handoff')}
+          onContinue={handlePdfRegionContinue}
+          onCopy={() => {
+            handlePdfRegionCopy().catch(() => {});
+          }}
+        />
       ) : null}
 
-      {isAssistant && !message.isStreaming && sourceReferences.length > 0 ? (
-        <div className="border-t pt-2">
-          <SourceReference
-            sources={sourceReferences}
-            onClickSource={(source) => openCitation(source.number)}
-          />
-        </div>
+      {showSources ? (
+        <AssistantSources
+          sources={sourceReferences}
+          onClickSource={(source) => openCitation(source.number)}
+        />
       ) : null}
 
-      {isAssistant && !message.isStreaming && isLastInGroup ? (
-        <MessageFooter className="gap-0.5 opacity-0 transition-opacity group-hover/turn:opacity-100 motion-reduce:transition-none">
-          <Button
-            type="button"
-            size="icon-xs"
-            variant="ghost"
-            onClick={() => handleCopy()}
-            title={t('chat.copy_message')}
-          >
-            <HugeiconsIcon icon={copied ? CheckmarkCircle02Icon : Copy01Icon} />
-          </Button>
-          {onRegenerate ? (
-            <Button
-              type="button"
-              size="icon-xs"
-              variant="ghost"
-              onClick={onRegenerate}
-              title={t('chat.regenerate')}
-            >
-              <HugeiconsIcon icon={RefreshIcon} />
-            </Button>
-          ) : null}
-          <span className="ml-auto text-xs tabular-nums text-muted-foreground">{formattedTime}</span>
-        </MessageFooter>
+      {showFooter ? (
+        <AssistantTurnFooter
+          copied={copied}
+          formattedTime={formattedTime}
+          onCopy={() => {
+            handleCopy().catch(() => {});
+          }}
+          onRegenerate={onRegenerate}
+          copyTitle={t('chat.copy_message')}
+          regenerateTitle={t('chat.regenerate')}
+        />
       ) : null}
     </div>
+  );
+}
+
+/**
+ * One Many message. Asymmetric by design: the user speaks in a tinted bubble
+ * on the right; Many answers as open prose on the panel surface, with tools,
+ * reasoning and sources framed around it. Actions reveal on hover.
+ */
+export default function ManyMessageView({
+  message,
+  isLastInGroup = true,
+  onRegenerate,
+  onClickCitation,
+  className,
+}: ManyMessageViewProps) {
+  if (message.role === 'user') {
+    return <ManyUserMessageTurn message={message} className={className} />;
+  }
+
+  return (
+    <ManyAssistantMessageTurn
+      message={message}
+      isLastInGroup={isLastInGroup}
+      onRegenerate={onRegenerate}
+      onClickCitation={onClickCitation}
+      className={className}
+    />
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `ManyMessageView` to clear Sonar typescript:S3776 (cognitive complexity 47 → ≤15) by splitting role branches into dedicated turn components and pure helpers.
- Preserves Many chat rendering behavior (user bubble, tools/prose interleave, thinking, sources, PDF region actions, footers).
- No UI redesign and no Sonar suppressions.

## Sonar
| Key | Rule | File | GitHub |
| --- | --- | --- | --- |
| `ea56e710-a24b-4bdf-99e9-b6c044f12b32` | typescript:S3776 | `app/components/many/conversation/ManyMessageView.tsx` | Closes #937 |

## What changed
- `ManyMessageView` now dispatches `role === 'user'` → `ManyUserMessageTurn`, otherwise → `ManyAssistantMessageTurn`.
- Extracted helpers/components for visual segments, bubble text, citations, PDF handoff, thinking collapsible, message parts, sources, and footers so each function stays under the complexity budget.

## Why this is safe
- Same props, same IPC/store side effects, same conditional visibility for streaming/idle extras.
- Pure moves of existing branches; no new chat presentation paths.

## Local validation
- `pnpm run typecheck` — pass
- `pnpm run lint` — pass (0 errors)
- `pnpm run test:coverage` — pass (electron 117, renderer 140, agent-core 54, ai 28)
- `pnpm run check:sonar-patterns -- --diff=origin/main` — OK

## Type
- [x] Refactor

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test:coverage` passes
- [x] i18n keys N/A (no new user-visible strings)
- [x] No hardcoded colors

Closes #937

Auto-merge: enabled (squash).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e0f3537-b075-4aab-a33b-1c00dae245ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e0f3537-b075-4aab-a33b-1c00dae245ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

