### PR TITLE
fix(sonar): lower convertMessages cognitive complexity (S3776)

### DIFF
--- a/packages/ai/src/providers/anthropic-messages.test.ts
+++ b/packages/ai/src/providers/anthropic-messages.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "vitest";
+import type { AssistantMessage, Message, Model, ToolResultMessage } from "../types.js";
+import { convertMessages } from "./anthropic.js";
+
+function baseModel(overrides: Partial<Model<"anthropic-messages">> = {}): Model<"anthropic-messages"> {
+	return {
+		id: "claude-sonnet-4-5",
+		name: "Claude Sonnet",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+		...overrides,
+	};
+}
+
+function assistant(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+function toolResult(partial: Partial<ToolResultMessage> & Pick<ToolResultMessage, "toolCallId" | "content">): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolName: "Read",
+		isError: false,
+		timestamp: 2,
+		...partial,
+	};
+}
+
+describe("convertMessages (anthropic)", () => {
+	it("skips blank string user messages and empty text-only content arrays", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "   ", timestamp: 1 },
+			{
+				role: "user",
+				content: [{ type: "text", text: "  " }],
+				timestamp: 2,
+			},
+			{ role: "user", content: "hello", timestamp: 3 },
+		];
+
+		expect(convertMessages(messages, baseModel(), false)).toEqual([
+			{ role: "user", content: "hello" },
+		]);
+	});
+
+	it("maps thinking without signature to text unless allowEmptySignature", () => {
+		const messages: Message[] = [
+			assistant([
+				{ type: "thinking", thinking: "ponder", thinkingSignature: "" },
+				{ type: "text", text: "answer" },
+			]),
+		];
+
+		expect(convertMessages(messages, baseModel(), false)).toEqual([
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "ponder" },
+					{ type: "text", text: "answer" },
+				],
+			},
+		]);
+
+		expect(convertMessages(messages, baseModel(), false, undefined, true)).toEqual([
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "ponder", signature: "" },
+					{ type: "text", text: "answer" },
+				],
+			},
+		]);
+	});
+
+	it("preserves redacted thinking and signed thinking blocks", () => {
+		const messages: Message[] = [
+			assistant([
+				{
+					type: "thinking",
+					thinking: "[Reasoning redacted]",
+					thinkingSignature: "opaque-payload",
+					redacted: true,
+				},
+				{
+					type: "thinking",
+					thinking: "visible",
+					thinkingSignature: "sig-1",
+				},
+			]),
+		];
+
+		expect(convertMessages(messages, baseModel(), false)).toEqual([
+			{
+				role: "assistant",
+				content: [
+					{ type: "redacted_thinking", data: "opaque-payload" },
+					{ type: "thinking", thinking: "visible", signature: "sig-1" },
+				],
+			},
+		]);
+	});
+
+	it("drops empty-name tool_use and orphans matching tool_result (MiniMax 2013)", () => {
+		const messages: Message[] = [
+			assistant([
+				{ type: "toolCall", id: "bad", name: "  ", arguments: {} },
+				{ type: "toolCall", id: "good", name: "Read", arguments: { path: "a.ts" } },
+			]),
+			toolResult({
+				toolCallId: "bad",
+				content: [{ type: "text", text: "should drop" }],
+			}),
+			toolResult({
+				toolCallId: "good",
+				content: [{ type: "text", text: "file contents" }],
+			}),
+		];
+
+		expect(convertMessages(messages, baseModel(), false)).toEqual([
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "good",
+						name: "Read",
+						input: { path: "a.ts" },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "good",
+						content: "file contents",
+						is_error: false,
+					},
+				],
+			},
+		]);
+	});
+
+	it("clears tool_use tracking when an assistant turn only had invalid tool calls", () => {
+		const messages: Message[] = [
+			assistant([{ type: "toolCall", id: "only-bad", name: "", arguments: {} }]),
+			toolResult({
+				toolCallId: "only-bad",
+				content: [{ type: "text", text: "orphan" }],
+			}),
+		];
+
+		expect(convertMessages(messages, baseModel(), false)).toEqual([]);
+	});
+
+	it("batches consecutive tool results into one user message", () => {
+		const messages: Message[] = [
+			assistant([
+				{ type: "toolCall", id: "a", name: "Read", arguments: {} },
+				{ type: "toolCall", id: "b", name: "Bash", arguments: {} },
+			]),
+			toolResult({
+				toolCallId: "a",
+				content: [{ type: "text", text: "one" }],
+			}),
+			toolResult({
+				toolCallId: "b",
+				content: [{ type: "text", text: "two" }],
+				isError: true,
+			}),
+		];
+
+		const params = convertMessages(messages, baseModel(), false);
+		expect(params).toHaveLength(2);
+		expect(params[1]).toEqual({
+			role: "user",
+			content: [
+				{
+					type: "tool_result",
+					tool_use_id: "a",
+					content: "one",
+					is_error: false,
+				},
+				{
+					type: "tool_result",
+					tool_use_id: "b",
+					content: "two",
+					is_error: true,
+				},
+			],
+		});
+	});
+
+	it("applies cache_control to the last user string or block", () => {
+		const cacheControl = { type: "ephemeral" as const };
+		const stringParams = convertMessages(
+			[{ role: "user", content: "hi", timestamp: 1 }],
+			baseModel(),
+			false,
+			cacheControl,
+		);
+		expect(stringParams).toEqual([
+			{
+				role: "user",
+				content: [{ type: "text", text: "hi", cache_control: cacheControl }],
+			},
+		]);
+
+		const blockParams = convertMessages(
+			[
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "see" },
+						{ type: "image", mimeType: "image/png", data: "abc" },
+					],
+					timestamp: 1,
+				},
+			],
+			baseModel(),
+			false,
+			cacheControl,
+		);
+		expect(blockParams[0]).toMatchObject({
+			role: "user",
+			content: [
+				{ type: "text", text: "see" },
+				{
+					type: "image",
+					source: { type: "base64", media_type: "image/png", data: "abc" },
+					cache_control: cacheControl,
+				},
+			],
+		});
+	});
+
+	it("maps tool names to Claude Code casing when using OAuth tokens", () => {
+		const messages: Message[] = [
+			assistant([{ type: "toolCall", id: "t1", name: "read", arguments: { path: "x" } }]),
+			toolResult({
+				toolCallId: "t1",
+				content: [{ type: "text", text: "ok" }],
+			}),
+		];
+
+		const params = convertMessages(messages, baseModel(), true);
+		expect(params[0]).toEqual({
+			role: "assistant",
+			content: [
+				{
+					type: "tool_use",
+					id: "t1",
+					name: "Read",
+					input: { path: "x" },
+				},
+			],
+		});
+		expect(params[1]).toMatchObject({
+			role: "user",
+			content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }],
+		});
+	});
+});

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1080,7 +1080,240 @@ function isValidToolCallName(name: unknown): name is string {
 	return typeof name === "string" && name.trim().length > 0;
 }
 
