### PR TITLE
fix(sonar): lower extractFileOpsFromMessage cognitive complexity (S3776, #850)

### DIFF
--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -49,16 +49,27 @@ function recordToolCallFileOp(name: string, path: string, fileOps: FileOperation
 	}
 }
 
+/** Assistant message content blocks, or null when the message cannot yield file ops. */
+function assistantContentBlocks(message: AgentMessage): unknown[] | null {
+	if (message.role !== "assistant") return null;
+	if (!("content" in message) || !Array.isArray(message.content)) return null;
+	return message.content;
+}
+
+function applyToolCallFileOp(block: ToolCall, fileOps: FileOperations): void {
+	const path = toolCallPath(block.arguments);
+	if (!path) return;
+	recordToolCallFileOp(block.name, path, fileOps);
+}
+
 /** Add file operations from assistant tool calls to an accumulator. */
 export function extractFileOpsFromMessage(message: AgentMessage, fileOps: FileOperations): void {
-	if (message.role !== "assistant") return;
-	if (!("content" in message) || !Array.isArray(message.content)) return;
+	const content = assistantContentBlocks(message);
+	if (!content) return;
 
-	for (const block of message.content) {
+	for (const block of content) {
 		if (!isToolCallBlock(block)) continue;
-		const path = toolCallPath(block.arguments);
-		if (!path) continue;
-		recordToolCallFileOp(block.name, path, fileOps);
+		applyToolCallFileOp(block, fileOps);
 	}
 }
 

--- a/packages/agent-core/test/compaction-utils.test.ts
+++ b/packages/agent-core/test/compaction-utils.test.ts
@@ -48,6 +48,23 @@ describe('extractFileOpsFromMessage / computeFileLists', () => {
     expect(readFiles).toEqual(['a.ts']);
     expect(modifiedFiles).toEqual(['b.ts', 'c.ts']);
   });
+
+  it('ignores non-assistant messages, non-array content, and malformed tool-call blocks', () => {
+    const fileOps = createFileOps();
+    extractFileOpsFromMessage({ role: 'toolResult', toolCallId: 't', toolName: 'read', content: [], isError: false, timestamp: 1 } as AgentMessage, fileOps);
+    extractFileOpsFromMessage({ role: 'assistant', timestamp: 1 } as AgentMessage, fileOps);
+    extractFileOpsFromMessage(
+      assistant([
+        null,
+        { type: 'toolCall', id: 'x', name: 1, arguments: { path: 'bad.ts' } },
+        { type: 'toolCall', id: 'y', name: 'read', arguments: null },
+        { type: 'toolCall', id: 'z', name: 'other', arguments: { path: 'skip.ts' } },
+      ] as never) as AgentMessage,
+      fileOps,
+    );
+
+    expect(computeFileLists(fileOps)).toEqual({ readFiles: [], modifiedFiles: [] });
+  });
 });
 
 describe('formatFileOperations', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Lowers Sonar `typescript:S3776` cognitive complexity on `extractFileOpsFromMessage` in `packages/agent-core/src/harness/compaction/utils.ts` (issue key `a5ec1b78-593b-4cd8-94e2-d6d4898eb6a4`, reported as 17 vs allowed 15).
- Extracts `assistantContentBlocks` and `applyToolCallFileOp` so the accumulator stays ≤15 without changing file-op or compaction summarization behavior.
- Extends `compaction-utils` unit tests for non-assistant messages, missing content, and malformed tool-call blocks.
- Does **not** rework the L91 serialization hotspot (`serializeAssistantMessage` / #1040 / #1246).

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File | GitHub |
| --- | --- | --- | --- |
| `a5ec1b78-593b-4cd8-94e2-d6d4898eb6a4` | typescript:S3776 | `packages/agent-core/src/harness/compaction/utils.ts` | Closes #850 |

## Why this is safe
- Pure maintainability extract: same guards (`role === "assistant"`, array `content`), same tool-call validation, same `read`/`write`/`edit` path accumulation.
- No compaction rewrite, no API/IPC changes, no sonar ignore.
- New tests lock the previously thin edge-case paths around malformed blocks.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes (incl. `@dome/agent-core` compaction-utils, 6/6)
- [x] i18n keys — N/A
- [x] No hardcoded colors — N/A

Closes #850

Auto-merge (squash) enabled — merges after required checks pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64cc2183-03ca-4e06-99d0-cd942b3d577e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64cc2183-03ca-4e06-99d0-cd942b3d577e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

