### PR TITLE
fix(sonar): reduce loadStoredTabs cognitive complexity (#810)

### DIFF
--- a/app/lib/store/useTabStore.test.ts
+++ b/app/lib/store/useTabStore.test.ts
@@ -1,5 +1,15 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { HOME_TAB_ID, useTabStore } from './useTabStore';
+import {
+  HOME_TAB_ID,
+  ensureHomeTab,
+  filterTabsForActiveProject,
+  resolveStoredActiveTabId,
+  tabsFromParsedPayload,
+  useTabStore,
+  type DomeTab,
+} from './useTabStore';
+
+const HOME: DomeTab = { id: HOME_TAB_ID, type: 'home', title: 'Home', pinned: true };
 
 describe('useTabStore', () => {
   beforeEach(() => {
@@ -12,5 +22,59 @@ describe('useTabStore', () => {
     useTabStore.getState().closeTab('note:1');
     expect(useTabStore.getState().tabs.map((tab) => tab.id)).toEqual([HOME_TAB_ID]);
     expect(useTabStore.getState().activeTabId).toBe(HOME_TAB_ID);
+  });
+});
+
+describe('loadStoredTabs helpers (S3776)', () => {
+  const foreignNote: DomeTab = {
+    id: 'note:x',
+    type: 'note',
+    title: 'X',
+    resourceId: 'x',
+    projectId: 'project-b',
+  };
+  const settings: DomeTab = { id: 'settings', type: 'settings', title: 'Settings' };
+
+  it('filterTabsForActiveProject drops foreign project-scoped tabs only', () => {
+    const tabs = [HOME, foreignNote, settings];
+    expect(filterTabsForActiveProject(tabs).map((t) => t.id)).toEqual([
+      HOME_TAB_ID,
+      'note:x',
+      'settings',
+    ]);
+    expect(filterTabsForActiveProject(tabs, 'project-a').map((t) => t.id)).toEqual([
+      HOME_TAB_ID,
+      'settings',
+    ]);
+    expect(filterTabsForActiveProject(tabs, 'project-b').map((t) => t.id)).toEqual([
+      HOME_TAB_ID,
+      'note:x',
+      'settings',
+    ]);
+  });
+
+  it('ensureHomeTab prepends Home when missing', () => {
+    expect(ensureHomeTab([settings]).map((t) => t.id)).toEqual([HOME_TAB_ID, 'settings']);
+    expect(ensureHomeTab([HOME, settings])).toEqual([HOME, settings]);
+  });
+
+  it('resolveStoredActiveTabId falls back to Home when missing', () => {
+    const tabs = [HOME, settings];
+    expect(resolveStoredActiveTabId(tabs, 'settings')).toBe('settings');
+    expect(resolveStoredActiveTabId(tabs, 'gone')).toBe(HOME_TAB_ID);
+    expect(resolveStoredActiveTabId(tabs, null)).toBe(HOME_TAB_ID);
+  });
+
+  it('tabsFromParsedPayload restores empty and filtered payloads safely', () => {
+    expect(tabsFromParsedPayload({ tabs: [] })).toEqual({
+      tabs: [HOME],
+      activeTabId: HOME_TAB_ID,
+    });
+    const restored = tabsFromParsedPayload(
+      { tabs: [foreignNote, settings], activeTabId: 'note:x' },
+      'project-a',
+    );
+    expect(restored.tabs.map((t) => t.id)).toEqual([HOME_TAB_ID, 'settings']);
+    expect(restored.activeTabId).toBe(HOME_TAB_ID);
   });
 });

--- a/app/lib/store/useTabStore.ts
+++ b/app/lib/store/useTabStore.ts
@@ -165,40 +165,68 @@ function generateTabId() {
 
 const STORAGE_KEY = 'dome:tabs-v1';
 
+function defaultTabsState(): { tabs: DomeTab[]; activeTabId: string } {
+  return { tabs: [HOME_TAB], activeTabId: HOME_TAB_ID };
+}
+
+/**
+ * Drop project-scoped tabs from a different project so documents generated in
+ * project A never resurface when Dome reopens in project B. Unscoped tabs
+ * (settings, calendar, …) survive. Extracted so `loadStoredTabs` stays under S3776.
+ * @internal Exported for unit tests (S3776 helpers).
+ */
+export function filterTabsForActiveProject(
+  tabs: DomeTab[],
+  activeProjectId?: string | null,
+): DomeTab[] {
+  if (activeProjectId == null) return tabs;
+  return tabs.filter((t) => !isProjectScopedTab(t) || t.projectId === activeProjectId);
+}
+
+/** Home is pinned and must survive any cleanup. @internal Exported for unit tests (S3776 helpers). */
+export function ensureHomeTab(tabs: DomeTab[]): DomeTab[] {
+  if (tabs.some((t) => t.id === HOME_TAB_ID)) return tabs;
+  return [HOME_TAB, ...tabs];
+}
+
+/**
+ * Prefer the stored active id when it still exists so ContentRouter never
+ * shows an endless Loading spinner on startup.
+ * @internal Exported for unit tests (S3776 helpers).
+ */
+export function resolveStoredActiveTabId(tabs: DomeTab[], storedActiveId: unknown): string {
+  const candidate = (storedActiveId as string | null | undefined) ?? HOME_TAB_ID;
+  return tabs.some((t) => t.id === candidate) ? candidate : HOME_TAB_ID;
+}
+
+/**
+ * Hydrate tabs + activeTabId from a parsed localStorage payload.
+ * Extracted so `loadStoredTabs` stays under Sonar S3776.
+ * @internal Exported for unit tests (S3776 helpers).
+ */
+export function tabsFromParsedPayload(
+  parsed: { tabs: DomeTab[]; activeTabId?: unknown },
+  activeProjectId?: string | null,
+): { tabs: DomeTab[]; activeTabId: string } {
+  if (parsed.tabs.length === 0) return defaultTabsState();
+  const tabs = ensureHomeTab(filterTabsForActiveProject(parsed.tabs, activeProjectId));
+  return { tabs, activeTabId: resolveStoredActiveTabId(tabs, parsed.activeTabId) };
+}
+
 function loadStoredTabs(activeProjectId?: string | null): { tabs: DomeTab[]; activeTabId: string } {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed.tabs) && parsed.tabs.length > 0) {
-        let storedTabs = parsed.tabs as DomeTab[];
-        // Drop project-scoped tabs from a different project so documents
-        // generated in project A never resurface when the user reopens
-        // Dome in project B. Unscoped tabs (settings, calendar, …) survive.
-        if (activeProjectId != null) {
-          storedTabs = storedTabs.filter(
-            (t) => !isProjectScopedTab(t) || t.projectId === activeProjectId,
-          );
-        }
-        // Ensure the home tab is always present (pinned, must survive any cleanup)
-        const hasHome = storedTabs.some((t) => t.id === HOME_TAB_ID);
-        const tabs = hasHome ? storedTabs : [HOME_TAB, ...storedTabs];
-        // Ensure activeTabId points to an existing tab so ContentRouter never
-        // shows an endless <Loading /> spinner on startup
-        const storedActiveId = parsed.activeTabId ?? HOME_TAB_ID;
-        const activeTabId = tabs.some((t) => t.id === storedActiveId)
-          ? storedActiveId
-          : HOME_TAB_ID;
-        return { tabs, activeTabId };
-      }
-      if (Array.isArray(parsed.tabs) && parsed.tabs.length === 0) {
-        return { tabs: [HOME_TAB], activeTabId: HOME_TAB_ID };
-      }
-    }
+    if (!raw) return defaultTabsState();
+    const parsed = JSON.parse(raw) as { tabs?: unknown; activeTabId?: unknown };
+    if (!Array.isArray(parsed.tabs)) return defaultTabsState();
+    return tabsFromParsedPayload(
+      { tabs: parsed.tabs as DomeTab[], activeTabId: parsed.activeTabId },
+      activeProjectId,
+    );
   } catch {
     // ignore
   }
-  return { tabs: [HOME_TAB], activeTabId: HOME_TAB_ID };
+  return defaultTabsState();
 }
 
 function saveTabs(tabs: DomeTab[], activeTabId: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactor `loadStoredTabs` in `app/lib/store/useTabStore.ts` by extracting pure helpers (`filterTabsForActiveProject`, `ensureHomeTab`, `resolveStoredActiveTabId`, `tabsFromParsedPayload`) so Sonar `typescript:S3776` drops from cognitive complexity 17 to ≤15.
- Behavior of tab restore (project filtering, Home guarantee, activeTabId fallback, corrupt/empty localStorage) is unchanged — early returns only; no tab-store rewrite.
- Extend `useTabStore.test.ts` to cover the extracted helpers (same pattern as other S3776 helper exports).

## Type
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| `ae5e62ab-7bde-4cfb-a8b1-4cf82e8d6731` | typescript:S3776 | `app/lib/store/useTabStore.ts` |

Closes #810

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [ ] `pnpm run build` passes — not required for this Sonar maintainability fix
- [x] i18n keys added in all 4 languages (en, es, fr, pt) if new user-visible strings — N/A
- [x] No hardcoded colors (CSS variables only) — N/A
- [x] `pnpm run test:coverage` passes (renderer + packages; `useTabStore` 5/5)

## Safety
Helpers preserve the previous control flow: missing/invalid storage → Home; empty `tabs` → Home; project filter; ensure Home; resolve active id. Auto-merge (squash) enabled so the PR merges only after required checks pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2183e36b-8032-4b76-a465-7f07403618b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2183e36b-8032-4b76-a465-7f07403618b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

