### PR TITLE
fix(sonar): lower legacyMessagesToContext cognitive complexity (S3776)

### DIFF
--- a/packages/ai/src/legacy-bridge.test.ts
+++ b/packages/ai/src/legacy-bridge.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { legacyMessagesToContext, mapThinkingLevel } from './legacy-bridge.js';
+
+describe('mapThinkingLevel', () => {
+  it('maps known levels and rejects off/unknown', () => {
+    expect(mapThinkingLevel(undefined)).toBeUndefined();
+    expect(mapThinkingLevel('off')).toBeUndefined();
+    expect(mapThinkingLevel('medium')).toBe('medium');
+    expect(mapThinkingLevel('bogus')).toBeUndefined();
+  });
+});
+
+describe('legacyMessagesToContext', () => {
+  it('skips system, nullish entries, and empty systemPrompt', () => {
+    const ctx = legacyMessagesToContext('', [
+      null as never,
+      { role: 'system', content: 'ignore' },
+      { role: 'user', content: 'hi' },
+    ]);
+    expect(ctx.systemPrompt).toBeUndefined();
+    expect(ctx.messages).toHaveLength(1);
+    expect(ctx.messages[0]).toMatchObject({ role: 'user', content: 'hi' });
+  });
+
+  it('appends data-url images from user attachments', () => {
+    const ctx = legacyMessagesToContext('sys', [
+      {
+        role: 'user',
+        content: 'caption',
+        attachments: {
+          images: [
+            { dataUrl: 'data:image/png;base64,abc' },
+            { dataUrl: 'not-a-data-url' },
+          ],
+        },
+      },
+    ]);
+    const msg = ctx.messages[0]!;
+    expect(msg.role).toBe('user');
+    expect(Array.isArray(msg.content)).toBe(true);
+    expect(msg.content).toEqual([
+      { type: 'text', text: 'caption' },
+      { type: 'image', mimeType: 'image/png', data: 'abc' },
+    ]);
+    expect(ctx.systemPrompt).toBe('sys');
+  });
+
+  it('converts assistant tool calls and tool results', () => {
+    const ctx = legacyMessagesToContext('p', [
+      {
+        role: 'assistant',
+        text: 'calling',
+        toolCalls: [{ id: 'c1', name: 'search', arguments: { q: 'x' } }],
+      },
+      { role: 'tool', toolCallId: 'c1', name: 'search', content: { ok: true } },
+      { role: 'toolResult', content: 'done' },
+    ]);
+    expect(ctx.messages).toHaveLength(3);
+    expect(ctx.messages[0]).toMatchObject({
+      role: 'assistant',
+      stopReason: 'toolUse',
+    });
+    expect(ctx.messages[1]).toMatchObject({
+      role: 'toolResult',
+      toolCallId: 'c1',
+      toolName: 'search',
+      content: [{ type: 'text', text: '{"ok":true}' }],
+    });
+    expect(ctx.messages[2]).toMatchObject({
+      role: 'toolResult',
+      toolCallId: 'tool',
+      toolName: 'tool',
+      content: [{ type: 'text', text: 'done' }],
+    });
+  });
+
+  it('treats non-standard roles with text as assistant-like', () => {
+    const ctx = legacyMessagesToContext('', [{ role: 'model', text: 'hello' } as never]);
+    expect(ctx.messages).toHaveLength(1);
+    expect(ctx.messages[0]).toMatchObject({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'hello' }],
+      stopReason: 'stop',
+    });
+  });
+
+  it('maps tool schemas onto context tools', () => {
+    const ctx = legacyMessagesToContext('x', [], [
+      {
+        type: 'function',
+        function: {
+          name: 'ping',
+          description: 'pong',
+          parameters: { type: 'object', properties: {} },
+        },
+      },
+    ]);
+    expect(ctx.tools).toHaveLength(1);
+    expect(ctx.tools![0]).toMatchObject({ name: 'ping', description: 'pong' });
+  });
+});

--- a/packages/ai/src/legacy-bridge.ts
+++ b/packages/ai/src/legacy-bridge.ts
@@ -19,6 +19,8 @@ type LegacyMessage = {
   };
 };
 
