### PR TITLE
fix(sonar): lower CoverPreviewContent cognitive complexity (S3776, #918)

### DIFF
--- a/app/components/shell/folder-tab/FolderCard.tsx
+++ b/app/components/shell/folder-tab/FolderCard.tsx
@@ -476,6 +476,33 @@ function deriveCardPresentation(
   };
 }
 
+/** PDF first-page / loading — extracted for S3776. `undefined` = continue cover chain. */
+function pdfCoverPreview(
+  p: CardPresentation,
+  visual: ResourceVisualPreview,
+): ReactNode | undefined {
+  // PDF first-page render (lazy IPC) — prefer over generic icon.
+  if (p.pdfDataUrl) return <PdfPageThumb dataUrl={p.pdfDataUrl} />;
+  if (p.isPdfCard && visual.loading) return <PreviewLoading />;
+  return undefined;
+}
+
+/** Note markdown / text / loading — extracted for S3776. `undefined` = continue cover chain. */
+function noteCoverPreview(
+  p: CardPresentation,
+  visual: ResourceVisualPreview,
+  searchQuery?: string,
+): ReactNode | undefined {
+  if (!p.isNoteCard) return undefined;
+  if (p.noteMarkdown) {
+    return searchQuery
+      ? <NoteTextThumb text={p.noteMarkdown} searchQuery={searchQuery} />
+      : <NoteMarkdownThumb markdown={p.noteMarkdown} title={p.displayTitle} />;
+  }
+  if (visual.loading) return <PreviewLoading />;
+  return undefined;
+}
+
 function CoverPreviewContent({
   item,
   isFolderCard,
@@ -502,13 +529,8 @@ function CoverPreviewContent({
   if (p.artifactTemplate) {
     return <ArtifactThumb template={p.artifactTemplate} data={visual.artifact?.data ?? null} />;
   }
-  // PDF first-page render (lazy IPC) — prefer over generic icon.
-  if (p.pdfDataUrl) {
-    return <PdfPageThumb dataUrl={p.pdfDataUrl} />;
-  }
-  if (p.isPdfCard && visual.loading) {
-    return <PreviewLoading />;
-  }
+  const pdfPreview = pdfCoverPreview(p, visual);
+  if (pdfPreview !== undefined) return pdfPreview;
   if (p.coverImage) {
     return (
       <img
@@ -523,14 +545,8 @@ function CoverPreviewContent({
   if (p.isSheetCard && p.snippet) {
     return <SpreadsheetThumb snippet={p.snippet} />;
   }
-  if (p.isNoteCard) {
-    if (p.noteMarkdown) {
-      return searchQuery
-        ? <NoteTextThumb text={p.noteMarkdown} searchQuery={searchQuery} />
-        : <NoteMarkdownThumb markdown={p.noteMarkdown} title={p.displayTitle} />;
-    }
-    if (visual.loading) return <PreviewLoading />;
-  }
+  const notePreview = noteCoverPreview(p, visual, searchQuery);
+  if (notePreview !== undefined) return notePreview;
   if (p.snippet && !p.isSheetCard) {
     return <NoteTextThumb text={p.snippet} searchQuery={searchQuery} />;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `CoverPreviewContent` in `FolderCard.tsx` to drop Sonar typescript:S3776 cognitive complexity (19 → ≤15) without changing folder-card cover behavior.
- Extracts `pdfCoverPreview` and `noteCoverPreview` (same selection order: folder → artifact → PDF → image → sheet → note → snippet → loading → type icon).
- Does not touch `FolderCardImpl` (#925/#1295) or `deriveCardPresentation`; only the L479 cover-preview hotspot from #918.

## Sonar
| Key | Rule | File | Issue |
| --- | --- | --- | --- |
| `fada1e09-4093-46aa-aed3-ffdf25870566` | typescript:S3776 | `app/components/shell/folder-tab/FolderCard.tsx:479` | Closes #918 |

## Why this is safe
- Pure structural extraction: cover branch order and JSX outputs are unchanged.
- No folder-tab UI redesign; no new props, IPC, or i18n.
- Fall-through for note cards without markdown still continues the cover chain via `undefined`.

## Type
- [x] Refactor

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] `pnpm run check:sonar-patterns -- --diff=origin/main` passes
- [x] No new user-visible strings / i18n
- [x] No hardcoded colors

Closes #918

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac648015-231a-4698-b69d-4a6dcc200fa0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac648015-231a-4698-b69d-4a6dcc200fa0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

