### PR TITLE
fix(sonar): lower truncateStringToBytesFromEnd cognitive complexity (S3776)

### DIFF
--- a/packages/agent-core/src/harness/utils/truncate.ts
+++ b/packages/agent-core/src/harness/utils/truncate.ts
@@ -288,6 +288,46 @@ export function truncateTail(content: string, options: TruncationOptions = {}): 
 	};
 }
 
+/** UTF-8 byte length for a non-surrogate BMP code unit. */
+function bmpUtf8ByteLength(code: number): number {
+	if (code <= 0x7f) return 1;
+	if (code <= 0x7ff) return 2;
+	return 3;
+}
+
+interface Utf8CharFromEnd {
+	characterStart: number;
+	characterBytes: number;
+	unpairedSurrogate: boolean;
+}
+
+/**
+ * Read one UTF-8 character ending at `endExclusive` (exclusive index), walking backwards.
+ * Surrogate pairs count as 4 bytes; unpaired surrogates as 3 (replacement later).
+ */
+function readUtf8CharFromEnd(str: string, endExclusive: number): Utf8CharFromEnd {
+	const characterStart = endExclusive - 1;
+	const code = str.charCodeAt(characterStart);
+
+	if (code >= 0xdc00 && code <= 0xdfff && characterStart > 0) {
+		const previous = str.charCodeAt(characterStart - 1);
+		if (previous >= 0xd800 && previous <= 0xdbff) {
+			return { characterStart: characterStart - 1, characterBytes: 4, unpairedSurrogate: false };
+		}
+		return { characterStart, characterBytes: 3, unpairedSurrogate: true };
+	}
+
+	if (code >= 0xd800 && code <= 0xdfff) {
+		return { characterStart, characterBytes: 3, unpairedSurrogate: true };
+	}
+
+	return {
+		characterStart,
+		characterBytes: bmpUtf8ByteLength(code),
+		unpairedSurrogate: false,
+	};
+}
+
 /**
  * Truncate a string to fit within a byte limit (from the end).
  * Handles multi-byte UTF-8 characters correctly.
@@ -299,25 +339,7 @@ function truncateStringToBytesFromEnd(str: string, maxBytes: number): string {
 	let start = str.length;
 	let needsReplacement = false;
 	for (let i = str.length; i > 0; ) {
-		let characterStart = i - 1;
-		const code = str.charCodeAt(characterStart);
-		let characterBytes: number;
-		let unpairedSurrogate = false;
-		if (code >= 0xdc00 && code <= 0xdfff && characterStart > 0) {
-			const previous = str.charCodeAt(characterStart - 1);
-			if (previous >= 0xd800 && previous <= 0xdbff) {
-				characterStart--;
-				characterBytes = 4;
-			} else {
-				characterBytes = 3;
-				unpairedSurrogate = true;
-			}
-		} else if (code >= 0xd800 && code <= 0xdfff) {
-			characterBytes = 3;
-			unpairedSurrogate = true;
-		} else {
-			characterBytes = code <= 0x7f ? 1 : code <= 0x7ff ? 2 : 3;
-		}
+		const { characterStart, characterBytes, unpairedSurrogate } = readUtf8CharFromEnd(str, i);
 		if (outputBytes + characterBytes > maxBytes) break;
 		outputBytes += characterBytes;
 		start = characterStart;

--- a/packages/agent-core/test/truncate.test.ts
+++ b/packages/agent-core/test/truncate.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DEFAULT_MAX_BYTES,
+	DEFAULT_MAX_LINES,
+	formatSize,
+	truncateHead,
+	truncateLine,
+	truncateTail,
+} from '../src/harness/utils/truncate.js';
+
+describe('formatSize', () => {
+	it('formats bytes, KB, and MB', () => {
+		expect(formatSize(512)).toBe('512B');
+		expect(formatSize(1536)).toBe('1.5KB');
+		expect(formatSize(2 * 1024 * 1024)).toBe('2.0MB');
+	});
+});
+
+describe('truncateHead', () => {
+	it('returns content unchanged when under limits', () => {
+		const content = 'a\nb\nc';
+		const r = truncateHead(content, { maxLines: 10, maxBytes: 1000 });
+		expect(r.truncated).toBe(false);
+		expect(r.content).toBe(content);
+		expect(r.truncatedBy).toBeNull();
+	});
+
+	it('truncates by line limit without partial lines', () => {
+		const content = Array.from({ length: 20 }, (_, i) => `L${i}`).join('\n');
+		const r = truncateHead(content, { maxLines: 5, maxBytes: 10_000 });
+		expect(r.truncated).toBe(true);
+		expect(r.truncatedBy).toBe('lines');
+		expect(r.content.split('\n')).toHaveLength(5);
+		expect(r.content).toBe('L0\nL1\nL2\nL3\nL4');
+	});
+
+	it('returns empty when first line alone exceeds byte limit', () => {
+		const content = `${'x'.repeat(100)}\nsecond`;
+		const r = truncateHead(content, { maxLines: 10, maxBytes: 10 });
+		expect(r.truncated).toBe(true);
+		expect(r.truncatedBy).toBe('bytes');
+		expect(r.content).toBe('');
+		expect(r.firstLineExceedsLimit).toBe(true);
+		expect(r.outputLines).toBe(0);
+	});
+
+	it('stops on byte limit at a line boundary', () => {
+		const content = 'aaaa\nbbbb\ncccc';
+		// "aaaa" = 4; next line needs +1 newline + 4 = 9 → exceeds maxBytes 8
+		const r = truncateHead(content, { maxLines: 10, maxBytes: 8 });
+		expect(r.truncated).toBe(true);
+		expect(r.truncatedBy).toBe('bytes');
+		expect(r.content).toBe('aaaa');
+		expect(r.lastLinePartial).toBe(false);
+	});
+});
+
+describe('truncateTail', () => {
+	it('keeps the end when line-limited', () => {
+		const content = `${Array.from({ length: 100 }, (_, i) => `L${i}`).join('\n')}\nTAIL`;
+		const r = truncateTail(content, { maxLines: 5, maxBytes: 10_000 });
+		expect(r.truncated).toBe(true);
+		expect(r.content).toMatch(/TAIL$/);
+		expect(r.content.split('\n').length).toBeLessThanOrEqual(5);
+	});
+
+	it('partially keeps the end of a single oversize line (ASCII)', () => {
+		const content = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		const r = truncateTail(content, { maxLines: 10, maxBytes: 5 });
+		expect(r.truncated).toBe(true);
+		expect(r.truncatedBy).toBe('bytes');
+		expect(r.lastLinePartial).toBe(true);
+		expect(r.content).toBe('VWXYZ');
+		expect(Buffer.byteLength(r.content, 'utf8')).toBe(5);
+	});
+
+	it('never splits a multi-byte UTF-8 character when truncating from the end', () => {
+		// "é" is 2 bytes; emoji 😀 is 4 bytes
+		const content = `prefix-${'é'.repeat(10)}-😀-suffix`;
+		const r = truncateTail(content, { maxLines: 5, maxBytes: 12 });
+		expect(r.truncated).toBe(true);
+		expect(r.lastLinePartial).toBe(true);
+		expect(Buffer.byteLength(r.content, 'utf8')).toBeLessThanOrEqual(12);
+		// Re-encoding must be valid UTF-8 (no replacement from mid-sequence)
+		expect(Buffer.from(r.content, 'utf8').toString('utf8')).toBe(r.content);
+		expect(r.content.endsWith('suffix')).toBe(true);
+	});
+
+	it('replaces unpaired surrogates included in the kept suffix', () => {
+		const loneLow = String.fromCharCode(0xdc00);
+		const content = `keep${loneLow}END`;
+		const r = truncateTail(content, { maxLines: 5, maxBytes: 20 });
+		expect(r.truncated).toBe(false);
+		expect(r.content).toContain('END');
+		// Under limits → original returned as-is (no replacement path)
+		expect(r.content).toBe(content);
+
+		const oversize = `${'A'.repeat(30)}${loneLow}END`;
+		const truncated = truncateTail(oversize, { maxLines: 5, maxBytes: 8 });
+		expect(truncated.truncated).toBe(true);
+		expect(truncated.lastLinePartial).toBe(true);
+		expect(truncated.content).toContain('END');
+		expect(truncated.content).toContain('\uFFFD');
+		expect(truncated.content).not.toContain(loneLow);
+	});
+
+	it('returns empty string when maxBytes is 0 on an oversize single line', () => {
+		const r = truncateTail('hello', { maxLines: 10, maxBytes: 0 });
+		expect(r.truncated).toBe(true);
+		expect(r.content).toBe('');
+		expect(r.lastLinePartial).toBe(true);
+	});
+});
+
+describe('truncateLine', () => {
+	it('leaves short lines alone and suffixes long ones', () => {
+		expect(truncateLine('short', 20)).toEqual({ text: 'short', wasTruncated: false });
+		expect(truncateLine('abcdefghijklmnopqrstuvwxyz', 10)).toEqual({
+			text: 'abcdefghij... [truncated]',
+			wasTruncated: true,
+		});
+	});
+});
+
+describe('defaults', () => {
+	it('exports expected default limits', () => {
+		expect(DEFAULT_MAX_LINES).toBe(2000);
+		expect(DEFAULT_MAX_BYTES).toBe(50 * 1024);
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `truncateStringToBytesFromEnd` in `packages/agent-core/src/harness/utils/truncate.ts` to drop Sonar cognitive complexity (typescript:S3776) from 23 to ≤15.
- Extracts `bmpUtf8ByteLength` and `readUtf8CharFromEnd` — same end-to-start UTF-8 walk, surrogate-pair handling, and unpaired-surrogate replacement; no truncation rewrite.
- Adds unit tests locking head/tail/line truncation, ASCII and multi-byte partial-tail edges, unpaired surrogates → U+FFFD, and `maxBytes: 0`.

## Type
- [ ] New feature
- [x] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| a55a8ffb-524f-470d-9749-c676fc2150a3 | typescript:S3776 | `packages/agent-core/src/harness/utils/truncate.ts` (~L295; hotspot is `truncateStringToBytesFromEnd`) |

Closes #854

## Why this is safe
Helpers preserve the previous control flow: walk characters from the end, count UTF-8 bytes (1/2/3 for BMP, 4 for surrogate pairs, 3 for unpaired surrogates), stop before exceeding `maxBytes`, then optionally run `replaceUnpairedSurrogates`. `truncateHead` / `truncateTail` / `truncateLine` call sites are unchanged.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] i18n N/A
- [x] No hardcoded colors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbd45613-eff5-4a7e-a23d-83b42685adeb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbd45613-eff5-4a7e-a23d-83b42685adeb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

