### PR TITLE
fix(sonar): lower ListState cognitive complexity (S3776, #917)

### DIFF
--- a/app/components/shared/ListState.test.tsx
+++ b/app/components/shared/ListState.test.tsx
@@ -11,4 +11,25 @@ describe('ListState', () => {
     expect(screen.getByText('No se pudo cargar')).toBeVisible();
     expect(retry).toHaveBeenCalledTimes(1);
   });
+
+  it('renders loading label inside a polite live region', () => {
+    render(<ListState variant="loading" loadingLabel="Cargando lista" />);
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByText('Cargando lista')).toBeVisible();
+  });
+
+  it('renders empty title, description, and action', () => {
+    render(
+      <ListState
+        variant="empty"
+        title="Sin elementos"
+        description="Aún no hay nada aquí"
+        action={<button type="button">Crear</button>}
+      />,
+    );
+    expect(screen.getByText('Sin elementos')).toBeVisible();
+    expect(screen.getByText('Aún no hay nada aquí')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Crear' })).toBeVisible();
+  });
 });

--- a/app/components/shared/ListState.tsx
+++ b/app/components/shared/ListState.tsx
@@ -22,6 +22,104 @@ export interface ListStateProps {
   fullHeight?: boolean;
 }
 
+function listStatePadding(compact?: boolean): string {
+  return compact ? 'py-10' : 'py-14';
+}
+
+function ListStateLoading({
+  loadingLabel,
+  fullHeight,
+  py,
+}: {
+  loadingLabel: string;
+  fullHeight?: boolean;
+  py: string;
+}) {
+  return (
+    <output
+      className={cn(
+        'flex flex-col items-center justify-center gap-2 px-4',
+        fullHeight ? 'h-full p-8 gap-4' : py,
+      )}
+      aria-live="polite"
+    >
+      <Spinner
+        className={cn(
+          'animate-spin motion-reduce:animate-none',
+          fullHeight ? 'size-8 text-primary' : 'size-5 text-muted-foreground',
+        )}
+        aria-hidden
+      />
+      <p className={cn('text-center', fullHeight ? 'text-sm text-muted-foreground' : 'text-xs text-muted-foreground')}>
+        {loadingLabel}
+      </p>
+    </output>
+  );
+}
+
+function ListStateError({
+  errorMessage,
+  onRetry,
+  retryLabel,
+  action,
+  fullHeight,
+  py,
+}: {
+  errorMessage: string;
+  onRetry?: () => void;
+  retryLabel: string;
+  action?: ReactNode;
+  fullHeight?: boolean;
+  py: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-3 px-6 text-center',
+        fullHeight ? 'h-full p-8 gap-4' : py,
+      )}
+    >
+      <HugeiconsIcon icon={Alert02Icon} className="size-12 shrink-0 text-destructive" aria-hidden />
+      <p className={cn('font-medium text-destructive', fullHeight ? 'text-sm max-w-md' : 'text-sm')}>
+        {errorMessage}
+      </p>
+      {onRetry ? (
+        <Button type="button" onClick={onRetry} size="sm">
+          {retryLabel}
+        </Button>
+      ) : null}
+      {action}
+    </div>
+  );
+}
+
+function ListStateEmpty({
+  icon,
+  title,
+  description,
+  action,
+  fullHeight,
+  py,
+}: {
+  icon?: ReactNode;
+  title?: string;
+  description?: string;
+  action?: ReactNode;
+  fullHeight?: boolean;
+  py: string;
+}) {
+  return (
+    <Empty className={cn('border-0 px-6', fullHeight ? 'h-full p-8' : py)}>
+      {icon ? <EmptyMedia variant="icon">{icon}</EmptyMedia> : null}
+      <EmptyHeader>
+        {title ? <EmptyTitle>{title}</EmptyTitle> : null}
+        {description ? <EmptyDescription>{description}</EmptyDescription> : null}
+      </EmptyHeader>
+      {action ? <EmptyContent>{action}</EmptyContent> : null}
+    </Empty>
+  );
+}
+
 /**
  * Estados unificados: carga, vacío y error (hub y vistas generales).
  */
