### PR TITLE
fix(sonar): lower JsonPrettyPrinter cognitive complexity (S3776)

### DIFF
--- a/app/lib/chat/jsonPrettyPrinter.test.tsx
+++ b/app/lib/chat/jsonPrettyPrinter.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  JSON_PRETTY_MAX_DEPTH,
+  JSON_PRETTY_MAX_NODES,
+  JsonPrettyBudgetProvider,
+  JsonPrettyPrinter,
+  JsonPrettyPrinterRoot,
+} from './jsonPrettyPrinter';
+
+describe('JsonPrettyPrinterRoot', () => {
+  it('renders null, booleans, numbers, and strings', () => {
+    const { rerender } = render(<JsonPrettyPrinterRoot value={null} />);
+    expect(screen.getByText('null')).toBeTruthy();
+
+    rerender(<JsonPrettyPrinterRoot value={true} />);
+    expect(screen.getByText('true')).toBeTruthy();
+
+    rerender(<JsonPrettyPrinterRoot value={42} />);
+    expect(screen.getByText('42')).toBeTruthy();
+
+    rerender(<JsonPrettyPrinterRoot value="hola" />);
+    expect(screen.getByText('"hola"')).toBeTruthy();
+  });
+
+  it('truncates long strings at 240 chars', () => {
+    const long = 'a'.repeat(300);
+    render(<JsonPrettyPrinterRoot value={long} />);
+    const text = screen.getByText(/^"a+…"$/).textContent ?? '';
+    expect(text.length).toBe(1 + 237 + 1 + 1); // " + 237 + … + "
+    expect(text.endsWith('…"')).toBe(true);
+  });
+
+  it('renders empty and nested arrays/objects', () => {
+    const { rerender } = render(<JsonPrettyPrinterRoot value={[]} />);
+    expect(screen.getByText('[]')).toBeTruthy();
+
+    rerender(<JsonPrettyPrinterRoot value={{}} />);
+    expect(screen.getByText('{}')).toBeTruthy();
+
+    rerender(<JsonPrettyPrinterRoot value={{ a: 1, b: [2, 3] }} />);
+    expect(screen.getByText('a:')).toBeTruthy();
+    expect(screen.getByText('b:')).toBeTruthy();
+    expect(screen.getByText('1')).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+    expect(screen.getByText('3')).toBeTruthy();
+  });
+
+  it('ellipses when max depth is exceeded', () => {
+    let nested: unknown = 'leaf';
+    for (let i = 0; i < JSON_PRETTY_MAX_DEPTH + 1; i += 1) {
+      nested = [nested];
+    }
+    render(<JsonPrettyPrinterRoot value={nested} />);
+    expect(screen.getAllByText('…').length).toBeGreaterThan(0);
+  });
+
+  it('shows omitted notice when node budget is exhausted at root', () => {
+    const budget = { nodes: JSON_PRETTY_MAX_NODES, omitted: 0 };
+    render(
+      <JsonPrettyBudgetProvider budget={budget}>
+        <JsonPrettyPrinter value={{ keep: true }} depth={0} showOmittedNotice />
+      </JsonPrettyBudgetProvider>,
+    );
+    expect(screen.getByText(/nodos omitidos/)).toBeTruthy();
+    expect(budget.omitted).toBe(1);
+  });
+
+  it('falls back to String(value) for unsupported types', () => {
+    render(<JsonPrettyPrinterRoot value={Symbol('x')} />);
+    expect(screen.getByText('Symbol(x)')).toBeTruthy();
+  });
+});

--- a/app/lib/chat/jsonPrettyPrinter.tsx
+++ b/app/lib/chat/jsonPrettyPrinter.tsx
@@ -44,6 +44,139 @@ function OmittedNodesNotice({ count }: { count: number }) {
   );
 }
 
