### PR TITLE
fix(sonar): lower RelationChip cognitive complexity (S3776, #852)

### DIFF
--- a/app/components/workspace/RelationChip.test.tsx
+++ b/app/components/workspace/RelationChip.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import RelationChip from './RelationChip';
+
+describe('RelationChip', () => {
+  it('renders tag title with hash prefix and type hint only for non-tags', () => {
+    const { rerender } = render(
+      <RelationChip variant="tag" title="research" resourceType="pdf" />,
+    );
+    expect(screen.getByText('#research')).toBeVisible();
+    expect(screen.queryByText('PDF')).toBeNull();
+
+    rerender(<RelationChip variant="mention" title="Paper" resourceType="pdf" />);
+    expect(screen.getByText('Paper')).toBeVisible();
+    expect(screen.getByText('PDF')).toBeVisible();
+  });
+
+  it('prefers subtitle over resource type label', () => {
+    render(
+      <RelationChip
+        variant="url"
+        title="Example"
+        subtitle="Custom hint"
+        resourceType="pdf"
+      />,
+    );
+    expect(screen.getByText('Custom hint')).toBeVisible();
+    expect(screen.queryByText('PDF')).toBeNull();
+  });
+
+  it('shows similarity percent and relation state badges', () => {
+    const { rerender } = render(
+      <RelationChip
+        variant="mention"
+        title="A"
+        similarity={0.42}
+        relationState="auto"
+      />,
+    );
+    expect(screen.getByText('42%')).toBeVisible();
+    expect(screen.getByText('auto')).toBeVisible();
+
+    rerender(
+      <RelationChip
+        variant="mention"
+        title="A"
+        similarity={0.995}
+        relationState="confirmed"
+      />,
+    );
+    expect(screen.getByText('100%')).toBeVisible();
+    expect(screen.getByText('OK')).toBeVisible();
+
+    rerender(
+      <RelationChip variant="mention" title="A" relationState="manual" />,
+    );
+    expect(screen.queryByText('manual')).toBeNull();
+
+    rerender(
+      <RelationChip variant="mention" title="A" relationState="rejected" />,
+    );
+    expect(screen.getByText('rejected')).toBeVisible();
+  });
+
+  it('invokes onOpen and onRemove when provided', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    const onRemove = vi.fn();
+    render(
+      <RelationChip
+        variant="mention"
+        title="Open me"
+        onOpen={onOpen}
+        onRemove={onRemove}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open me' }));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a spinner when remove is disabled', () => {
+    render(
+      <RelationChip
+        variant="mention"
+        title="Busy"
+        onRemove={vi.fn()}
+        removeDisabled
+      />,
+    );
+    const remove = screen.getByRole('button', { name: 'Remove' });
+    expect(remove).toBeDisabled();
+    expect(remove.querySelector('.animate-spin')).toBeTruthy();
+  });
+});

--- a/app/components/workspace/RelationChip.tsx
+++ b/app/components/workspace/RelationChip.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
   Cancel01Icon,
@@ -35,6 +36,156 @@ const TYPE_LABELS: Partial<Record<string, string>> = {
   ppt: 'PPT',
 };
 
+/** Prefer subtitle; else mapped resource type label (or raw type). Extracted for S3776. */
+function resolveTypeHint(subtitle: string | undefined, resourceType: string | undefined): string | undefined {
+  if (subtitle != null) return subtitle;
+  if (!resourceType) return undefined;
+  return TYPE_LABELS[resourceType] ?? resourceType;
+}
+
+/** Percent label for finite similarity scores; null otherwise. */
+function formatSimilarityLabel(similarity: number | undefined): string | null {
+  if (similarity == null || !Number.isFinite(similarity)) return null;
+  return `${Math.round(similarity * 100)}%`;
+}
+
+/** Badge text for relation state; null for missing/manual. */
+function formatRelationStateLabel(
+  relationState: RelationChipProps['relationState'],
+): string | null {
+  if (!relationState || relationState === 'manual') return null;
+  if (relationState === 'auto') return 'auto';
+  if (relationState === 'confirmed') return 'OK';
+  return relationState;
+}
+
+function RelationChipTitle({
+  variant,
+  title,
+  accentColor,
+}: {
+  variant: RelationChipVariant;
+  title: string;
+  accentColor?: string;
+}) {
+  if (variant === 'tag') {
+    return (
+      <span
+        className="text-xs font-semibold px-2 py-0.5 rounded-full shrink-0"
+        style={{
+          background: accentColor ?? 'color-mix(in srgb, var(--primary) 12%, transparent)',
+          color: 'var(--foreground)',
+        }}
+      >
+        #{title}
+      </span>
+    );
+  }
+  return <p className="text-sm font-medium truncate text-foreground">{title}</p>;
+}
+
+function RelationChipMetaBadges({
+  simLabel,
+  stateLabel,
+  similarityHint,
+}: {
+  simLabel: string | null;
+  stateLabel: string | null;
+  similarityHint: string;
+}) {
+  return (
+    <>
+      {simLabel ? (
+        <span
+          className="text-[10px] px-1.5 py-0 rounded-full shrink-0 font-medium"
+          style={{
+            background: 'color-mix(in srgb, var(--primary) 12%, transparent)',
+            color: 'var(--muted-foreground)',
+          }}
+          title={similarityHint}
+        >
+          {simLabel}
+        </span>
+      ) : null}
+      {stateLabel ? (
+        <span
+          className="text-[10px] px-1.5 py-0 rounded-full shrink-0 font-medium capitalize"
+          style={{
+            background: 'var(--accent)',
+            color: 'var(--muted-foreground)',
+          }}
+        >
+          {stateLabel}
+        </span>
+      ) : null}
+    </>
+  );
+}
+
+function RelationChipBody({
+  variant,
+  title,
+  accentColor,
+  typeHint,
+  simLabel,
+  stateLabel,
+  similarityHint,
+}: {
+  variant: RelationChipVariant;
+  title: string;
+  accentColor?: string;
+  typeHint: string | undefined;
+  simLabel: string | null;
+  stateLabel: string | null;
+  similarityHint: string;
+}): ReactNode {
+  return (
+    <>
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        <RelationChipTitle variant={variant} title={title} accentColor={accentColor} />
+        <RelationChipMetaBadges
+          simLabel={simLabel}
+          stateLabel={stateLabel}
+          similarityHint={similarityHint}
+        />
+      </div>
+      {typeHint && variant !== 'tag' ? (
+        <p className="text-[11px] mt-0.5 truncate w-full text-muted-foreground">
+          {typeHint}
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+function RelationChipRemoveButton({
+  onRemove,
+  removeDisabled,
+}: {
+  onRemove: () => void;
+  removeDisabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onRemove();
+      }}
+      disabled={removeDisabled}
+      className="px-2 rounded-lg shrink-0 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-accent focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-40 self-stretch flex items-center"
+      style={{ color: 'var(--muted-foreground)' }}
+      aria-label="Remove"
+    >
+      {removeDisabled ? (
+        <span className="inline-block size-3.5 border border-current border-t-transparent rounded-full animate-spin" />
+      ) : (
+        <HugeiconsIcon icon={Cancel01Icon} size={14} />
+      )}
+    </button>
+  );
+}
+
 export default function RelationChip({
   variant,
   title,
@@ -48,70 +199,20 @@ export default function RelationChip({
   removeDisabled,
 }: RelationChipProps) {
   const { t } = useTranslation();
-  const typeHint =
-    subtitle ?? (resourceType ? (TYPE_LABELS[resourceType] ?? resourceType) : undefined);
-
-  const simLabel =
-    similarity != null && Number.isFinite(similarity)
-      ? `${Math.round(similarity * 100)}%`
-      : null;
-  const stateLabel =
-    relationState && relationState !== 'manual'
-      ? relationState === 'auto'
-        ? 'auto'
-        : relationState === 'confirmed'
-          ? 'OK'
-          : relationState
-      : null;
+  const typeHint = resolveTypeHint(subtitle, resourceType);
+  const simLabel = formatSimilarityLabel(similarity);
+  const stateLabel = formatRelationStateLabel(relationState);
 
   const body = (
-    <>
-      <div className="flex items-center gap-2 min-w-0 flex-1">
-        {variant === 'tag' ? (
-          <span
-            className="text-xs font-semibold px-2 py-0.5 rounded-full shrink-0"
-            style={{
-              background: accentColor ?? 'color-mix(in srgb, var(--primary) 12%, transparent)',
-              color: 'var(--foreground)',
-            }}
-          >
-            #{title}
-          </span>
-        ) : (
-          <p className="text-sm font-medium truncate text-foreground">
-            {title}
-          </p>
-        )}
-        {simLabel ? (
-          <span
-            className="text-[10px] px-1.5 py-0 rounded-full shrink-0 font-medium"
-            style={{
-              background: 'color-mix(in srgb, var(--primary) 12%, transparent)',
-              color: 'var(--muted-foreground)',
-            }}
-            title={t('workspace.relations_similarity_hint')}
-          >
-            {simLabel}
-          </span>
-        ) : null}
-        {stateLabel ? (
-          <span
-            className="text-[10px] px-1.5 py-0 rounded-full shrink-0 font-medium capitalize"
-            style={{
-              background: 'var(--accent)',
-              color: 'var(--muted-foreground)',
-            }}
-          >
-            {stateLabel}
-          </span>
-        ) : null}
-      </div>
-      {typeHint && variant !== 'tag' ? (
-        <p className="text-[11px] mt-0.5 truncate w-full text-muted-foreground">
-          {typeHint}
-        </p>
-      ) : null}
-    </>
+    <RelationChipBody
+      variant={variant}
+      title={title}
+      accentColor={accentColor}
+      typeHint={typeHint}
+      simLabel={simLabel}
+      stateLabel={stateLabel}
+      similarityHint={t('workspace.relations_similarity_hint')}
+    />
   );
 
   return (
@@ -134,23 +235,7 @@ export default function RelationChip({
         <div className="flex-1 min-w-0 px-2.5 py-1.5 flex flex-col justify-center">{body}</div>
       )}
       {onRemove ? (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onRemove();
-          }}
-          disabled={removeDisabled}
-          className="px-2 rounded-lg shrink-0 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-accent focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-40 self-stretch flex items-center"
-          style={{ color: 'var(--muted-foreground)' }}
-          aria-label="Remove"
-        >
-          {removeDisabled ? (
-            <span className="inline-block size-3.5 border border-current border-t-transparent rounded-full animate-spin" />
-          ) : (
-            <HugeiconsIcon icon={Cancel01Icon} size={14} />
-          )}
-        </button>
+        <RelationChipRemoveButton onRemove={onRemove} removeDisabled={removeDisabled} />
       ) : null}
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Lower Sonar cognitive complexity (`typescript:S3776`) in `RelationChip` by extracting pure label helpers (`resolveTypeHint`, `formatSimilarityLabel`, `formatRelationStateLabel`) and small presentational subcomponents (`RelationChipTitle`, `RelationChipMetaBadges`, `RelationChipBody`, `RelationChipRemoveButton`).
- Behavior is unchanged: same labels, badges, open/remove affordances, and tag vs mention/url rendering.
- Add focused renderer tests covering tags, type hints, similarity/state badges, and open/remove actions.

| Sonar key | Rule | File | Closes |
| --- | --- | --- | --- |
| `a5d19d04-b46b-4579-aa2b-7bec4e123980` | typescript:S3776 | `app/components/workspace/RelationChip.tsx` | #852 |

Closes #852

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs / config

## Why this is safe
- Label and control-flow logic moved into helpers/subcomponents with the same predicates (`subtitle ?? …`, finite similarity, manual/auto/confirmed state mapping).
- No redesign of the chip UI and no caller changes in `RelationsTab`.
- New unit tests lock the previous label and interaction contract (5/5 green).

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] i18n keys — N/A (no new user-visible strings)
- [x] No hardcoded colors (CSS variables only)

Auto-merge (squash) enabled after required checks pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5213060c-db40-45aa-a7e2-41fa4cd70246?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5213060c-db40-45aa-a7e2-41fa4cd70246&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

