### PR TITLE
fix(sonar): lower parseArtifactResult cognitive complexity (S3776, #808)

### DIFF
--- a/app/components/chat/tool-card/toolResultParsers.test.ts
+++ b/app/components/chat/tool-card/toolResultParsers.test.ts
@@ -1,5 +1,59 @@
 import { describe, expect, it } from 'vitest';
-import { smartToolSummary, formatArgsSummary } from './toolResultParsers';
+import { smartToolSummary, formatArgsSummary, parseArtifactResult } from './toolResultParsers';
+
+describe('parseArtifactResult', () => {
+  const legacyList = { type: 'list', title: 'Items', items: [{ text: 'a' }] };
+  const htmlArtifact = { type: 'html', title: 'Preview', html: '<p>hi</p>' };
+
+  it('returns null for empty or non-object results', () => {
+    expect(parseArtifactResult(null)).toBeNull();
+    expect(parseArtifactResult(undefined)).toBeNull();
+    expect(parseArtifactResult(42)).toBeNull();
+    expect(parseArtifactResult('not-json')).toBeNull();
+    expect(parseArtifactResult('{"ok":true}')).toBeNull();
+  });
+
+  it('reads a top-level artifact object (object or JSON string)', () => {
+    expect(parseArtifactResult({ artifact: legacyList })).toEqual(legacyList);
+    expect(parseArtifactResult(JSON.stringify({ artifact: legacyList }))).toEqual(legacyList);
+  });
+
+  it('reads artifact nested in MCP content[0].text JSON', () => {
+    expect(
+      parseArtifactResult({
+        content: [{ text: JSON.stringify({ artifact: legacyList }) }],
+      }),
+    ).toEqual(legacyList);
+  });
+
+  it('reads artifact nested under details', () => {
+    expect(parseArtifactResult({ details: { artifact: legacyList } })).toEqual(legacyList);
+  });
+
+  it('prefers top-level artifact over content/details fallbacks', () => {
+    const other = { type: 'chart', title: 'Other' };
+    expect(
+      parseArtifactResult({
+        artifact: legacyList,
+        content: [{ text: JSON.stringify({ artifact: other }) }],
+        details: { artifact: other },
+      }),
+    ).toEqual(legacyList);
+  });
+
+  it('validates Zod artifact types and rejects invalid payloads', () => {
+    expect(parseArtifactResult({ artifact: htmlArtifact })).toEqual(htmlArtifact);
+    expect(parseArtifactResult({ artifact: { type: 'html' } })).toBeNull();
+  });
+
+  it('rejects unknown artifact types', () => {
+    expect(parseArtifactResult({ artifact: { type: 'not_a_real_type' } })).toBeNull();
+  });
+
+  it('ignores unparsable content text without failing', () => {
+    expect(parseArtifactResult({ content: [{ text: 'not-json' }] })).toBeNull();
+  });
+});
 
 describe('smartToolSummary', () => {
   it('shows only the tail of a long absolute path', () => {

--- a/app/components/chat/tool-card/toolResultParsers.ts
+++ b/app/components/chat/tool-card/toolResultParsers.ts
@@ -53,54 +53,76 @@ export function parsePersistedArtifactCreateResult(result: unknown): PersistedAr
   return { resourceId, title, artifactType };
 }
 
+const LEGACY_ARTIFACT_TYPES: ArtifactType[] = [
+  'pdf_summary',
+  'table',
+  'action_items',
+  'chart',
+  'code',
+  'list',
+  'created_entity',
+  'docling_images',
+];
+
+/** Coerce a tool result string/object into a parsed value (or null). */
+function coerceToolResultJson(result: unknown): unknown | null {
+  if (typeof result === 'string') {
+    try {
+      return JSON.parse(result);
+    } catch {
+      return null;
+    }
+  }
+  if (result && typeof result === 'object') return result;
+  return null;
+}
+
+/** Pull `artifact` from MCP-style `content[0].text` JSON, if present. */
+function artifactFromContentBlocks(content: unknown): AnyArtifact | undefined {
+  if (!Array.isArray(content)) return undefined;
+  const textContent = (content[0] as { text?: unknown } | undefined)?.text;
+  if (typeof textContent !== 'string') return undefined;
+  try {
+    const parsed = JSON.parse(textContent);
+    if (parsed?.artifact) return parsed.artifact as AnyArtifact;
+  } catch {
+    /* Not JSON */
+  }
+  return undefined;
+}
+
+/** Pull `artifact` from a nested `details` object, if present. */
+function artifactFromDetails(details: unknown): AnyArtifact | undefined {
+  if (!details || typeof details !== 'object') return undefined;
+  const nested = (details as Record<string, unknown>).artifact;
+  return nested ? (nested as AnyArtifact) : undefined;
+}
+
+/** Resolve an artifact payload from the common tool-result shapes. */
+function extractArtifactPayload(obj: Record<string, unknown>): AnyArtifact | undefined {
+  if (obj.artifact && typeof obj.artifact === 'object') return obj.artifact as AnyArtifact;
+  return artifactFromContentBlocks(obj.content) ?? artifactFromDetails(obj.details);
+}
+
+/** Accept Zod-validated or known legacy artifact types; reject everything else. */
+function validateArtifactCandidate(artifact: AnyArtifact): AnyArtifact | null {
+  const artifactType = (artifact as { type?: string }).type as ArtifactType | undefined;
+  if (!artifactType) return null;
+  if (ZOD_VALIDATED_ARTIFACT_TYPES.has(artifactType)) {
+    const validated = tryParseArtifact(artifactType, artifact);
+    return validated.ok ? (validated.value as AnyArtifact) : null;
+  }
+  return LEGACY_ARTIFACT_TYPES.includes(artifactType) ? artifact : null;
+}
+
 /** Parse result as artifact */
 export function parseArtifactResult(result: unknown): AnyArtifact | null {
   if (!result) return null;
-  let parsed: unknown;
-  if (typeof result === 'string') {
-    try { parsed = JSON.parse(result); } catch { return null; }
-  } else if (result && typeof result === 'object') {
-    parsed = result;
-  } else {
-    return null;
-  }
+  const parsed = coerceToolResultJson(result);
   if (!parsed || typeof parsed !== 'object') return null;
-  const obj = parsed as Record<string, unknown>;
-  let artifact: AnyArtifact | undefined;
-  if (obj.artifact && typeof obj.artifact === 'object') artifact = obj.artifact as AnyArtifact;
-  if (!artifact && obj.content && Array.isArray(obj.content)) {
-    const textContent = obj.content[0]?.text;
-    if (typeof textContent === 'string') {
-      try {
-        const p = JSON.parse(textContent);
-        if (p.artifact) artifact = p.artifact as AnyArtifact;
-      } catch { /* Not JSON */ }
-    }
-  }
-  if (!artifact && obj.details && typeof obj.details === 'object') {
-    const details = obj.details as Record<string, unknown>;
-    if (details.artifact) artifact = details.artifact as AnyArtifact;
-  }
+  const artifact = extractArtifactPayload(parsed as Record<string, unknown>);
   if (!artifact) return null;
-  const artifactType = (artifact as { type?: string }).type as ArtifactType | undefined;
-  if (!artifactType) return null;
-  const legacyTypes: ArtifactType[] = [
-    'pdf_summary',
-    'table',
-    'action_items',
-    'chart',
-    'code',
-    'list',
-    'created_entity',
-    'docling_images',
-  ];
-  if (ZOD_VALIDATED_ARTIFACT_TYPES.has(artifactType)) {
-    const validated = tryParseArtifact(artifactType, artifact);
-    if (!validated.ok) return null;
-    return validated.value as AnyArtifact;
-  }
-  if (!legacyTypes.includes(artifactType)) return null;
-  return artifact;
+  return validateArtifactCandidate(artifact);
 }
 
 export interface ResourceItem {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `parseArtifactResult` in `app/components/chat/tool-card/toolResultParsers.ts` to drop Sonar cognitive complexity (typescript:S3776) from 30 to ≤15.
- Extracts pure helpers (`coerceToolResultJson`, `artifactFromContentBlocks`, `artifactFromDetails`, `extractArtifactPayload`, `validateArtifactCandidate`) with identical control flow and outputs for the same payloads.
- Extends `toolResultParsers.test.ts` with coverage for the common tool-result shapes (top-level, MCP content text, details, Zod vs legacy).

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| `aea30617-6f40-4e34-81af-ccab7dba6ebf` | typescript:S3776 | `toolResultParsers.ts:57` |

Closes #808

## Type
- [x] Refactor

## Why this is safe
Behavior-preserving maintainability refactor only: no tool-card UI rewrite, no Sonar suppressions, and the same parse/validate paths (JSON coerce → extract from `artifact` / `content[0].text` / `details` → Zod or legacy allowlist).

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [ ] `pnpm run build` passes (not required for this Sonar fix; coverage instead)
- [x] i18n N/A
- [x] No hardcoded colors
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d5802bf-e0eb-4c6a-b828-f929334a5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d5802bf-e0eb-4c6a-b828-f929334a5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