-function convertMessages(
+/** Returns null when the message converts to empty content and must be skipped. */
+function convertUserMessage(msg: Extract<Message, { role: "user" }>): MessageParam | null {
+	if (typeof msg.content === "string") {
+		if (msg.content.trim().length === 0) return null;
+		return {
+			role: "user",
+			content: sanitizeSurrogates(msg.content),
+		};
+	}
+
+	const blocks: ContentBlockParam[] = msg.content.map((item) => {
+		if (item.type === "text") {
+			return {
+				type: "text",
+				text: sanitizeSurrogates(item.text),
+			};
+		}
+		return {
+			type: "image",
+			source: {
+				type: "base64",
+				media_type: item.mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
+				data: item.data,
+			},
+		};
+	});
+	const filteredBlocks = blocks.filter((b) => (b.type === "text" ? b.text.trim().length > 0 : true));
+	if (filteredBlocks.length === 0) return null;
+	return {
+		role: "user",
+		content: filteredBlocks,
+	};
+}
+
+function appendThinkingBlock(
+	blocks: ContentBlockParam[],
+	block: ThinkingContent,
+	allowEmptySignature: boolean,
+): void {
+	// Redacted thinking: pass the opaque payload back as redacted_thinking
+	if (block.redacted) {
+		blocks.push({
+			type: "redacted_thinking",
+			data: block.thinkingSignature!,
+		});
+		return;
+	}
+	if (block.thinking.trim().length === 0) return;
+	// If thinking signature is missing/empty (e.g., from aborted stream),
+	// convert to plain text for Anthropic. Some compatible providers emit
+	// and accept empty signatures, so let marked models preserve the block.
+	if (!block.thinkingSignature || block.thinkingSignature.trim().length === 0) {
+		blocks.push(
+			allowEmptySignature
+				? {
+						type: "thinking",
+						thinking: sanitizeSurrogates(block.thinking),
+						signature: "",
+					}
+				: {
+						type: "text",
+						text: sanitizeSurrogates(block.thinking),
+					},
+		);
+		return;
+	}
+	blocks.push({
+		type: "thinking",
+		thinking: sanitizeSurrogates(block.thinking),
+		signature: block.thinkingSignature,
+	});
+}
+
+/**
+ * Returns null when the assistant message has no emit-able blocks.
+ * Callers still need the empty-toolCall branch for MiniMax orphan tracking.
+ */
+function convertAssistantMessage(
+	msg: AssistantMessage,
+	isOAuthToken: boolean,
+	allowEmptySignature: boolean,
+): { message: MessageParam; includedToolUseIds: Set<string> } | null {
+	const blocks: ContentBlockParam[] = [];
+	const includedToolUseIds = new Set<string>();
+
+	for (const block of msg.content) {
+		if (block.type === "text") {
+			if (block.text.trim().length === 0) continue;
+			blocks.push({
+				type: "text",
+				text: sanitizeSurrogates(block.text),
+			});
+			continue;
+		}
+		if (block.type === "thinking") {
+			appendThinkingBlock(blocks, block, allowEmptySignature);
+			continue;
+		}
+		if (block.type !== "toolCall") continue;
+		const toolName = isOAuthToken ? toClaudeCodeName(block.name) : block.name;
+		// MiniMax rejects tool_use blocks with an empty name (error 2013).
+		if (!isValidToolCallName(toolName)) continue;
+		includedToolUseIds.add(block.id);
+		blocks.push({
+			type: "tool_use",
+			id: block.id,
+			name: toolName,
+			input: block.arguments ?? {},
+		});
+	}
+
+	if (blocks.length === 0) return null;
+	return {
+		message: {
+			role: "assistant",
+			content: blocks,
+		},
+		includedToolUseIds,
+	};
+}
+
+/**
+ * Convert a run of consecutive toolResult messages starting at startIndex.
+ * Orphan results (tool_use dropped above) are skipped to avoid MiniMax 2013.
+ */
+function convertToolResultGroup(
+	transformedMessages: Message[],
+	startIndex: number,
+	lastIncludedToolUseIds: Set<string>,
+): { message: MessageParam | null; endIndex: number } {
+	const toolResults: ContentBlockParam[] = [];
+	let j = startIndex;
+
+	while (j < transformedMessages.length && transformedMessages[j].role === "toolResult") {
+		const toolMsg = transformedMessages[j] as ToolResultMessage;
+		j++;
+		if (!lastIncludedToolUseIds.has(toolMsg.toolCallId)) continue;
+		toolResults.push({
+			type: "tool_result",
+			tool_use_id: toolMsg.toolCallId,
+			content: convertContentBlocks(toolMsg.content),
+			is_error: toolMsg.isError,
+		});
+	}
+
+	const endIndex = j - 1;
+	if (toolResults.length === 0) {
+		return { message: null, endIndex };
+	}
+	return {
+		message: {
+			role: "user",
+			content: toolResults,
+		},
+		endIndex,
+	};
+}
+
+/** Stamp cache_control on the last user message to cache conversation history. */
+function applyCacheControlToLastUserMessage(
+	params: MessageParam[],
+	cacheControl: CacheControlEphemeral,
+): void {
+	if (params.length === 0) return;
+	const lastMessage = params[params.length - 1];
+	if (lastMessage.role !== "user") return;
+
+	if (Array.isArray(lastMessage.content)) {
+		const lastBlock = lastMessage.content[lastMessage.content.length - 1];
+		if (
+			lastBlock &&
+			(lastBlock.type === "text" || lastBlock.type === "image" || lastBlock.type === "tool_result")
+		) {
+			(lastBlock as { cache_control?: CacheControlEphemeral }).cache_control = cacheControl;
+		}
+		return;
+	}
+
+	if (typeof lastMessage.content === "string") {
+		lastMessage.content = [
+			{
+				type: "text",
+				text: lastMessage.content,
+				cache_control: cacheControl,
+			},
+		] as ContentBlockParam[];
+	}
+}
+
+/**
+ * Process a single transformed message and append converted params.
+ * Returns the index of the last consumed message and updated tool_use id set.
+ */
+function processMessage(
+	transformedMessages: Message[],
+	index: number,
+	lastIncludedToolUseIds: Set<string>,
+	isOAuthToken: boolean,
+	allowEmptySignature: boolean,
+	params: MessageParam[],
+): { index: number; lastIncludedToolUseIds: Set<string> } {
+	const msg = transformedMessages[index];
+
+	switch (msg.role) {
+		case "user": {
+			const userMsg = convertUserMessage(msg);
+			if (userMsg) params.push(userMsg);
+			return { index, lastIncludedToolUseIds };
+		}
+		case "assistant": {
+			const converted = convertAssistantMessage(msg, isOAuthToken, allowEmptySignature);
+			if (!converted) {
+				if (msg.content.some((block) => block.type === "toolCall")) {
+					return { index, lastIncludedToolUseIds: new Set() };
+				}
+				return { index, lastIncludedToolUseIds };
+			}
+			params.push(converted.message);
+			return { index, lastIncludedToolUseIds: converted.includedToolUseIds };
+		}
+		case "toolResult": {
+			const group = convertToolResultGroup(transformedMessages, index, lastIncludedToolUseIds);
+			if (group.message) params.push(group.message);
+			return { index: group.endIndex, lastIncludedToolUseIds };
+		}
+		default: {
+			const _exhaustive: never = msg;
+			void _exhaustive;
+			return { index, lastIncludedToolUseIds };
+		}
+	}
+}
+
+export function convertMessages(
 	messages: Message[],
 	model: Model<"anthropic-messages">,
 	isOAuthToken: boolean,
@@ -1096,182 +1329,20 @@ function convertMessages(
 	let lastIncludedToolUseIds = new Set<string>();
 
 	for (let i = 0; i < transformedMessages.length; i++) {
-		const msg = transformedMessages[i];
-
-		if (msg.role === "user") {
-			if (typeof msg.content === "string") {
-				if (msg.content.trim().length > 0) {
-					params.push({
-						role: "user",
-						content: sanitizeSurrogates(msg.content),
-					});
-				}
-			} else {
-				const blocks: ContentBlockParam[] = msg.content.map((item) => {
-					if (item.type === "text") {
-						return {
-							type: "text",
-							text: sanitizeSurrogates(item.text),
-						};
-					} else {
-						return {
-							type: "image",
-							source: {
-								type: "base64",
-								media_type: item.mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
-								data: item.data,
-							},
-						};
-					}
-				});
-				const filteredBlocks = blocks.filter((b) => {
-					if (b.type === "text") {
-						return b.text.trim().length > 0;
-					}
-					return true;
-				});
-				if (filteredBlocks.length === 0) continue;
-				params.push({
-					role: "user",
-					content: filteredBlocks,
-				});
-			}
-		} else if (msg.role === "assistant") {
-			const blocks: ContentBlockParam[] = [];
-			const includedToolUseIds = new Set<string>();
-
-			for (const block of msg.content) {
-				if (block.type === "text") {
-					if (block.text.trim().length === 0) continue;
-					blocks.push({
-						type: "text",
-						text: sanitizeSurrogates(block.text),
-					});
-				} else if (block.type === "thinking") {
-					// Redacted thinking: pass the opaque payload back as redacted_thinking
-					if (block.redacted) {
-						blocks.push({
-							type: "redacted_thinking",
-							data: block.thinkingSignature!,
-						});
-						continue;
-					}
-					if (block.thinking.trim().length === 0) continue;
-					// If thinking signature is missing/empty (e.g., from aborted stream),
-					// convert to plain text for Anthropic. Some compatible providers emit
-					// and accept empty signatures, so let marked models preserve the block.
-					if (!block.thinkingSignature || block.thinkingSignature.trim().length === 0) {
-						blocks.push(
-							allowEmptySignature
-								? {
-										type: "thinking",
-										thinking: sanitizeSurrogates(block.thinking),
-										signature: "",
-									}
-								: {
-										type: "text",
-										text: sanitizeSurrogates(block.thinking),
-									},
-						);
-					} else {
-						blocks.push({
-							type: "thinking",
-							thinking: sanitizeSurrogates(block.thinking),
-							signature: block.thinkingSignature,
-						});
-					}
-				} else if (block.type === "toolCall") {
-					const toolName = isOAuthToken ? toClaudeCodeName(block.name) : block.name;
-					// MiniMax rejects tool_use blocks with an empty name (error 2013).
-					if (!isValidToolCallName(toolName)) continue;
-					includedToolUseIds.add(block.id);
-					blocks.push({
-						type: "tool_use",
-						id: block.id,
-						name: toolName,
-						input: block.arguments ?? {},
-					});
-				}
-			}
-			if (blocks.length === 0) {
-				if (msg.content.some((block) => block.type === "toolCall")) {
-					lastIncludedToolUseIds = new Set();
-				}
-				continue;
-			}
-			lastIncludedToolUseIds = includedToolUseIds;
-			params.push({
-				role: "assistant",
-				content: blocks,
-			});
-		} else if (msg.role === "toolResult") {
-			if (!lastIncludedToolUseIds.has(msg.toolCallId)) {
-				// Orphan result (e.g. tool_use dropped above) — skip to avoid MiniMax 2013.
-				continue;
-			}
-			// Collect all consecutive toolResult messages, needed for z.ai Anthropic endpoint
-			const toolResults: ContentBlockParam[] = [];
-
-			// Add the current tool result
-			toolResults.push({
-				type: "tool_result",
-				tool_use_id: msg.toolCallId,
-				content: convertContentBlocks(msg.content),
-				is_error: msg.isError,
-			});
-
-			// Look ahead for consecutive toolResult messages
-			let j = i + 1;
-			while (j < transformedMessages.length && transformedMessages[j].role === "toolResult") {
-				const nextMsg = transformedMessages[j] as ToolResultMessage; // We know it's a toolResult
-				if (!lastIncludedToolUseIds.has(nextMsg.toolCallId)) {
-					j++;
-					continue;
-				}
-				toolResults.push({
-					type: "tool_result",
-					tool_use_id: nextMsg.toolCallId,
-					content: convertContentBlocks(nextMsg.content),
-					is_error: nextMsg.isError,
-				});
-				j++;
-			}
-
-			// Skip the messages we've already processed
-			i = j - 1;
-
-			if (toolResults.length === 0) continue;
-
-			// Add a single user message with all tool results
-			params.push({
-				role: "user",
-				content: toolResults,
-			});
-		}
+		const result = processMessage(
+			transformedMessages,
+			i,
+			lastIncludedToolUseIds,
+			isOAuthToken,
+			allowEmptySignature,
+			params,
+		);
+		i = result.index;
+		lastIncludedToolUseIds = result.lastIncludedToolUseIds;
 	}
 
-	// Add cache_control to the last user message to cache conversation history
-	if (cacheControl && params.length > 0) {
-		const lastMessage = params[params.length - 1];
-		if (lastMessage.role === "user") {
-			if (Array.isArray(lastMessage.content)) {
-				const lastBlock = lastMessage.content[lastMessage.content.length - 1];
-				if (
-					lastBlock &&
-					(lastBlock.type === "text" || lastBlock.type === "image" || lastBlock.type === "tool_result")
-				) {
-					(lastBlock as any).cache_control = cacheControl;
-				}
-			} else if (typeof lastMessage.content === "string") {
-				lastMessage.content = [
-					{
-						type: "text",
-						text: lastMessage.content,
-						cache_control: cacheControl,
-					},
-				] as any;
-			}
-		}
+	if (cacheControl) {
+		applyCacheControlToLastUserMessage(params, cacheControl);
 	}
 
 	return params;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `convertMessages` in `packages/ai/src/providers/anthropic.ts` to drop Sonar cognitive complexity (typescript:S3776) from 43 to ≤15.
- Extracts `convertUserMessage`, `appendThinkingBlock`, `convertAssistantMessage`, `convertToolResultGroup`, `applyCacheControlToLastUserMessage`, and `processMessage` — same message mapping control flow, no Anthropic provider rewrite.
- Adds unit tests locking blank-user skips, thinking/signature/redacted mapping, MiniMax empty-name + orphan tool_result handling, consecutive tool-result batching, `cache_control`, and OAuth Claude Code tool-name casing.

## Type
- [ ] New feature
- [x] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| a38378aa-7c77-4c93-bfb3-2be1bb0fc710 | typescript:S3776 | `packages/ai/src/providers/anthropic.ts` (~L923 reported; hotspot is `convertMessages`) |

Closes #867

## Why this is safe
Helpers preserve the previous control flow: identical user string/block filtering, thinking→text vs empty-signature preservation, redacted thinking, OAuth Claude Code tool rename, MiniMax empty-name drop + orphan tool_result skip (including clearing the last tool_use id set when an assistant turn only had invalid tool calls), consecutive tool_result batching into one user message, and `cache_control` on the last user string/block. `buildParams` / streaming paths are untouched.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] i18n N/A
- [x] No hardcoded colors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe234209-0d39-46fa-aa8b-6d04fccc6b83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe234209-0d39-46fa-aa8b-6d04fccc6b83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

