### PR TITLE
fix(sonar): lower PipelineCard cognitive complexity (S3776, #820)

### DIFF
--- a/app/components/pipelines/PipelineCard.tsx
+++ b/app/components/pipelines/PipelineCard.tsx
@@ -15,7 +15,7 @@ import {
   UserIcon,
   ZapIcon,
 } from '@hugeicons/core-free-icons';
-import type { PipelineItem, PipelineStage, ExecStatus } from '@/lib/pipelines/types';
+import type { AssignedKind, PipelineItem, PipelineStage, ExecStatus } from '@/lib/pipelines/types';
 import { PIPELINE_ITEM_DRAG_TYPE } from '@/lib/pipelines/types';
 import { usePipelinesStore } from '@/lib/store/usePipelinesStore';
 import { cn } from '@/lib/utils';
@@ -27,6 +27,12 @@ const STATUS_BADGE: Record<ExecStatus, 'outline' | 'mint' | 'lime' | 'destructiv
   failed: 'destructive',
   blocked: 'secondary',
 };
+
+const ASSIGNED_ICONS = {
+  agent: BotIcon,
+  auto: ZapIcon,
+  manual: UserIcon,
+} as const;
 
 function formatDate(ms?: number | null): string | null {
   if (!ms) return null;
@@ -53,6 +59,212 @@ function toPreviewText(md: string): string {
     .trim();
 }
 
+/** Icon for assigned kind — extracted so PipelineCard stays under S3776. */
+function assignedIconFor(kind: AssignedKind) {
+  switch (kind) {
+    case 'agent':
+    case 'auto':
+    case 'manual':
+      return ASSIGNED_ICONS[kind];
+    case 'unassigned':
+      return null;
+    default: {
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
+  }
+}
+
+/** Todo progress from item payload — extracted for S3776. */
+function todoCounts(data: Record<string, unknown> | null | undefined): { done: number; total: number } {
+  if (!Array.isArray(data?.todos)) return { done: 0, total: 0 };
+  const todos = data.todos as Array<{ done?: boolean }>;
+  return { done: todos.filter((td) => td?.done).length, total: todos.length };
+}
+
+/** Compact data.text preview — extracted for S3776. */
+function dataPreviewText(data: Record<string, unknown> | null | undefined): string | null {
+  if (typeof data?.text !== 'string') return null;
+  if (data.text.trim().length === 0) return null;
+  return toPreviewText(data.text);
+}
+
+/** Last-output snippet when run finished — extracted for S3776. */
+function lastOutputSnippetFor(item: PipelineItem, isRunning: boolean): string | null {
+  if (isRunning) return null;
+  if (item.execStatus !== 'failed' && item.execStatus !== 'ready') return null;
+  if (typeof item.lastOutput !== 'string') return null;
+  if (item.lastOutput.trim().length === 0) return null;
+  return toPreviewText(item.lastOutput).slice(0, 80);
+}
+
+function stageAllowsRun(stage: PipelineStage | undefined, isRunning: boolean): boolean {
+  return stage?.executionPolicy === 'manual_agent' && !isRunning;
+}
+
+function stageAllowsResolve(stage: PipelineStage | undefined, execStatus: ExecStatus): boolean {
+  return stage?.executionPolicy === 'manual_resolve' && execStatus !== 'ready';
+}
+
+/** Title + todo badge + spinner — extracted for S3776. */
+function PipelineCardTitleRow({
+  title,
+  todoDone,
+  todoTotal,
+  isRunning,
+}: {
+  title: string;
+  todoDone: number;
+  todoTotal: number;
+  isRunning: boolean;
+}) {
+  return (
+    <div className="flex items-start gap-1.5">
+      <HugeiconsIcon
+        icon={GripVerticalIcon}
+        className="mt-0.5 size-3 shrink-0 text-muted-foreground"
+        aria-hidden
+      />
+      <span className="min-w-0 flex-1 text-sm font-medium leading-snug text-foreground">{title}</span>
+      {todoTotal > 0 ? (
+        <Badge variant="outline" className="shrink-0 gap-0.5 tabular-nums">
+          <HugeiconsIcon icon={CheckmarkSquare02Icon} className="size-3" />
+          {todoDone}/{todoTotal}
+        </Badge>
+      ) : null}
+      {isRunning ? (
+        <HugeiconsIcon
+          icon={Loading03Icon}
+          className="mt-0.5 size-3.5 shrink-0 animate-spin text-primary"
+          aria-hidden
+        />
+      ) : null}
+    </div>
+  );
+}
+
+type Translate = (key: string) => string;
+
+/** Status / assignee / due meta — extracted for S3776. */
+function PipelineCardMetaRow({
+  displayStatus,
+  assignedIcon,
+  agentName,
+  assignedKind,
+  due,
+  t,
+}: {
+  displayStatus: ExecStatus;
+  assignedIcon: (typeof ASSIGNED_ICONS)[keyof typeof ASSIGNED_ICONS] | null;
+  agentName?: string;
+  assignedKind: AssignedKind;
+  due: string | null;
+  t: Translate;
+}) {
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-1.5 pl-4">
+      <Badge variant={STATUS_BADGE[displayStatus]} className="font-normal">
+        {t(`pipelines.status_${displayStatus}`)}
+      </Badge>
+      {assignedIcon ? (
+        <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground">
+          <HugeiconsIcon icon={assignedIcon} className="size-3" />
+          <span className="max-w-[7rem] truncate">
+            {agentName ?? t(`pipelines.assigned_${assignedKind}`)}
+          </span>
+        </span>
+      ) : null}
+      {due ? (
+        <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground">
+          <HugeiconsIcon icon={Calendar03Icon} className="size-2.5" />
+          {due}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/** Data + last-output previews — extracted for S3776. */
+function PipelineCardSnippets({
+  dataText,
+  lastOutputSnippet,
+  lastOutput,
+}: {
+  dataText: string | null;
+  lastOutputSnippet: string | null;
+  lastOutput?: string | null;
+}) {
+  if (!dataText && !lastOutputSnippet) return null;
+  return (
+    <div className="mt-1.5 flex flex-col gap-1 pl-4">
+      {dataText ? (
+        <span className="line-clamp-2 text-[11px] leading-snug text-muted-foreground" title={dataText}>
+          {dataText}
+        </span>
+      ) : null}
+      {lastOutputSnippet ? (
+        <span
+          className="inline-flex items-center gap-1 truncate text-[11px] leading-snug text-muted-foreground"
+          title={lastOutput ?? undefined}
+        >
+          <HugeiconsIcon icon={Comment01Icon} className="size-2.5 shrink-0" aria-hidden />
+          {lastOutputSnippet}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/** Run / resolve actions — extracted for S3776. */
+function PipelineCardActions({
+  canRun,
+  canResolve,
+  onRun,
+  onResolve,
+  t,
+}: {
+  canRun: boolean;
+  canResolve: boolean;
+  onRun: () => void;
+  onResolve: () => void;
+  t: Translate;
+}) {
+  if (!canRun && !canResolve) return null;
+  return (
+    <div className="mt-2 flex items-center justify-end gap-1">
+      {canRun ? (
+        <Button
+          type="button"
+          size="xs"
+          draggable={false}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRun();
+          }}
+        >
+          <HugeiconsIcon icon={PlayIcon} data-icon="inline-start" />
+          {t('pipelines.run_now')}
+        </Button>
+      ) : null}
+      {canResolve ? (
+        <Button
+          type="button"
+          size="xs"
+          variant="outline"
+          draggable={false}
+          onClick={(e) => {
+            e.stopPropagation();
+            onResolve();
+          }}
+        >
+          <HugeiconsIcon icon={CheckIcon} data-icon="inline-start" />
+          {t('pipelines.resolve')}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
 interface Props {
   item: PipelineItem;
   stage: PipelineStage | undefined;
@@ -76,33 +288,12 @@ export default function PipelineCard({ item, stage, agentName, onOpen, onRun, on
   };
 
   const due = formatDate(item.endAt) ?? formatDate(item.startAt);
-  const canRun = stage?.executionPolicy === 'manual_agent' && !isRunning;
-  const canResolve = stage?.executionPolicy === 'manual_resolve' && item.execStatus !== 'ready';
-
-  const assignedIcon =
-    item.assignedKind === 'agent'
-      ? BotIcon
-      : item.assignedKind === 'auto'
-        ? ZapIcon
-        : item.assignedKind === 'manual'
-          ? UserIcon
-          : null;
-
-  const todos = Array.isArray(item.data?.todos) ? (item.data!.todos as Array<{ done?: boolean }>) : [];
-  const todoTotal = todos.length;
-  const todoDone = todos.filter((td) => td?.done).length;
-
-  const dataText =
-    typeof item.data?.text === 'string' && item.data.text.trim().length > 0
-      ? toPreviewText(item.data.text)
-      : null;
-
-  const showLastOutput =
-    !isRunning &&
-    (item.execStatus === 'failed' || item.execStatus === 'ready') &&
-    typeof item.lastOutput === 'string' &&
-    item.lastOutput.trim().length > 0;
-  const lastOutputSnippet = showLastOutput ? toPreviewText(item.lastOutput!).slice(0, 80) : null;
+  const canRun = stageAllowsRun(stage, isRunning);
+  const canResolve = stageAllowsResolve(stage, item.execStatus);
+  const assignedIcon = assignedIconFor(item.assignedKind);
+  const { done: todoDone, total: todoTotal } = todoCounts(item.data);
+  const dataText = dataPreviewText(item.data);
+  const lastOutputSnippet = lastOutputSnippetFor(item, isRunning);
 
   const onKeyActivate = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -130,102 +321,32 @@ export default function PipelineCard({ item, stage, agentName, onOpen, onRun, on
         'active:cursor-grabbing',
       )}
     >
-      <div className="flex items-start gap-1.5">
-        <HugeiconsIcon
-          icon={GripVerticalIcon}
-          className="mt-0.5 size-3 shrink-0 text-muted-foreground"
-          aria-hidden
-        />
-        <span className="min-w-0 flex-1 text-sm font-medium leading-snug text-foreground">
-          {item.title}
-        </span>
-        {todoTotal > 0 ? (
-          <Badge variant="outline" className="shrink-0 gap-0.5 tabular-nums">
-            <HugeiconsIcon icon={CheckmarkSquare02Icon} className="size-3" />
-            {todoDone}/{todoTotal}
-          </Badge>
-        ) : null}
-        {isRunning ? (
-          <HugeiconsIcon
-            icon={Loading03Icon}
-            className="mt-0.5 size-3.5 shrink-0 animate-spin text-primary"
-            aria-hidden
-          />
-        ) : null}
-      </div>
-
-      <div className="mt-2 flex flex-wrap items-center gap-1.5 pl-4">
-        <Badge variant={STATUS_BADGE[displayStatus]} className="font-normal">
-          {t(`pipelines.status_${displayStatus}`)}
-        </Badge>
-        {assignedIcon ? (
-          <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground">
-            <HugeiconsIcon icon={assignedIcon} className="size-3" />
-            <span className="max-w-[7rem] truncate">
-              {agentName ?? t(`pipelines.assigned_${item.assignedKind}`)}
-            </span>
-          </span>
-        ) : null}
-        {due ? (
-          <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground">
-            <HugeiconsIcon icon={Calendar03Icon} className="size-2.5" />
-            {due}
-          </span>
-        ) : null}
-      </div>
-
-      {dataText || lastOutputSnippet ? (
-        <div className="mt-1.5 flex flex-col gap-1 pl-4">
-          {dataText ? (
-            <span className="line-clamp-2 text-[11px] leading-snug text-muted-foreground" title={dataText}>
-              {dataText}
-            </span>
-          ) : null}
-          {lastOutputSnippet ? (
-            <span
-              className="inline-flex items-center gap-1 truncate text-[11px] leading-snug text-muted-foreground"
-              title={item.lastOutput ?? undefined}
-            >
-              <HugeiconsIcon icon={Comment01Icon} className="size-2.5 shrink-0" aria-hidden />
-              {lastOutputSnippet}
-            </span>
-          ) : null}
-        </div>
-      ) : null}
-
-      {canRun || canResolve ? (
-        <div className="mt-2 flex items-center justify-end gap-1">
-          {canRun ? (
-            <Button
-              type="button"
-              size="xs"
-              draggable={false}
-              onClick={(e) => {
-                e.stopPropagation();
-                onRun();
-              }}
-            >
-              <HugeiconsIcon icon={PlayIcon} data-icon="inline-start" />
-              {t('pipelines.run_now')}
-            </Button>
-          ) : null}
-          {canResolve ? (
-            <Button
-              type="button"
-              size="xs"
-              variant="outline"
-              draggable={false}
-              onClick={(e) => {
-                e.stopPropagation();
-                onResolve();
-              }}
-            >
-              <HugeiconsIcon icon={CheckIcon} data-icon="inline-start" />
-              {t('pipelines.resolve')}
-            </Button>
-          ) : null}
-        </div>
-      ) : null}
+      <PipelineCardTitleRow
+        title={item.title}
+        todoDone={todoDone}
+        todoTotal={todoTotal}
+        isRunning={isRunning}
+      />
+      <PipelineCardMetaRow
+        displayStatus={displayStatus}
+        assignedIcon={assignedIcon}
+        agentName={agentName}
+        assignedKind={item.assignedKind}
+        due={due}
+        t={t}
+      />
+      <PipelineCardSnippets
+        dataText={dataText}
+        lastOutputSnippet={lastOutputSnippet}
+        lastOutput={item.lastOutput}
+      />
+      <PipelineCardActions
+        canRun={canRun}
+        canResolve={canResolve}
+        onRun={onRun}
+        onResolve={onResolve}
+        t={t}
+      />
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reduce cognitive complexity of `PipelineCard` (typescript:S3776, Sonar key `acc7d24a-261c-4916-a93e-bf4c6b22c961`) by extracting pure helpers (`assignedIconFor`, `todoCounts`, `dataPreviewText`, `lastOutputSnippetFor`, stage allow helpers) and presentational subcomponents (`PipelineCardTitleRow`, `PipelineCardMetaRow`, `PipelineCardSnippets`, `PipelineCardActions`).
- UI markup, i18n keys, drag/keyboard handlers, and run/resolve gating are unchanged — maintainability-only refactor.

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File | GitHub |
| --- | --- | --- | --- |
| `acc7d24a-261c-4916-a93e-bf4c6b22c961` | typescript:S3776 | `app/components/pipelines/PipelineCard.tsx` | Closes #820 |

## Why safe
- Same props and callbacks; same conditional visibility for todos, spinner, assignee, due date, snippets, and action buttons.
- No pipelines board / store / IPC changes.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test:coverage` passes
- [ ] i18n keys added in all 4 languages (en, es, fr, pt) if new user-visible strings
- [x] No hardcoded colors (CSS variables only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c631e3f-ce7d-4a70-a82c-32e69807d821?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c631e3f-ce7d-4a70-a82c-32e69807d821&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

