### PR TITLE
fix(sonar): lower DomeSyncSection cognitive complexity (S3776, #919)

### DIFF
--- a/app/components/settings/sections/DomeSyncSection.tsx
+++ b/app/components/settings/sections/DomeSyncSection.tsx
@@ -34,6 +34,286 @@ const DOMAIN_ROWS: Array<{
 
 type SyncProgress = { phase: string; domain?: string; index?: number; total?: number } | null;
 
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+/** Hide section when cloud UI is off and there is no Dome session — extracted for S3776. */
+function shouldHideDomeSyncSection(
+  entitlementsLoading: boolean,
+  showCloudUi: boolean,
+  sessionConnected: boolean,
+): boolean {
+  if (entitlementsLoading) return false;
+  if (showCloudUi) return false;
+  return !sessionConnected;
+}
+
+/** Latest push timestamp across domains — extracted for S3776. */
+function maxLastPushAt(domainState: Record<string, DomainState>): number {
+  return Math.max(0, ...Object.values(domainState).map((d) => d?.lastPushAt ?? 0));
+}
+
+/** Feature-gated domain rows — extracted for S3776. */
+function visibleDomainRows(features: readonly string[]) {
+  return DOMAIN_ROWS.filter((row) => features.includes(row.feature));
+}
+
+/** OAuth connect flow — extracted for S3776. */
+async function connectDomeOAuth(
+  t: Translate,
+  onConnected: () => void,
+): Promise<void> {
+  if (!window.electron?.domeAuth) return;
+  try {
+    const result = await window.electron.domeAuth.startOAuthFlow();
+    if (result.success) {
+      showToast('success', t('settings.domain_sync.connected_to_dome'));
+      onConnected();
+      return;
+    }
+    showToast('error', result.error ?? t('settings.domain_sync.connect_error'));
+  } catch (err) {
+    showToast('error', err instanceof Error ? err.message : t('common.unknown_error'));
+  }
+}
+
+/** Manual sync-now — extracted for S3776. */
+async function runDomainSyncNow(
+  t: Translate,
+  onSuccess: () => Promise<void>,
+): Promise<void> {
+  if (!window.electron?.domainSync?.syncNow) return;
+  const res = await window.electron.domainSync.syncNow({});
+  if (!res?.success && !res?.skipped) {
+    showToast('error', res?.error || t('settings.domain_sync.sync_error'));
+    return;
+  }
+  showToast('success', t('settings.domain_sync.sync_ok'));
+  await onSuccess();
+}
+
+/** Toggle a single domain — extracted for S3776. */
+async function setDomainEnabledFlag(
+  domain: string,
+  enabled: boolean,
+  onSuccess: () => Promise<void>,
+): Promise<void> {
+  if (!window.electron?.domainSync?.setDomainEnabled) return;
+  const res = await window.electron.domainSync.setDomainEnabled({ domain, enabled });
+  if (res?.success) await onSuccess();
+}
+
+/** Disconnect Dome account — extracted for S3776. */
+async function disconnectDomeAccount(
+  t: Translate,
+  onDisconnected: () => void,
+): Promise<void> {
+  const result = await window.electron?.domeAuth?.disconnect?.();
+  if (result?.success) {
+    showToast('success', t('settings.domain_sync.disconnected_from_dome'));
+    onDisconnected();
+  }
+}
+
+function DomeSyncLoadingSkeleton() {
+  return (
+    <div className="flex flex-col gap-3">
+      <Skeleton className="h-16 w-full" />
+      <Skeleton className="h-48 w-full" />
+    </div>
+  );
+}
+
+/** Not-connected empty state — extracted for S3776. */
+function DomeSyncDisconnectedView({
+  connectingOAuth,
+  onConnect,
+}: {
+  connectingOAuth: boolean;
+  onConnect: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <Empty className="rounded-xl border bg-card py-10">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <HugeiconsIcon icon={CloudCogIcon} />
+        </EmptyMedia>
+        <EmptyTitle>{t('settings.domain_sync.not_connected')}</EmptyTitle>
+        <EmptyDescription>
+          Inicia sesión con tu cuenta Dome para activar la sincronización.{' '}
+          {t('settings.domain_sync.oauth_pkce')}
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button type="button" onClick={onConnect} disabled={connectingOAuth}>
+          {connectingOAuth ? <Spinner data-icon="inline-start" /> : null}
+          {connectingOAuth ? 'Conectando…' : 'Iniciar sesión en Dome'}
+        </Button>
+      </EmptyContent>
+    </Empty>
+  );
+}
+
+/** First-sync progress banner — extracted for S3776. */
+function DomeSyncProgressBanner({ progress }: { progress: NonNullable<SyncProgress> }) {
+  const { t } = useTranslation();
+  const label =
+    progress.phase === 'files'
+      ? t('settings.domain_sync.first_sync_files')
+      : t('settings.domain_sync.first_sync', { domain: progress.domain ?? '…' });
+  return (
+    <div className="flex items-center gap-3 rounded-xl border bg-card px-4 py-3">
+      <Spinner className="shrink-0 text-primary" />
+      <p className="text-sm">{label}</p>
+    </div>
+  );
+}
+
+/** Connected sync settings — extracted for S3776. */
+function DomeSyncConnectedView({
+  progress,
+  lastSyncAt,
+  visibleRows,
+  domainState,
+  domainSyncing,
+  onSyncNow,
+  onToggleDomain,
+  onDisconnect,
+}: {
+  progress: SyncProgress;
+  lastSyncAt: number;
+  visibleRows: typeof DOMAIN_ROWS;
+  domainState: Record<string, DomainState>;
+  domainSyncing: boolean;
+  onSyncNow: () => void;
+  onToggleDomain: (domain: string, enabled: boolean) => void;
+  onDisconnect: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <>
+      {progress ? <DomeSyncProgressBanner progress={progress} /> : null}
+
+      <SettingsGroup title={t('settings.domain_sync.connection')}>
+        <SettingsRow
+          title={t('settings.domain_sync.connection')}
+          control={
+            <Badge variant="secondary" className="text-primary">
+              <span className="size-1.5 shrink-0 rounded-full bg-primary" aria-hidden />
+              {t('settings.domain_sync.active')}
+            </Badge>
+          }
+        />
+        <SettingsRow
+          title={t('settings.domain_sync.last_sync')}
+          control={
+            <span className="font-mono text-xs">
+              {lastSyncAt > 0 ? new Date(lastSyncAt).toLocaleString() : '—'}
+            </span>
+          }
+        />
+      </SettingsGroup>
+
+      <SettingsGroup
+        title={t('settings.domain_sync.title')}
+        description={t('settings.domain_sync.description')}
+        actions={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={domainSyncing}
+            onClick={onSyncNow}
+          >
+            {domainSyncing ? (
+              <Spinner data-icon="inline-start" />
+            ) : (
+              <HugeiconsIcon icon={RefreshIcon} data-icon="inline-start" />
+            )}
+            {t('settings.domain_sync.sync_now')}
+          </Button>
+        }
+      >
+        {visibleRows.map(({ domain, labelKey }) => (
+          <SettingsRow
+            key={domain}
+            title={t(labelKey)}
+            control={
+              <Switch
+                checked={domainState[domain]?.enabled !== false}
+                onCheckedChange={(checked) => onToggleDomain(domain, checked)}
+                aria-label={t(labelKey)}
+              />
+            }
+          />
+        ))}
+      </SettingsGroup>
+
+      <div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:text-destructive"
+          onClick={onDisconnect}
+        >
+          Desconectar cuenta
+        </Button>
+      </div>
+    </>
+  );
+}
+
+/** Body switch for loading / disconnected / connected — extracted for S3776. */
+function DomeSyncSectionBody({
+  loading,
+  sessionLoading,
+  sessionConnected,
+  connectingOAuth,
+  progress,
+  lastSyncAt,
+  visibleRows,
+  domainState,
+  domainSyncing,
+  onConnect,
+  onSyncNow,
+  onToggleDomain,
+  onDisconnect,
+}: {
+  loading: boolean;
+  sessionLoading: boolean;
+  sessionConnected: boolean;
+  connectingOAuth: boolean;
+  progress: SyncProgress;
+  lastSyncAt: number;
+  visibleRows: typeof DOMAIN_ROWS;
+  domainState: Record<string, DomainState>;
+  domainSyncing: boolean;
+  onConnect: () => void;
+  onSyncNow: () => void;
+  onToggleDomain: (domain: string, enabled: boolean) => void;
+  onDisconnect: () => void;
+}) {
+  if (loading || sessionLoading) return <DomeSyncLoadingSkeleton />;
+  if (!sessionConnected) {
+    return (
+      <DomeSyncDisconnectedView connectingOAuth={connectingOAuth} onConnect={onConnect} />
+    );
+  }
+  return (
+    <DomeSyncConnectedView
+      progress={progress}
+      lastSyncAt={lastSyncAt}
+      visibleRows={visibleRows}
+      domainState={domainState}
+      domainSyncing={domainSyncing}
+      onSyncNow={onSyncNow}
+      onToggleDomain={onToggleDomain}
+      onDisconnect={onDisconnect}
+    />
+  );
+}
+
 export default function DomeSyncSection() {
   const { t } = useTranslation();
   const cloudEntitlements = useCloudEntitlements();
@@ -52,64 +332,54 @@ export default function DomeSyncSection() {
     }
   }, []);
 
-  useEffect(() => { loadDomainStatus().finally(() => setLoading(false));
+  useEffect(() => {
+    loadDomainStatus().finally(() => setLoading(false));
   }, [loadDomainStatus]);
 
   useEffect(() => {
     const unsub = window.electron?.domainSync?.onProgress?.((data: SyncProgress) => {
       setProgress(data?.phase === 'done' ? null : data);
-      if (data?.phase === 'done') void loadDomainStatus();
+      if (data?.phase === 'done') {
+        loadDomainStatus().catch(() => {});
+      }
     });
     return () => unsub?.();
   }, [loadDomainStatus]);
 
-  const handleConnect = async () => {
-    if (!window.electron?.domeAuth) return;
-    setConnectingOAuth(true);
-    try {
-      const result = await window.electron.domeAuth.startOAuthFlow();
-      if (result.success) {
-        showToast('success', t('settings.domain_sync.connected_to_dome')); session.refresh(); loadDomainStatus();
-      } else {
-        showToast('error', result.error ?? t('settings.domain_sync.connect_error'));
-      }
-    } catch (err) {
-      showToast('error', err instanceof Error ? err.message : t('common.unknown_error'));
-    } finally {
-      setConnectingOAuth(false);
-    }
-  };
-
-  if (!cloudEntitlements.loading && !cloudEntitlements.showCloudUi && !session.connected) {
+  if (
+    shouldHideDomeSyncSection(
+      cloudEntitlements.loading,
+      cloudEntitlements.showCloudUi,
+      session.connected,
+    )
+  ) {
     return null;
   }
 
-  const featureAvailable = (feature: string) => cloudEntitlements.features.includes(feature);
-
-  const toggleDomain = async (domain: string, enabled: boolean) => {
-    if (!window.electron?.domainSync?.setDomainEnabled) return;
-    const res = await window.electron.domainSync.setDomainEnabled({ domain, enabled });
-    if (res?.success) await loadDomainStatus();
+  const handleConnect = () => {
+    setConnectingOAuth(true);
+    connectDomeOAuth(t, () => {
+      session.refresh();
+      loadDomainStatus().catch(() => {});
+    })
+      .catch(() => {})
+      .finally(() => setConnectingOAuth(false));
   };
 
-  const syncDomainsNow = async () => {
-    if (!window.electron?.domainSync?.syncNow) return;
+  const handleSyncNow = () => {
     setDomainSyncing(true);
-    try {
-      const res = await window.electron.domainSync.syncNow({});
-      if (!res?.success && !res?.skipped) {
-        showToast('error', res?.error || t('settings.domain_sync.sync_error'));
-      } else {
-        showToast('success', t('settings.domain_sync.sync_ok'));
-        await loadDomainStatus();
-      }
-    } finally {
-      setDomainSyncing(false);
-    }
+    runDomainSyncNow(t, loadDomainStatus)
+      .catch(() => {})
+      .finally(() => setDomainSyncing(false));
   };
 
-  const lastSyncAt = Math.max(0, ...Object.values(domainState).map((d) => d?.lastPushAt ?? 0));
-  const visibleRows = DOMAIN_ROWS.filter((row) => featureAvailable(row.feature));
+  const handleToggleDomain = (domain: string, enabled: boolean) => {
+    setDomainEnabledFlag(domain, enabled, loadDomainStatus).catch(() => {});
+  };
+
+  const handleDisconnect = () => {
+    disconnectDomeAccount(t, () => session.refresh()).catch(() => {});
+  };
 
   return (
     <SettingsSurface
@@ -117,116 +387,21 @@ export default function DomeSyncSection() {
       title="Dome Sync"
       description={t('settings.domain_sync.subtitle')}
     >
-      {loading || session.loading ? (
-        <div className="flex flex-col gap-3">
-          <Skeleton className="h-16 w-full" />
-          <Skeleton className="h-48 w-full" />
-        </div>
-      ) : !session.connected ? (
-        <Empty className="rounded-xl border bg-card py-10">
-          <EmptyHeader>
-            <EmptyMedia variant="icon">
-              <HugeiconsIcon icon={CloudCogIcon} />
-            </EmptyMedia>
-            <EmptyTitle>{t('settings.domain_sync.not_connected')}</EmptyTitle>
-            <EmptyDescription>
-              Inicia sesión con tu cuenta Dome para activar la sincronización.{' '}
-              {t('settings.domain_sync.oauth_pkce')}
-            </EmptyDescription>
-          </EmptyHeader>
-          <EmptyContent>
-            <Button type="button" onClick={() => handleConnect()} disabled={connectingOAuth}>
-              {connectingOAuth ? <Spinner data-icon="inline-start" /> : null}
-              {connectingOAuth ? 'Conectando…' : 'Iniciar sesión en Dome'}
-            </Button>
-          </EmptyContent>
-        </Empty>
-      ) : (
-        <>
-          {progress ? (
-            <div className="flex items-center gap-3 rounded-xl border bg-card px-4 py-3">
-              <Spinner className="shrink-0 text-primary" />
-              <p className="text-sm">
-                {progress.phase === 'files'
-                  ? t('settings.domain_sync.first_sync_files')
-                  : t('settings.domain_sync.first_sync', { domain: progress.domain ?? '…' })}
-              </p>
-            </div>
-          ) : null}
-
-          <SettingsGroup title={t('settings.domain_sync.connection')}>
-            <SettingsRow
-              title={t('settings.domain_sync.connection')}
-              control={
-                <Badge variant="secondary" className="text-primary">
-                  <span className="size-1.5 shrink-0 rounded-full bg-primary" aria-hidden />
-                  {t('settings.domain_sync.active')}
-                </Badge>
-              }
-            />
-            <SettingsRow
-              title={t('settings.domain_sync.last_sync')}
-              control={
-                <span className="font-mono text-xs">
-                  {lastSyncAt > 0 ? new Date(lastSyncAt).toLocaleString() : '—'}
-                </span>
-              }
-            />
-          </SettingsGroup>
-
-          <SettingsGroup
-            title={t('settings.domain_sync.title')}
-            description={t('settings.domain_sync.description')}
-            actions={
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={domainSyncing}
-                onClick={() => syncDomainsNow()}
-              >
-                {domainSyncing ? (
-                  <Spinner data-icon="inline-start" />
-                ) : (
-                  <HugeiconsIcon icon={RefreshIcon} data-icon="inline-start" />
-                )}
-                {t('settings.domain_sync.sync_now')}
-              </Button>
-            }
-          >
-            {visibleRows.map(({ domain, labelKey }) => (
-              <SettingsRow
-                key={domain}
-                title={t(labelKey)}
-                control={
-                  <Switch
-                    checked={domainState[domain]?.enabled !== false}
-                    onCheckedChange={(checked) => toggleDomain(domain, checked)}
-                    aria-label={t(labelKey)}
-                  />
-                }
-              />
-            ))}
-          </SettingsGroup>
-
-          <div>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="text-muted-foreground hover:text-destructive"
-              onClick={async () => {
-                const result = await window.electron?.domeAuth?.disconnect?.();
-                if (result?.success) {
-                  showToast('success', t('settings.domain_sync.disconnected_from_dome')); session.refresh();
-                }
-              }}
-            >
-              Desconectar cuenta
-            </Button>
-          </div>
-        </>
-      )}
+      <DomeSyncSectionBody
+        loading={loading}
+        sessionLoading={session.loading}
+        sessionConnected={session.connected}
+        connectingOAuth={connectingOAuth}
+        progress={progress}
+        lastSyncAt={maxLastPushAt(domainState)}
+        visibleRows={visibleDomainRows(cloudEntitlements.features)}
+        domainState={domainState}
+        domainSyncing={domainSyncing}
+        onConnect={handleConnect}
+        onSyncNow={handleSyncNow}
+        onToggleDomain={handleToggleDomain}
+        onDisconnect={handleDisconnect}
+      />
     </SettingsSurface>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `DomeSyncSection` to drop Sonar typescript:S3776 cognitive complexity (24 → ≤15) without changing Dome Sync settings behavior.
- Extracts pure helpers (`shouldHideDomeSyncSection`, `maxLastPushAt`, `visibleDomainRows`), async handlers (`connectDomeOAuth`, `runDomainSyncNow`, `setDomainEnabledFlag`, `disconnectDomeAccount`), and view helpers (`DomeSyncDisconnectedView`, `DomeSyncProgressBanner`, `DomeSyncConnectedView`, `DomeSyncSectionBody`).
- Adjusts async progress/handlers to the repo `.catch()` form (no `void` operator) on the touched file.

## Sonar
| Key | Rule | File | Issue |
| --- | --- | --- | --- |
| `fa7e524b-7a7a-481e-bb7a-5738fd1df133` | typescript:S3776 | `app/components/settings/sections/DomeSyncSection.tsx:37` | Closes #919 |

## Why this is safe
- Same IPC calls, toasts, feature gates, domain list, and UI copy/structure.
- No settings redesign; only structural extraction for maintainability.
- Behavior of hide-when-no-cloud-ui, OAuth connect/disconnect, per-domain toggles, sync-now, and first-sync progress banner is preserved.

## Type
- [x] Refactor

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] `pnpm run check:sonar-patterns -- --diff=origin/main` passes
- [x] No new user-visible strings / i18n
- [x] No hardcoded colors

Closes #919

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-449342b2-480d-4fcd-9424-93d16b4b4e29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-449342b2-480d-4fcd-9424-93d16b4b4e29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