+function JsonPrettyEllipsis() {
+  return <span className="text-muted-foreground">…</span>;
+}
+
+function RootOmittedNotice({
+  showOmittedNotice,
+  depth,
+  omitted,
+}: {
+  showOmittedNotice: boolean;
+  depth: number;
+  omitted: number;
+}) {
+  if (!showOmittedNotice || depth !== 0) return null;
+  return <OmittedNodesNotice count={omitted} />;
+}
+
+function JsonPrettyBudgetExceeded({
+  showOmittedNotice,
+  depth,
+  omitted,
+}: {
+  showOmittedNotice: boolean;
+  depth: number;
+  omitted: number;
+}) {
+  if (showOmittedNotice && depth === 0) {
+    return <OmittedNodesNotice count={omitted} />;
+  }
+  return <JsonPrettyEllipsis />;
+}
+
+function stripeBackground(index: number): string {
+  return index % 2 === 0
+    ? 'transparent'
+    : 'color-mix(in srgb, var(--accent) 50%, transparent)';
+}
+
+function renderJsonPrettyScalar(value: unknown): ReactNode | undefined {
+  if (value === null) return <span className="text-muted-foreground">null</span>;
+  if (typeof value === 'boolean') {
+    return <span className="text-[var(--warning)]">{String(value)}</span>;
+  }
+  if (typeof value === 'number') {
+    return <span className="text-[var(--success)]">{value}</span>;
+  }
+  if (typeof value === 'string') {
+    const display = value.length > 240 ? `${value.slice(0, 237)}…` : value;
+    return <span className="text-muted-foreground">"{display}"</span>;
+  }
+  return undefined;
+}
+
+function JsonPrettyArrayView({
+  value,
+  depth,
+  showOmittedNotice,
+  omitted,
+}: {
+  value: unknown[];
+  depth: number;
+  showOmittedNotice: boolean;
+  omitted: number;
+}) {
+  if (value.length === 0) return <span className="text-muted-foreground">[]</span>;
+  return (
+    <span>
+      {'[\u200B'}
+      <span style={{ paddingLeft: 16 * (depth + 1) }}>
+        {value.map((item, i) => (
+          <div
+            key={i}
+            style={{
+              paddingLeft: 16,
+              background: stripeBackground(i),
+            }}
+          >
+            <JsonPrettyPrinter value={item} depth={depth + 1} showOmittedNotice={false} />
+            {i < value.length - 1 && <span className="text-muted-foreground">,</span>}
+          </div>
+        ))}
+      </span>
+      {']'}
+      <RootOmittedNotice
+        showOmittedNotice={showOmittedNotice}
+        depth={depth}
+        omitted={omitted}
+      />
+    </span>
+  );
+}
+
+function JsonPrettyObjectView({
+  value,
+  depth,
+  showOmittedNotice,
+  omitted,
+}: {
+  value: Record<string, unknown>;
+  depth: number;
+  showOmittedNotice: boolean;
+  omitted: number;
+}) {
+  const entries = Object.entries(value);
+  if (entries.length === 0) return <span className="text-muted-foreground">{'{}'}</span>;
+  return (
+    <div>
+      {entries.map(([k, v], i) => (
+        <div
+          key={k}
+          style={{
+            display: 'flex',
+            gap: 6,
+            padding: '2px 6px',
+            borderRadius: 3,
+            background: stripeBackground(i),
+          }}
+        >
+          <span style={{ color: 'var(--primary)', fontWeight: 500, flexShrink: 0 }}>{k}:</span>
+          <span style={{ wordBreak: 'break-word', minWidth: 0 }}>
+            <JsonPrettyPrinter value={v} depth={depth + 1} showOmittedNotice={false} />
+          </span>
+        </div>
+      ))}
+      <RootOmittedNotice
+        showOmittedNotice={showOmittedNotice}
+        depth={depth}
+        omitted={omitted}
+      />
+    </div>
+  );
+}
+
 /**
  * JSON pretty-printer with hard node/depth limits to avoid freezing the chat UI.
  */
