### PR TITLE
fix(sonar): lower parseSpreadsheetSnippet cognitive complexity (S3776, #818)

### DIFF
--- a/app/components/shell/folder-tab/FolderCard.tsx
+++ b/app/components/shell/folder-tab/FolderCard.tsx
@@ -222,41 +222,65 @@ type SheetPreview = {
   rows: string[][];
 };
 
+const SHEET_HEADER_RE = /^\[Sheet:\s*([^\]]+)\]\s*/i;
+
+function splitSnippetCells(line: string): string[] {
+  return line.split(',').map((c) => c.trim()).slice(0, 4);
+}
+
+/** Strip optional `[Sheet: name]` prefix; null if body is empty. */
+function spreadsheetBodyAndSheet(
+  trimmed: string,
+): { sheet: string | null; body: string } | null {
+  const sheetMatch = trimmed.match(SHEET_HEADER_RE);
+  const body = (sheetMatch ? trimmed.slice(sheetMatch[0].length) : trimmed).trim();
+  if (!body) return null;
+  return { sheet: sheetMatch?.[1]?.trim() ?? null, body };
+}
+
+/** Newline rows, or flattened dumps: "headers 1,row… 2,row…". */
+function spreadsheetSnippetLines(body: string): string[] {
+  let lines = body.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  if (lines.length < 2) {
+    lines = body.split(/\s+(?=\d+,)/).map((l) => l.trim()).filter(Boolean);
+  }
+  return lines;
+}
+
+/** Align cells to header width; drop leading numeric index when present. */
+function alignSpreadsheetRow(line: string, headerCount: number): string[] {
+  const cells = splitSnippetCells(line);
+  if (cells.length > headerCount && /^\d+$/.test(cells[0] ?? '')) {
+    return cells.slice(1, headerCount + 1);
+  }
+  return cells.slice(0, headerCount);
+}
+
+function parseSpreadsheetRows(lines: string[], headers: string[]): string[][] {
+  return lines
+    .slice(1, 4)
+    .map((line) => alignSpreadsheetRow(line, headers.length))
+    .filter((r) => r.some(Boolean));
+}
+
 /** Turn a spreadsheet text dump into a small table preview. */
 function parseSpreadsheetSnippet(snippet: string): SheetPreview | null {
   const trimmed = snippet.trim();
   if (!trimmed) return null;
 
-  const sheetMatch = trimmed.match(/^\[Sheet:\s*([^\]]+)\]\s*/i);
-  const body = (sheetMatch ? trimmed.slice(sheetMatch[0].length) : trimmed).trim();
-  if (!body) return null;
+  const extracted = spreadsheetBodyAndSheet(trimmed);
+  if (!extracted) return null;
 
-  let lines = body.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
-  if (lines.length < 2) {
-    // Flattened dumps: "headers 1,row… 2,row…"
-    lines = body.split(/\s+(?=\d+,)/).map((l) => l.trim()).filter(Boolean);
-  }
+  const lines = spreadsheetSnippetLines(extracted.body);
   if (lines.length === 0) return null;
 
-  const splitCells = (line: string) =>
-    line.split(',').map((c) => c.trim()).slice(0, 4);
-
-  const headers = splitCells(lines[0]).slice(0, 3);
+  const headers = splitSnippetCells(lines[0]).slice(0, 3);
   if (headers.length === 0) return null;
 
-  const rows = lines.slice(1, 4).map((line) => {
-    const cells = splitCells(line);
-    // Drop leading numeric index column when headers don't look like an ID list
-    if (cells.length > headers.length && /^\d+$/.test(cells[0] ?? '')) {
-      return cells.slice(1, headers.length + 1);
-    }
-    return cells.slice(0, headers.length);
-  }).filter((r) => r.some(Boolean));
-
   return {
-    sheet: sheetMatch?.[1]?.trim() ?? null,
+    sheet: extracted.sheet,
     headers,
-    rows,
+    rows: parseSpreadsheetRows(lines, headers),
   };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `parseSpreadsheetSnippet` in `FolderCard.tsx` (~L220) to drop Sonar typescript:S3776 cognitive complexity (21 → ≤15) without changing spreadsheet thumb preview behavior.
- Extracts `spreadsheetBodyAndSheet`, `spreadsheetSnippetLines`, `alignSpreadsheetRow`, `parseSpreadsheetRows`, and `splitSnippetCells` — same parse order and outputs (sheet label, headers, rows with leading numeric index dropped when present).
- Does **not** touch `CoverPreviewContent` (#918/#1298) or `FolderCardImpl` (#925/#1295); only the L220 `parseSpreadsheetSnippet` hotspot from #818.

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File | GitHub |
| --- | --- | --- | --- |
| `ad6714a2-00df-4322-bdd0-b813007ced9c` | typescript:S3776 | `app/components/shell/folder-tab/FolderCard.tsx:220` | Closes #818 |

## Why this is safe
Pure maintainability extract: control flow moved to named helpers with identical conditions and cell slicing. No UI redesign, no sonar ignore, no behavioral change to folder-tab cards.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test:coverage` passes
- [x] No new i18n keys
- [x] No hardcoded colors

Closes #818

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36175bb7-4e9c-4d5c-928f-c58eabf5d810?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36175bb7-4e9c-4d5c-928f-c58eabf5d810&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