@@ -39,66 +137,40 @@ export default function ListState({
   fullHeight,
 }: ListStateProps) {
   const { t } = useTranslation();
-  const py = compact ? 'py-10' : 'py-14';
+  const py = listStatePadding(compact);
   const retry = retryLabel ?? t('ui.try_again');
 
   if (variant === 'loading') {
-    const label = loadingLabel ?? t('ui.loading');
     return (
-      <output
-        className={cn(
-          'flex flex-col items-center justify-center gap-2 px-4',
-          fullHeight ? 'h-full p-8 gap-4' : py,
-        )}
-        aria-live="polite"
-      >
-        <Spinner
-          className={cn(
-            'animate-spin motion-reduce:animate-none',
-            fullHeight ? 'size-8 text-primary' : 'size-5 text-muted-foreground',
-          )}
-          aria-hidden
-        />
-        <p className={cn('text-center', fullHeight ? 'text-sm text-muted-foreground' : 'text-xs text-muted-foreground')}>
-          {label}
-        </p>
-      </output>
+      <ListStateLoading
+        loadingLabel={loadingLabel ?? t('ui.loading')}
+        fullHeight={fullHeight}
+        py={py}
+      />
     );
   }
 
   if (variant === 'error') {
-    const msg = errorMessage ?? 'Error';
     return (
-      <div
-        className={cn(
-          'flex flex-col items-center justify-center gap-3 px-6 text-center',
-          fullHeight ? 'h-full p-8 gap-4' : py,
-        )}
-      >
-        <HugeiconsIcon icon={Alert02Icon} className="size-12 shrink-0 text-destructive" aria-hidden />
-        <p className={cn('font-medium text-destructive', fullHeight ? 'text-sm max-w-md' : 'text-sm')}>
-          {msg}
-        </p>
-        {onRetry ? (
-          <Button type="button"
-  onClick={onRetry}
-  size="sm">
-            {retry}
-          </Button>
-        ) : null}
-        {action}
-      </div>
+      <ListStateError
+        errorMessage={errorMessage ?? 'Error'}
+        onRetry={onRetry}
+        retryLabel={retry}
+        action={action}
+        fullHeight={fullHeight}
+        py={py}
+      />
     );
   }
 
   return (
-    <Empty className={cn('border-0 px-6', fullHeight ? 'h-full p-8' : py)}>
-      {icon ? <EmptyMedia variant="icon">{icon}</EmptyMedia> : null}
-      <EmptyHeader>
-        {title ? <EmptyTitle>{title}</EmptyTitle> : null}
-        {description ? <EmptyDescription>{description}</EmptyDescription> : null}
-      </EmptyHeader>
-      {action ? <EmptyContent>{action}</EmptyContent> : null}
-    </Empty>
+    <ListStateEmpty
+      icon={icon}
+      title={title}
+      description={description}
+      action={action}
+      fullHeight={fullHeight}
+      py={py}
+    />
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Extract `ListStateLoading`, `ListStateError`, and `ListStateEmpty` helpers from `ListState` so the exported component stays under Sonar’s cognitive complexity limit (typescript:S3776, was 20 / allowed 15).
- Preserve exact loading / empty / error rendering (classes, labels, retry button, empty media/header/content).
- Extend `ListState.test.tsx` with loading and empty coverage alongside the existing retry test.

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| `fc159495-9e0d-4bfa-b5c3-10f8c2a8f0cd` | typescript:S3776 | `app/components/shared/ListState.tsx:28` |

Closes #917

## Type
- [x] Refactor

## Checklist
- [x] `pnpm run typecheck` passes (run in PR validation)
- [x] `pnpm run lint` passes (run in PR validation)
- [ ] `pnpm run build` passes (unchanged UI surface; coverage/typecheck/lint are the acceptance gates)
- [x] No new i18n keys
- [x] No hardcoded colors

## Why this is safe
Pure structural extraction: same props, same JSX trees per variant, no behavior or copy changes. Existing error-retry test kept; loading/empty smoke tests added.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f57f6dff-cebb-4bf4-8ecf-aa33863f64f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f57f6dff-cebb-4bf4-8ecf-aa33863f64f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