+type LegacyImageAttachment = NonNullable<NonNullable<LegacyMessage['attachments']>['images']>[number];
+
 function contentToUserContent(content: unknown): UserMessage['content'] {
   if (typeof content === 'string') return content;
   if (Array.isArray(content)) {
@@ -93,6 +95,80 @@ export function mapThinkingLevel(
   return undefined;
 }
 
+function ensureUserContentBlocks(content: UserMessage['content']): UserMessage['content'] {
+  if (typeof content !== 'string') return content;
+  return content ? [{ type: 'text' as const, text: content }] : [];
+}
+
+function appendDataUrlImages(
+  content: UserMessage['content'],
+  images: LegacyImageAttachment[],
+): UserMessage['content'] {
+  const blocks = ensureUserContentBlocks(content);
+  if (!Array.isArray(blocks)) return content;
+  for (const img of images) {
+    const match = /^data:([^;]+);base64,(.+)$/.exec(img.dataUrl || '');
+    if (match) {
+      blocks.push({ type: 'image' as const, mimeType: match[1]!, data: match[2]! });
+    }
+  }
+  return blocks;
+}
+
+function legacyUserToMessage(m: LegacyMessage, timestamp: number): UserMessage {
+  let content = contentToUserContent(m.content);
+  const images = m.attachments?.images;
+  if (images?.length) {
+    content = appendDataUrlImages(content, images);
+  }
+  return {
+    role: 'user',
+    content,
+    timestamp,
+  };
+}
+
+function isLegacyAssistantLike(m: LegacyMessage): boolean {
+  if (m.role === 'assistant') return true;
+  return 'text' in m && m.role !== 'user' && m.role !== 'tool' && m.role !== 'toolResult';
+}
+
+function toolResultText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  return JSON.stringify(content ?? '');
+}
+
+function legacyToolToMessage(m: LegacyMessage, timestamp: number): ToolResultMessage {
+  return {
+    role: 'toolResult',
+    toolCallId: m.toolCallId || 'tool',
+    toolName: m.name || 'tool',
+    content: [{ type: 'text', text: toolResultText(m.content) }],
+    isError: false,
+    timestamp,
+  };
+}
+
+/** Convert one legacy chat message into context messages (may append zero or one). */
+function appendLegacyMessage(m: LegacyMessage, contextMessages: Message[], now: number): void {
+  if (!m || typeof m !== 'object') return;
+  if (m.role === 'system') return;
+
+  if (m.role === 'user') {
+    contextMessages.push(legacyUserToMessage(m, now));
+    return;
+  }
+
+  if (isLegacyAssistantLike(m)) {
+    contextMessages.push(legacyAssistantToMessage(m, now));
+    return;
+  }
+
+  if (m.role === 'tool' || m.role === 'toolResult') {
+    contextMessages.push(legacyToolToMessage(m, now));
+  }
+}
+
 export function legacyMessagesToContext(
   systemPrompt: string,
   messages: LegacyMessage[],
@@ -102,49 +178,7 @@ export function legacyMessagesToContext(
   const now = Date.now();
 
   for (const m of messages ?? []) {
-    if (!m || typeof m !== 'object') continue;
-    if (m.role === 'system') continue;
-
-    if (m.role === 'user') {
-      let content = contentToUserContent(m.content);
-      if (m.attachments?.images?.length) {
-        if (typeof content === 'string') {
-          content = content ? [{ type: 'text' as const, text: content }] : [];
-        }
-        if (Array.isArray(content)) {
-          for (const img of m.attachments.images) {
-            const url = img.dataUrl;
-            const match = /^data:([^;]+);base64,(.+)$/.exec(url || '');
-            if (match) {
-              content.push({ type: 'image' as const, mimeType: match[1]!, data: match[2]! });
-            }
-          }
-        }
-      }
-      contextMessages.push({
-        role: 'user',
-        content,
-        timestamp: now,
-      });
-      continue;
-    }
-
-    if (m.role === 'assistant' || ('text' in m && m.role !== 'user' && m.role !== 'tool' && m.role !== 'toolResult')) {
-      contextMessages.push(legacyAssistantToMessage(m, now));
-      continue;
-    }
-
-    if (m.role === 'tool' || m.role === 'toolResult') {
-      const toolMsg: ToolResultMessage = {
-        role: 'toolResult',
-        toolCallId: m.toolCallId || 'tool',
-        toolName: m.name || 'tool',
-        content: [{ type: 'text', text: typeof m.content === 'string' ? m.content : JSON.stringify(m.content ?? '') }],
-        isError: false,
-        timestamp: now,
-      };
-      contextMessages.push(toolMsg);
-    }
+    appendLegacyMessage(m, contextMessages, now);
   }
 
   return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactor `legacyMessagesToContext` in `packages/ai/src/legacy-bridge.ts` to drop Sonar cognitive complexity (typescript:S3776) from 42 to ≤15 by extracting per-role helpers (`legacyUserToMessage`, `appendDataUrlImages`, `isLegacyAssistantLike`, `legacyToolToMessage`, `appendLegacyMessage`).
- Behavior of legacy chat → agent `Context` conversion is unchanged; no Sonar ignore / no-op.
- Add `packages/ai/src/legacy-bridge.test.ts` covering skip/system, attachment images, tool results, assistant-like roles, and tool schemas.

| Sonar key | Rule | File | GitHub |
| --- | --- | --- | --- |
| `a606a158-7e45-465f-882b-b7256e5b1d55` | typescript:S3776 | `packages/ai/src/legacy-bridge.ts:96` | Closes #849 |

## Type
- [x] Refactor

## Why safe
Helpers preserve the same control flow and fallbacks (`toolCallId || 'tool'`, data-URL image parsing, assistant-like `'text' in m` branch). Unit tests lock the public conversion contract.

## Local validation
- `pnpm run typecheck` — pass
- `pnpm run lint` — pass (0 errors; pre-existing warnings only)
- `pnpm run test:coverage` — pass (incl. new `@dome/ai` legacy-bridge tests)

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test:coverage` passes
- [ ] i18n N/A
- [ ] No hardcoded colors N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72405e94-3280-4ff0-b582-bd20b6325c68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72405e94-3280-4ff0-b582-bd20b6325c68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

