### PR TITLE
fix(sonar): lower firstStringish cognitive complexity (S3776, #1314)

### DIFF
--- a/app/lib/hooks/useResourceVisualPreview.ts
+++ b/app/lib/hooks/useResourceVisualPreview.ts
@@ -212,20 +212,41 @@ function setBounded<K, V>(map: Map<K, V>, key: K, value: V): void {
   }
 }
 
+/** Depth-gated entry for artifact snippet extraction — kept trivial for S3776. */
 function firstStringish(value: unknown, depth = 0): string | null {
   if (depth > 4 || value == null) return null;
-  if (typeof value === 'string') return nonEmptyString(value);
-  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
-  if (Array.isArray(value)) return firstStringishFromValues(value, depth);
-  if (typeof value === 'object') {
-    return firstStringishFromValues(Object.values(value as Record<string, unknown>), depth);
+  return coerceFirstStringish(value, depth);
+}
+
+/** Dispatch by typeof — extracted so `firstStringish` stays under S3776. */
+function coerceFirstStringish(value: NonNullable<unknown>, depth: number): string | null {
+  switch (typeof value) {
+    case 'string':
+      return nonEmptyString(value);
+    case 'number':
+      return finiteNumberString(value);
+    case 'object':
+      return firstStringishFromObject(value, depth);
+    default:
+      return null;
   }
-  return null;
 }
 
 function nonEmptyString(value: string): string | null {
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function finiteNumberString(value: number): string | null {
+  return Number.isFinite(value) ? String(value) : null;
+}
+
+/** Arrays and plain objects share the same depth-first string walk. */
+function firstStringishFromObject(value: object, depth: number): string | null {
+  const values = Array.isArray(value)
+    ? value
+    : Object.values(value as Record<string, unknown>);
+  return firstStringishFromValues(values, depth);
 }
 
 function firstStringishFromValues(values: unknown[], depth: number): string | null {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Lower Sonar cognitive complexity (`typescript:S3776`) for `firstStringish` in `useResourceVisualPreview.ts` by extracting typeof dispatch (`coerceFirstStringish`), finite-number coercion, and object/array walks into small helpers.
- Preview loading behavior is unchanged: same depth cap, string/number/object/array walk order, and empty-string rejection used when building artifact card snippets.

| Sonar key | Rule | File | Closes |
| --- | --- | --- | --- |
| `b4ae1399-f31a-495e-b861-5aa80a047112` | typescript:S3776 | `app/lib/hooks/useResourceVisualPreview.ts` | #1314 |

Closes #1314

## Why this is safe
- Pure control-flow extraction only: `firstStringish` still returns the first non-empty stringish value within depth 4.
- No changes to `fetchPdfPreview` / `fetchArtifactPreview` / `fetchResourceDetail` or the hook’s IntersectionObserver gating.
- No new UI strings or caller API changes.

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs / config

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors; pre-existing warnings elsewhere)
- [x] `pnpm run test:coverage` passes (electron 142, renderer 160, agent-core 67, ai 45)
- [x] i18n keys — N/A
- [x] No hardcoded colors
- [x] No unrelated files touched
- [x] Auto-merge (squash) enabled after required checks pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40c7a4ab-b5cb-43a9-95ae-8ae02f0501f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40c7a4ab-b5cb-43a9-95ae-8ae02f0501f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

