### PR TITLE
fix(sonar): lower processWebSocketStream cognitive complexity (S3776)

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses-ws.test.ts
+++ b/packages/ai/src/providers/openai-codex-responses-ws.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+	recordWebSocketStreamRequestStats,
+	type OpenAICodexWebSocketDebugStats,
+} from "./openai-codex-responses.js";
+
+function emptyStats(): OpenAICodexWebSocketDebugStats {
+	return {
+		requests: 0,
+		connectionsCreated: 0,
+		connectionsReused: 0,
+		cachedContextRequests: 0,
+		storeTrueRequests: 0,
+		fullContextRequests: 0,
+		deltaRequests: 0,
+		lastInputItems: 0,
+		websocketFailures: 0,
+		sseFallbacks: 0,
+	};
+}
+
+describe("recordWebSocketStreamRequestStats", () => {
+	it("no-ops when stats are undefined", () => {
+		expect(() =>
+			recordWebSocketStreamRequestStats(undefined, false, true, { input: [{}, {}] }),
+		).not.toThrow();
+	});
+
+	it("records a full-context request on a new connection", () => {
+		const stats = emptyStats();
+		recordWebSocketStreamRequestStats(stats, false, true, {
+			store: false,
+			input: [{ type: "message" }, { type: "message" }, { type: "message" }],
+		});
+
+		expect(stats.requests).toBe(1);
+		expect(stats.connectionsCreated).toBe(1);
+		expect(stats.connectionsReused).toBe(0);
+		expect(stats.cachedContextRequests).toBe(1);
+		expect(stats.storeTrueRequests).toBe(0);
+		expect(stats.fullContextRequests).toBe(1);
+		expect(stats.deltaRequests).toBe(0);
+		expect(stats.lastInputItems).toBe(3);
+		expect(stats.lastDeltaInputItems).toBeUndefined();
+		expect(stats.lastPreviousResponseId).toBeUndefined();
+	});
+
+	it("records a delta request on a reused connection with store:true", () => {
+		const stats = emptyStats();
+		recordWebSocketStreamRequestStats(stats, true, false, {
+			store: true,
+			previous_response_id: "resp_abc",
+			input: [{ type: "message" }],
+		});
+
+		expect(stats.requests).toBe(1);
+		expect(stats.connectionsCreated).toBe(0);
+		expect(stats.connectionsReused).toBe(1);
+		expect(stats.cachedContextRequests).toBe(0);
+		expect(stats.storeTrueRequests).toBe(1);
+		expect(stats.fullContextRequests).toBe(0);
+		expect(stats.deltaRequests).toBe(1);
+		expect(stats.lastInputItems).toBe(1);
+		expect(stats.lastDeltaInputItems).toBe(1);
+		expect(stats.lastPreviousResponseId).toBe("resp_abc");
+	});
+});

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -1311,6 +1311,71 @@ async function* startWebSocketOutputOnFirstEvent(
 	}
 }
 