@@ -60,77 +193,44 @@ export function JsonPrettyPrinter({
 
   if (depth >= JSON_PRETTY_MAX_DEPTH) {
     budget.omitted += 1;
-    return <span className="text-muted-foreground">…</span>;
+    return <JsonPrettyEllipsis />;
   }
 
   if (budget.nodes >= JSON_PRETTY_MAX_NODES) {
     budget.omitted += 1;
-    return showOmittedNotice && depth === 0 ? (
-      <OmittedNodesNotice count={budget.omitted} />
-    ) : (
-      <span className="text-muted-foreground">…</span>
+    return (
+      <JsonPrettyBudgetExceeded
+        showOmittedNotice={showOmittedNotice}
+        depth={depth}
+        omitted={budget.omitted}
+      />
     );
   }
 
   budget.nodes += 1;
 
-  if (value === null) return <span className="text-muted-foreground">null</span>;
-  if (typeof value === 'boolean') return <span className="text-[var(--warning)]">{String(value)}</span>;
-  if (typeof value === 'number') return <span className="text-[var(--success)]">{value}</span>;
-  if (typeof value === 'string') {
-    const display = value.length > 240 ? `${value.slice(0, 237)}…` : value;
-    return <span className="text-muted-foreground">"{display}"</span>;
-  }
+  const scalar = renderJsonPrettyScalar(value);
+  if (scalar !== undefined) return scalar;
 
   if (Array.isArray(value)) {
-    if (value.length === 0) return <span className="text-muted-foreground">[]</span>;
     return (
-      <span>
-        {'[\u200B'}
-        <span style={{ paddingLeft: 16 * (depth + 1) }}>
-          {value.map((item, i) => (
-            <div
-              key={i}
-              style={{
-                paddingLeft: 16,
-                background: i % 2 === 0 ? 'transparent' : 'color-mix(in srgb, var(--accent) 50%, transparent)',
-              }}
-            >
-              <JsonPrettyPrinter value={item} depth={depth + 1} showOmittedNotice={false} />
-              {i < value.length - 1 && <span className="text-muted-foreground">,</span>}
-            </div>
-          ))}
-        </span>
-        {']'}
-        {showOmittedNotice && depth === 0 ? <OmittedNodesNotice count={budget.omitted} /> : null}
-      </span>
+      <JsonPrettyArrayView
+        value={value}
+        depth={depth}
+        showOmittedNotice={showOmittedNotice}
+        omitted={budget.omitted}
+      />
     );
   }
 
   if (typeof value === 'object') {
-    const entries = Object.entries(value as Record<string, unknown>);
-    if (entries.length === 0) return <span className="text-muted-foreground">{'{}'}</span>;
     return (
-      <div>
-        {entries.map(([k, v], i) => (
-          <div
-            key={k}
-            style={{
-              display: 'flex',
-              gap: 6,
-              padding: '2px 6px',
-              borderRadius: 3,
-              background: i % 2 === 0 ? 'transparent' : 'color-mix(in srgb, var(--accent) 50%, transparent)',
-            }}
-          >
-            <span style={{ color: 'var(--primary)', fontWeight: 500, flexShrink: 0 }}>{k}:</span>
-            <span style={{ wordBreak: 'break-word', minWidth: 0 }}>
-              <JsonPrettyPrinter value={v} depth={depth + 1} showOmittedNotice={false} />
-            </span>
-          </div>
-        ))}
-        {showOmittedNotice && depth === 0 ? <OmittedNodesNotice count={budget.omitted} /> : null}
-      </div>
+      <JsonPrettyObjectView
+        value={value as Record<string, unknown>}
+        depth={depth}
+        showOmittedNotice={showOmittedNotice}
+        omitted={budget.omitted}
+      />
     );
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `JsonPrettyPrinter` (`app/lib/chat/jsonPrettyPrinter.tsx` ~L50) to clear Sonar typescript:S3776 (cognitive complexity 23 → ≤15) by extracting helpers — no pretty-print behavior change.
- Helpers: `renderJsonPrettyScalar`, `JsonPrettyArrayView`, `JsonPrettyObjectView`, `JsonPrettyBudgetExceeded`, `RootOmittedNotice`, `JsonPrettyEllipsis`, `stripeBackground`.
- Adds `jsonPrettyPrinter.test.tsx` covering scalars, truncation, nesting, depth/node budgets, and fallback.

## Sonar

| Key | Rule | File | GitHub |
| --- | --- | --- | --- |
| `f85a26ad-f3a3-4fff-a97b-98f611fe221d` | typescript:S3776 | `app/lib/chat/jsonPrettyPrinter.tsx:50` | Closes #920 |

## Why this is safe
- Pure maintainability extract: same markup, styles, truncation limits (`JSON_PRETTY_MAX_NODES` / `JSON_PRETTY_MAX_DEPTH`), budget mutation, and root omitted notice.
- No UI redesign, no Sonar suppressions, no rewrite of pretty-printing logic.

## Local validation
- `pnpm run typecheck` — pass
- `pnpm run lint` — pass (0 errors; pre-existing warnings elsewhere)
- `pnpm run test:coverage` — pass (electron + renderer 146 + agent-core 54 + ai 28)

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs / config

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test:coverage` passes
- [x] i18n keys — N/A (no new strings)
- [x] No hardcoded colors

## Auto-merge
Squash auto-merge enabled; merges after required checks pass.

Closes #920

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b4ca3cb-86b3-4ce1-b59a-aad278479289?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b4ca3cb-86b3-4ce1-b59a-aad278479289&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

