### PR TITLE
fix(sonar): lower SidebarContextMenu cognitive complexity (S3776, #1316)

### DIFF
--- a/app/components/workspace/sidebar/SidebarContextMenu.test.tsx
+++ b/app/components/workspace/sidebar/SidebarContextMenu.test.tsx
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Resource } from '@/lib/hooks/useResources';
+import { FOLDER_COLOR_DEFAULT } from '@/lib/ui/palettes';
+import ContextMenu, {
+  buildSidebarMenuActions,
+  clampColorPickerPos,
+  resolveFolderPickerColor,
+} from './SidebarContextMenu';
+
+function makeResource(overrides: Partial<Resource> = {}): Resource {
+  return {
+    id: 'res-1',
+    title: 'Notes',
+    type: 'folder',
+    project_id: 'proj-1',
+    folder_id: null,
+    created_at: 0,
+    updated_at: 0,
+    ...overrides,
+  };
+}
+
+describe('clampColorPickerPos', () => {
+  const originalInnerWidth = window.innerWidth;
+  const originalInnerHeight = window.innerHeight;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1000 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight });
+  });
+
+  it('clamps left into the viewport with an 8px margin', () => {
+    expect(clampColorPickerPos(-50, 100)).toEqual({ top: 104, left: 8 });
+    expect(clampColorPickerPos(900, 100).left).toBe(1000 - 220 - 8);
+  });
+
+  it('keeps top within the lower viewport bound', () => {
+    expect(clampColorPickerPos(40, 900).top).toBe(800 - 120);
+  });
+});
+
+describe('resolveFolderPickerColor', () => {
+  it('returns hex colors unchanged and falls back otherwise', () => {
+    expect(resolveFolderPickerColor('#aabbcc')).toBe('#aabbcc');
+    expect(resolveFolderPickerColor('blue')).toBe(FOLDER_COLOR_DEFAULT);
+    expect(resolveFolderPickerColor(undefined)).toBe(FOLDER_COLOR_DEFAULT);
+  });
+});
+
+describe('buildSidebarMenuActions', () => {
+  it('wires folder actions and omits optional open handlers when absent', () => {
+    const r = makeResource({ type: 'folder' });
+    const onRename = vi.fn();
+    const onMove = vi.fn();
+    const onMoveToProject = vi.fn();
+    const onDelete = vi.fn();
+    const onNewFolder = vi.fn();
+    const openColorPicker = vi.fn();
+
+    const actions = buildSidebarMenuActions(
+      r,
+      true,
+      { onRename, onMove, onMoveToProject, onDelete, onNewFolder },
+      openColorPicker,
+    );
+
+    expect(actions.onOpenInSplit).toBeUndefined();
+    expect(actions.onOpenInWindow).toBeUndefined();
+    actions.onRename();
+    actions.onMoveToFolder?.();
+    actions.onMoveToProject();
+    actions.onChangeColor?.();
+    actions.onNewSubfolder?.();
+    actions.onDelete();
+
+    expect(onRename).toHaveBeenCalledWith(r);
+    expect(onMove).toHaveBeenCalledWith(r);
+    expect(onMoveToProject).toHaveBeenCalledWith(r);
+    expect(openColorPicker).toHaveBeenCalledTimes(1);
+    expect(onNewFolder).toHaveBeenCalledWith(r.id);
+    expect(onDelete).toHaveBeenCalledWith(r);
+  });
+
+  it('skips folder-only actions for non-folders and forwards open handlers', () => {
+    const r = makeResource({ type: 'pdf', title: 'Doc' });
+    const onOpenInSplit = vi.fn();
+    const onOpenInWindow = vi.fn();
+    const actions = buildSidebarMenuActions(
+      r,
+      false,
+      {
+        onRename: vi.fn(),
+        onMove: vi.fn(),
+        onMoveToProject: vi.fn(),
+        onDelete: vi.fn(),
+        onNewFolder: vi.fn(),
+        onOpenInSplit,
+        onOpenInWindow,
+      },
+      vi.fn(),
+    );
+
+    expect(actions.onChangeColor).toBeUndefined();
+    expect(actions.onNewSubfolder).toBeUndefined();
+    actions.onOpenInSplit?.();
+    actions.onOpenInWindow?.();
+    expect(onOpenInSplit).toHaveBeenCalledWith(r);
+    expect(onOpenInWindow).toHaveBeenCalledWith(r);
+  });
+});
+
+describe('ContextMenu', () => {
+  it('renders nothing when closed with no resource', () => {
+    const { container } = render(
+      <ContextMenu
+        state={{ visible: false, x: 0, y: 0, resource: null }}
+        onClose={vi.fn()}
+        onRename={vi.fn()}
+        onMove={vi.fn()}
+        onMoveToProject={vi.fn()}
+        onColorChange={vi.fn()}
+        onDelete={vi.fn()}
+        onNewFolder={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows rename for a visible resource menu', () => {
+    render(
+      <ContextMenu
+        state={{ visible: true, x: 12, y: 24, resource: makeResource({ title: 'Alpha' }) }}
+        onClose={vi.fn()}
+        onRename={vi.fn()}
+        onMove={vi.fn()}
+        onMoveToProject={vi.fn()}
+        onColorChange={vi.fn()}
+        onDelete={vi.fn()}
+        onNewFolder={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('menuitem', { name: /renombrar|rename/i })).toBeInTheDocument();
+  });
+});

--- a/app/components/workspace/sidebar/SidebarContextMenu.tsx
+++ b/app/components/workspace/sidebar/SidebarContextMenu.tsx
@@ -1,11 +1,13 @@
 /** Sidebar resource/folder context menu — shared items with folder tab view. */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { createPortal } from 'react-dom';
 import type { Resource } from '@/lib/hooks/useResources';
 import { FOLDER_COLOR_DEFAULT } from '@/lib/ui/palettes';
 import ColorPickerPopover from '@/components/shell/folder-tab/ColorPickerPopover';
-import ResourceContextMenuItems from '@/components/shell/folder-tab/ResourceContextMenuItems';
+import ResourceContextMenuItems, {
+  type ResourceContextMenuActions,
+} from '@/components/shell/folder-tab/ResourceContextMenuItems';
 import { parseMeta, type CtxState } from './sidebarHelpers';
 import '@/styles/folder-view.css';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
@@ -25,6 +27,139 @@ export interface ContextMenuProps {
   canOpenInSplit?: boolean;
 }
 
+/** Clamp color-picker popover to the viewport (same math as before). */
+export function clampColorPickerPos(x: number, y: number): { top: number; left: number } {
+  const popoverWidth = 220;
+  const left = Math.min(Math.max(8, x), window.innerWidth - popoverWidth - 8);
+  const top = Math.min(y + 4, window.innerHeight - 120);
+  return { top, left };
+}
+
+/** Hex folder color for the picker, else default swatch. */
+export function resolveFolderPickerColor(currentColor: string | undefined): string {
+  if (currentColor?.startsWith('#')) return currentColor;
+  return FOLDER_COLOR_DEFAULT;
+}
+
+type MenuActionHandlers = {
+  onRename: (r: Resource) => void;
+  onMove: (r: Resource) => void;
+  onMoveToProject: (r: Resource) => void;
+  onDelete: (r: Resource) => void;
+  onNewFolder: (parentId: string | null) => void;
+  onOpenInSplit?: (r: Resource) => void;
+  onOpenInWindow?: (r: Resource) => void;
+};
+
+/** Wire resource callbacks into ResourceContextMenuItems actions (extracted for S3776). */
+export function buildSidebarMenuActions(
+  r: Resource,
+  isFolder: boolean,
+  handlers: MenuActionHandlers,
+  openColorPicker: () => void,
+): ResourceContextMenuActions {
+  const { onRename, onMove, onMoveToProject, onDelete, onNewFolder, onOpenInSplit, onOpenInWindow } =
+    handlers;
+  return {
+    onRename: () => onRename(r),
+    onOpenInSplit: onOpenInSplit ? () => onOpenInSplit(r) : undefined,
+    onOpenInWindow: onOpenInWindow ? () => onOpenInWindow(r) : undefined,
+    onChangeColor: isFolder ? openColorPicker : undefined,
+    onMoveToFolder: () => onMove(r),
+    onMoveToProject: () => onMoveToProject(r),
+    onNewSubfolder: isFolder ? () => onNewFolder(r.id) : undefined,
+    onDelete: () => onDelete(r),
+  };
+}
+
+function useStickyMenuResource(state: CtxState): Resource | null {
+  const resourceRef = useRef<Resource | null>(null);
+  if (state.visible && state.resource) {
+    resourceRef.current = state.resource;
+  }
+  return state.resource ?? resourceRef.current;
+}
+
+function useColorPickerPos(
+  menuVisible: boolean,
+): [
+  { top: number; left: number } | null,
+  Dispatch<SetStateAction<{ top: number; left: number } | null>>,
+] {
+  const [colorPickerPos, setColorPickerPos] = useState<{ top: number; left: number } | null>(null);
+
+  useEffect(() => {
+    if (menuVisible) setColorPickerPos(null);
+  }, [menuVisible]);
+
+  useEffect(() => {
+    if (!colorPickerPos) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setColorPickerPos(null);
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [colorPickerPos]);
+
+  return [colorPickerPos, setColorPickerPos];
+}
+
+function SidebarMenuDropdown({
+  state,
+  resource,
+  isFolder,
+  canOpenInSplit,
+  openColorPicker,
+  onClose,
+  handlers,
+}: {
+  state: CtxState;
+  resource: Resource;
+  isFolder: boolean;
+  canOpenInSplit?: boolean;
+  openColorPicker: () => void;
+  onClose: () => void;
+  handlers: MenuActionHandlers;
+}) {
+  return (
+    <DropdownMenu
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DropdownMenuTrigger
+        nativeButton={false}
+        render={
+          <span
+            className="pointer-events-none fixed size-px"
+            style={{ top: state.y, left: state.x }}
+            aria-hidden
+          />
+        }
+      />
+      <DropdownMenuContent
+        align="start"
+        side="bottom"
+        sideOffset={0}
+        positionMethod="fixed"
+        className="dome-folder-view__row-menu w-auto p-1.5"
+      >
+        <ResourceContextMenuItems
+          resource={resource}
+          options={{
+            isFolder,
+            isNote: resource.type === 'note',
+            canOpenInSplit,
+          }}
+          actions={buildSidebarMenuActions(resource, isFolder, handlers, openColorPicker)}
+          onDismiss={onClose}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export default function ContextMenu({
   state,
   onClose,
@@ -38,93 +173,47 @@ export default function ContextMenu({
   onOpenInWindow,
   canOpenInSplit,
 }: ContextMenuProps) {
-  const resourceRef = useRef<Resource | null>(null);
-  const [colorPickerPos, setColorPickerPos] = useState<{ top: number; left: number } | null>(null);
+  const resource = useStickyMenuResource(state);
+  const [colorPickerPos, setColorPickerPos] = useColorPickerPos(state.visible);
 
-  if (state.visible && state.resource) {
-    resourceRef.current = state.resource;
-  }
-
-  useEffect(() => {
-    if (state.visible) setColorPickerPos(null);
-  }, [state.visible]);
-
-  useEffect(() => {
-    if (!colorPickerPos) return;
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setColorPickerPos(null);
-    };
-    document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
-  }, [colorPickerPos]);
-
-  const r = state.resource ?? resourceRef.current;
-  if (!r && !colorPickerPos) return null;
-  if (!r) return null;
-
-  const isFolder = r.type === 'folder';
-  const currentColor = parseMeta(r).color as string | undefined;
-
-  const openColorPicker = () => {
-    const popoverWidth = 220;
-    const left = Math.min(Math.max(8, state.x), window.innerWidth - popoverWidth - 8);
-    const top = Math.min(state.y + 4, window.innerHeight - 120);
-    setColorPickerPos({ top, left });
-  };
-
+  if (!resource && !colorPickerPos) return null;
+  if (!resource) return null;
   if (typeof document === 'undefined') return null;
 
-  // Portal the cursor anchor to `document.body` so `position: fixed` is viewport-relative
-  // (sidebar ancestors with overflow/transform would otherwise skew the anchor).
+  const isFolder = resource.type === 'folder';
+  const currentColor = parseMeta(resource).color as string | undefined;
+  const openColorPicker = () => {
+    setColorPickerPos(clampColorPickerPos(state.x, state.y));
+  };
+  const handlers: MenuActionHandlers = {
+    onRename,
+    onMove,
+    onMoveToProject,
+    onDelete,
+    onNewFolder,
+    onOpenInSplit,
+    onOpenInWindow,
+  };
+
   return createPortal(
     <>
       {state.visible && !colorPickerPos ? (
-        <DropdownMenu open onOpenChange={(open) => { if (!open) onClose(); }}>
-          <DropdownMenuTrigger
-            nativeButton={false}
-            render={
-              <span
-                className="pointer-events-none fixed size-px"
-                style={{ top: state.y, left: state.x }}
-                aria-hidden
-              />
-            }
-          />
-          <DropdownMenuContent
-            align="start"
-            side="bottom"
-            sideOffset={0}
-            positionMethod="fixed"
-            className="dome-folder-view__row-menu w-auto p-1.5"
-          >
-            <ResourceContextMenuItems
-              resource={r}
-              options={{
-                isFolder,
-                isNote: r.type === 'note',
-                canOpenInSplit,
-              }}
-              actions={{
-                onRename: () => onRename(r),
-                onOpenInSplit: onOpenInSplit ? () => onOpenInSplit(r) : undefined,
-                onOpenInWindow: onOpenInWindow ? () => onOpenInWindow(r) : undefined,
-                onChangeColor: isFolder ? openColorPicker : undefined,
-                onMoveToFolder: () => onMove(r),
-                onMoveToProject: () => onMoveToProject(r),
-                onNewSubfolder: isFolder ? () => onNewFolder(r.id) : undefined,
-                onDelete: () => onDelete(r),
-              }}
-              onDismiss={onClose}
-            />
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <SidebarMenuDropdown
+          state={state}
+          resource={resource}
+          isFolder={isFolder}
+          canOpenInSplit={canOpenInSplit}
+          openColorPicker={openColorPicker}
+          onClose={onClose}
+          handlers={handlers}
+        />
       ) : null}
 
       {colorPickerPos ? (
         <ColorPickerPopover
           pos={colorPickerPos}
-          currentColor={currentColor?.startsWith('#') ? currentColor : FOLDER_COLOR_DEFAULT}
-          onSave={(color) => onColorChange(r, color)}
+          currentColor={resolveFolderPickerColor(currentColor)}
+          onSave={(color) => onColorChange(resource, color)}
           onClose={() => setColorPickerPos(null)}
         />
       ) : null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactor `ContextMenu` in `SidebarContextMenu.tsx` (Sonar `typescript:S3776`, key `afdf0ccc-7da7-4149-982e-826f395e243c`) by extracting pure helpers (`clampColorPickerPos`, `resolveFolderPickerColor`, `buildSidebarMenuActions`), hooks (`useStickyMenuResource`, `useColorPickerPos`), and `SidebarMenuDropdown` so the reported function stays at or below complexity 15.
- Behavior is unchanged: same portal/dropdown wiring, color-picker positioning, Escape-to-close, and `ResourceContextMenuItems` actions.
- Adds focused unit tests for helpers and basic menu render (repo pattern for workspace S3776 fixes).

## Sonar

| Key | Rule | File | Issue |
| --- | --- | --- | --- |
| afdf0ccc-7da7-4149-982e-826f395e243c | typescript:S3776 | `SidebarContextMenu.tsx:28` | #1316 |

Closes #1316

## Type
- [x] Refactor

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test:coverage` passes
- [x] No new user-visible strings / i18n
- [x] No hardcoded colors added

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98cf80ca-396d-43f4-a915-513c06d6b43c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98cf80ca-396d-43f4-a915-513c06d6b43c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