+function isCachedWebSocketTransport(transport: OpenAICodexResponsesOptions["transport"]): boolean {
+	return transport === "websocket-cached" || transport === "auto";
+}
+
+function resolveWebSocketStreamRequestBody(
+	useCachedContext: boolean,
+	entry: CachedWebSocketConnection | undefined,
+	fullBody: RequestBody,
+): RequestBody {
+	return useCachedContext && entry ? buildCachedWebSocketRequestBody(entry, fullBody) : fullBody;
+}
+
+/** Exported for unit tests — mutates WS stream request debug counters in place. */
+export function recordWebSocketStreamRequestStats(
+	stats: OpenAICodexWebSocketDebugStats | undefined,
+	reused: boolean,
+	useCachedContext: boolean,
+	requestBody: {
+		store?: boolean;
+		input?: ReadonlyArray<unknown>;
+		previous_response_id?: string;
+	},
+): void {
+	if (!stats) return;
+	stats.requests++;
+	if (reused) stats.connectionsReused++;
+	else stats.connectionsCreated++;
+	if (useCachedContext) stats.cachedContextRequests++;
+	if (requestBody.store === true) stats.storeTrueRequests++;
+	stats.lastInputItems = requestBody.input?.length ?? 0;
+	if (requestBody.previous_response_id) {
+		stats.deltaRequests++;
+		stats.lastDeltaInputItems = requestBody.input?.length ?? 0;
+		stats.lastPreviousResponseId = requestBody.previous_response_id;
+	} else {
+		stats.fullContextRequests++;
+		stats.lastDeltaInputItems = undefined;
+		stats.lastPreviousResponseId = undefined;
+	}
+}
+
+function storeWebSocketContinuationIfNeeded(
+	useCachedContext: boolean,
+	entry: CachedWebSocketConnection | undefined,
+	output: AssistantMessage,
+	model: Model<"openai-codex-responses">,
+	fullBody: RequestBody,
+): void {
+	if (!useCachedContext || !entry || !output.responseId) return;
+	const responseItems = convertResponsesMessages(model, { messages: [output] }, CODEX_TOOL_CALL_PROVIDERS, {
+		includeSystemPrompt: false,
+	}).filter((item) => item.type !== "function_call_output");
+	entry.continuation = {
+		lastRequestBody: fullBody,
+		lastResponseId: output.responseId,
+		lastResponseItems: responseItems,
+	};
+}
+
+function clearWebSocketContinuation(entry: CachedWebSocketConnection | undefined): void {
+	if (entry) {
+		entry.continuation = undefined;
+	}
+}
+
 async function processWebSocketStream(
 	url: string,
 	body: RequestBody,
@@ -1331,29 +1396,13 @@ async function processWebSocketStream(
 		websocketConnectTimeoutMs,
 	);
 	let keepConnection = true;
-	const useCachedContext = options?.transport === "websocket-cached" || options?.transport === "auto";
+	const useCachedContext = isCachedWebSocketTransport(options?.transport);
 	// ChatGPT Codex Responses rejects `store: true` ("Store must be set to false").
 	// WebSocket continuation still works via connection-scoped previous_response_id state.
 	const fullBody = body;
-	const requestBody = useCachedContext && entry ? buildCachedWebSocketRequestBody(entry, fullBody) : fullBody;
+	const requestBody = resolveWebSocketStreamRequestBody(useCachedContext, entry, fullBody);
 	const stats = options?.sessionId ? getOrCreateWebSocketDebugStats(options.sessionId) : undefined;
-	if (stats) {
-		stats.requests++;
-		if (reused) stats.connectionsReused++;
-		else stats.connectionsCreated++;
-		if (useCachedContext) stats.cachedContextRequests++;
-		if (requestBody.store === true) stats.storeTrueRequests++;
-		stats.lastInputItems = requestBody.input?.length ?? 0;
-		if (requestBody.previous_response_id) {
-			stats.deltaRequests++;
-			stats.lastDeltaInputItems = requestBody.input?.length ?? 0;
-			stats.lastPreviousResponseId = requestBody.previous_response_id;
-		} else {
-			stats.fullContextRequests++;
-			stats.lastDeltaInputItems = undefined;
-			stats.lastPreviousResponseId = undefined;
-		}
-	}
+	recordWebSocketStreamRequestStats(stats, reused, useCachedContext, requestBody);
 	try {
 		socket.send(JSON.stringify({ type: "response.create", ...requestBody }));
 		await processResponsesStream(
@@ -1374,20 +1423,11 @@ async function processWebSocketStream(
 		);
 		if (options?.signal?.aborted) {
 			keepConnection = false;
-		} else if (useCachedContext && entry && output.responseId) {
-			const responseItems = convertResponsesMessages(model, { messages: [output] }, CODEX_TOOL_CALL_PROVIDERS, {
-				includeSystemPrompt: false,
-			}).filter((item) => item.type !== "function_call_output");
-			entry.continuation = {
-				lastRequestBody: fullBody,
-				lastResponseId: output.responseId,
-				lastResponseItems: responseItems,
-			};
+		} else {
+			storeWebSocketContinuationIfNeeded(useCachedContext, entry, output, model, fullBody);
 		}
 	} catch (error) {
-		if (entry) {
-			entry.continuation = undefined;
-		}
+		clearWebSocketContinuation(entry);
 		keepConnection = false;
 		throw error;
 	} finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `processWebSocketStream` in `packages/ai/src/providers/openai-codex-responses.ts` to drop Sonar cognitive complexity (typescript:S3776) from 20 to ≤15.
- Extracts `isCachedWebSocketTransport`, `resolveWebSocketStreamRequestBody`, `recordWebSocketStreamRequestStats`, `storeWebSocketContinuationIfNeeded`, and `clearWebSocketContinuation` — same WebSocket request/stats/continuation control flow, no Codex provider rewrite.
- Adds unit tests locking full-context vs delta stats recording (reuse, cached-context, `store: true`).

## Type
- [ ] New feature
- [x] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| a1505817-aa05-462c-a28d-6027d53b3cbb | typescript:S3776 | `packages/ai/src/providers/openai-codex-responses.ts` (~L1313; hotspot is `processWebSocketStream`) |

Closes #874

## Why this is safe
Helpers preserve the previous control flow: identical cached-transport detection, request-body delta/full selection, debug counter updates, abort→drop-connection, continuation store on success, and continuation clear on error. `processWebSocketStream` still acquires/releases the socket the same way and still sends `response.create` through `processResponsesStream`.

## Checklist
- [x] `pnpm run typecheck` passes (run in PR validation)
- [x] `pnpm run lint` passes (run in PR validation)
- [x] `pnpm run test:coverage` passes (run in PR validation)
- [x] i18n N/A
- [x] No hardcoded colors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-390d2798-e8c6-4d9e-9b7f-9c8327efc137?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-390d2798-e8c6-4d9e-9b7f-9c8327efc137&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

