### PR TITLE
fix(sonar): lower resolveDomeModel cognitive complexity (S3776, #796)

### DIFF
--- a/packages/ai/src/dome-bridge.test.ts
+++ b/packages/ai/src/dome-bridge.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+import {
+  domeUsageToLegacy,
+  extractTextFromAssistantMessage,
+  legacyUsageToDome,
+  resolveDomeModel,
+} from './dome-bridge.js';
+import type { AssistantMessage, Usage } from './types.js';
+
+describe('resolveDomeModel', () => {
+  it('defaults empty model id to gpt-4o-mini (catalog when known)', () => {
+    const m = resolveDomeModel({ provider: 'openai', model: '' });
+    expect(m.id).toBe('gpt-4o-mini');
+    expect(m.provider).toBe('openai');
+    // Catalog entry uses Responses API; custom ids fall back to completions.
+    expect(m.api === 'openai-responses' || m.api === 'openai-completions').toBe(true);
+  });
+
+  it('uses custom openai baseUrl when not in catalog', () => {
+    const m = resolveDomeModel({
+      provider: 'openai',
+      model: 'totally-custom-model-xyz',
+      baseUrl: 'https://example.test/v1',
+    });
+    expect(m).toMatchObject({
+      id: 'totally-custom-model-xyz',
+      api: 'openai-completions',
+      provider: 'openai',
+      baseUrl: 'https://example.test/v1',
+    });
+  });
+
+  it('maps anthropic and claude-oauth to anthropic-messages', () => {
+    const a = resolveDomeModel({ provider: 'anthropic', model: 'claude-sonnet-4-5' });
+    const o = resolveDomeModel({ provider: 'claude-oauth', model: 'claude-sonnet-4-5' });
+    expect(a.api).toBe('anthropic-messages');
+    expect(o.api).toBe('anthropic-messages');
+    expect(a.provider).toBe('anthropic');
+    expect(o.provider).toBe('anthropic');
+  });
+
+  it('builds openai-codex fallback and applies optional baseUrl', () => {
+    const fallback = resolveDomeModel({
+      provider: 'openai-codex',
+      model: 'codex-unlisted-model',
+    });
+    expect(fallback).toMatchObject({
+      id: 'codex-unlisted-model',
+      api: 'openai-codex-responses',
+      provider: 'openai-codex',
+      baseUrl: 'https://chatgpt.com/backend-api',
+      reasoning: true,
+      maxTokens: 128_000,
+    });
+
+    const withUrl = resolveDomeModel({
+      provider: 'openai-codex',
+      model: 'codex-unlisted-model',
+      baseUrl: 'https://codex.test',
+    });
+    expect(withUrl.baseUrl).toBe('https://codex.test');
+  });
+
+  it('normalizes ollama baseUrl to …/v1', () => {
+    expect(resolveDomeModel({ provider: 'ollama', model: 'llama3' }).baseUrl).toBe(
+      'http://127.0.0.1:11434/v1',
+    );
+    expect(
+      resolveDomeModel({ provider: 'ollama', model: 'llama3', baseUrl: 'http://host:11434' }).baseUrl,
+    ).toBe('http://host:11434/v1');
+    expect(
+      resolveDomeModel({
+        provider: 'ollama',
+        model: 'llama3',
+        baseUrl: 'http://host:11434/',
+      }).baseUrl,
+    ).toBe('http://host:11434/v1');
+    expect(
+      resolveDomeModel({
+        provider: 'ollama',
+        model: 'llama3',
+        baseUrl: 'http://host:11434/v1',
+      }).baseUrl,
+    ).toBe('http://host:11434/v1');
+
+    const m = resolveDomeModel({ provider: 'ollama', model: 'llama3' });
+    expect(m.api).toBe('openai-completions');
+    expect(m.provider).toBe('ollama');
+    expect(m.compat).toEqual({ supportsUsageInStreaming: false, supportsStore: false });
+  });
+
+  it('resolves openrouter, copilot, minimax, and dome providers', () => {
+    const or = resolveDomeModel({
+      provider: 'openrouter',
+      model: 'openrouter-unlisted/x',
+    });
+    expect(or).toMatchObject({
+      api: 'openai-completions',
+      provider: 'openrouter',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      compat: { thinkingFormat: 'openrouter' },
+    });
+
+    const copilot = resolveDomeModel({
+      provider: 'copilot',
+      model: 'copilot-unlisted',
+    });
+    expect(copilot).toMatchObject({
+      api: 'openai-responses',
+      provider: 'github-copilot',
+      baseUrl: 'https://api.githubcopilot.com',
+      input: ['text'],
+    });
+
+    const minimax = resolveDomeModel({ provider: 'minimax', model: 'MiniMax-M3' });
+    expect(minimax).toMatchObject({
+      api: 'anthropic-messages',
+      provider: 'minimax',
+      baseUrl: 'https://api.minimax.io/anthropic',
+      maxTokens: 16_384,
+    });
+
+    // Empty model becomes gpt-4o-mini before the dome helper (same as legacy).
+    const domeEmpty = resolveDomeModel({ provider: 'dome', model: '' });
+    expect(domeEmpty).toMatchObject({
+      id: 'gpt-4o-mini',
+      api: 'openai-completions',
+      provider: 'minimax',
+      baseUrl: 'https://api.minimax.io/v1',
+      compat: {
+        supportsUsageInStreaming: true,
+        supportsStore: false,
+        maxTokensField: 'max_tokens',
+      },
+    });
+    const domeNamed = resolveDomeModel({ provider: 'dome', model: 'dome/auto' });
+    expect(domeNamed.id).toBe('dome/auto');
+  });
+
+  it('resolves deepseek, moonshot, qwen, opencode family, google, and unknown default', () => {
+    expect(resolveDomeModel({ provider: 'deepseek', model: 'deepseek-chat' })).toMatchObject({
+      provider: 'deepseek',
+      baseUrl: 'https://api.deepseek.com/v1',
+      api: 'openai-completions',
+    });
+    expect(resolveDomeModel({ provider: 'moonshot', model: 'kimi' })).toMatchObject({
+      provider: 'moonshot',
+      baseUrl: 'https://api.moonshot.cn/v1',
+    });
+    expect(resolveDomeModel({ provider: 'qwen', model: 'qwen-max' })).toMatchObject({
+      provider: 'qwen',
+      baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    });
+    expect(
+      resolveDomeModel({ provider: 'opencode', model: 'opencode-unlisted' }),
+    ).toMatchObject({
+      provider: 'opencode',
+      baseUrl: 'https://opencode.ai/zen/v1',
+    });
+    expect(
+      resolveDomeModel({ provider: 'opencode-go', model: 'opencode-go-unlisted' }),
+    ).toMatchObject({
+      provider: 'opencode-go',
+      baseUrl: 'https://opencode.ai/zen/go/v1',
+    });
+
+    const google = resolveDomeModel({ provider: 'google', model: 'gemini-unlisted-xyz' });
+    expect(google.api).toBe('google-generative-ai');
+    expect(google.provider).toBe('google');
+
+    const unknown = resolveDomeModel({
+      provider: 'some-unknown-provider',
+      model: 'm1',
+    });
+    expect(unknown).toMatchObject({
+      id: 'm1',
+      provider: 'some-unknown-provider',
+      api: 'openai-completions',
+      baseUrl: 'https://openrouter.ai/api/v1',
+    });
+  });
+});
+
+describe('usage + text helpers', () => {
+  it('converts usage both ways and extracts assistant text', () => {
+    const usage: Usage = {
+      input: 3,
+      output: 5,
+      cacheRead: 1,
+      cacheWrite: 0,
+      totalTokens: 8,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    };
+    expect(domeUsageToLegacy(usage)).toEqual({
+      inputTokens: 3,
+      outputTokens: 5,
+      totalTokens: 8,
+    });
+    expect(domeUsageToLegacy(null)).toBeNull();
+    expect(legacyUsageToDome(null)).toBeNull();
+    expect(legacyUsageToDome({ inputTokens: 1, outputTokens: 2, totalTokens: 3 })).toMatchObject({
+      input: 1,
+      output: 2,
+      totalTokens: 3,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+
+    const msg: AssistantMessage = {
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'hello' },
+        { type: 'toolCall', id: 't', name: 'x', arguments: {} },
+        { type: 'text', text: ' world' },
+      ],
+      api: 'openai-completions',
+      provider: 'openai',
+      model: 'gpt',
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: 'stop',
+      timestamp: 1,
+    };
+    expect(extractTextFromAssistantMessage(msg)).toBe('hello world');
+  });
+});

--- a/packages/ai/src/dome-bridge.ts
+++ b/packages/ai/src/dome-bridge.ts
@@ -124,107 +124,161 @@ function googleModel(id: string): Model<'google-generative-ai'> {
   };
 }
 
+/** Prefer catalog entry; otherwise build an OpenAI-completions model. */
+function catalogOrOpenAiCompletions(
+  catalogProvider: KnownProvider,
+  modelId: string,
+  provider: KnownProvider | string,
+  baseUrl: string,
+  compat?: OpenAICompletionsCompat,
+): Model<Api> {
+  const fromCatalog = getModel(catalogProvider, modelId as never);
+  if (fromCatalog) return fromCatalog;
+  return openAiCompletionsModel(modelId, provider, baseUrl, compat);
+}
+
+function withOptionalBaseUrl<T extends Model<Api>>(model: T, baseUrl?: string): T {
+  return baseUrl ? { ...model, baseUrl } : model;
+}
+
+function resolveOpenaiModel(modelId: string, baseUrl?: string): Model<Api> {
+  return catalogOrOpenAiCompletions('openai', modelId, 'openai', baseUrl || 'https://api.openai.com/v1');
+}
+
+function resolveOpenaiCodexModel(modelId: string, baseUrl?: string): Model<Api> {
+  const fromCodex = getModel('openai-codex', modelId as never);
+  if (fromCodex) {
+    return withOptionalBaseUrl(fromCodex, baseUrl);
+  }
+  // Same model ids as OpenAI API / ChatGPT (GPT-5.6 Sol/Terra/Luna) — Codex Responses.
+  return {
+    id: modelId,
+    name: modelId,
+    api: 'openai-codex-responses',
+    provider: 'openai-codex',
+    baseUrl: baseUrl || 'https://chatgpt.com/backend-api',
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_050_000,
+    maxTokens: 128_000,
+  };
+}
+
+function ollamaBaseUrl(baseUrl?: string): string {
+  if (!baseUrl) return OLLAMA_DEFAULT;
+  if (baseUrl.endsWith('/v1')) return baseUrl;
+  return `${baseUrl.replace(/\/$/, '')}/v1`;
+}
+
+function resolveOllamaModel(modelId: string, baseUrl?: string): Model<'openai-completions'> {
+  return openAiCompletionsModel(modelId, 'ollama', ollamaBaseUrl(baseUrl), {
+    supportsUsageInStreaming: false,
+    supportsStore: false,
+  });
+}
+
+function resolveOpenrouterModel(modelId: string, baseUrl?: string): Model<Api> {
+  return catalogOrOpenAiCompletions('openrouter', modelId, 'openrouter', baseUrl || OPENROUTER_DEFAULT, {
+    thinkingFormat: 'openrouter',
+  });
+}
+
+function resolveCopilotModel(modelId: string, baseUrl?: string): Model<Api> {
+  const fromCatalog = getModel('github-copilot', modelId as never);
+  if (fromCatalog) {
+    return withOptionalBaseUrl(fromCatalog, baseUrl);
+  }
+  return {
+    id: modelId,
+    name: modelId,
+    api: 'openai-responses',
+    provider: 'github-copilot',
+    baseUrl: baseUrl || 'https://api.githubcopilot.com',
+    reasoning: false,
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 8192,
+  };
+}
+
+function resolveDomeProviderModel(modelId: string, baseUrl?: string): Model<'openai-completions'> {
+  return openAiCompletionsModel(modelId || 'dome/auto', 'minimax', baseUrl || MINIMAX_OPENAI, {
+    supportsUsageInStreaming: true,
+    supportsStore: false,
+    maxTokensField: 'max_tokens',
+  });
+}
+
+function resolveOpencodeModel(modelId: string, baseUrl?: string): Model<Api> {
+  return catalogOrOpenAiCompletions('opencode', modelId, 'opencode', baseUrl || OPENCODE_DEFAULT);
+}
+
+function resolveOpencodeGoModel(modelId: string, baseUrl?: string): Model<Api> {
+  return catalogOrOpenAiCompletions(
+    'opencode-go',
+    modelId,
+    'opencode-go',
+    baseUrl || OPENCODE_GO_DEFAULT,
+  );
+}
+
+function resolveOpenAiCompatProvider(
+  provider: 'deepseek' | 'moonshot' | 'qwen',
+  modelId: string,
+  baseUrl: string | undefined,
+  defaultBaseUrl: string,
+): Model<'openai-completions'> {
+  return openAiCompletionsModel(modelId, provider, baseUrl || defaultBaseUrl);
+}
+
+function resolveDefaultProviderModel(
+  provider: string,
+  modelId: string,
+  baseUrl?: string,
+): Model<Api> {
+  return catalogOrOpenAiCompletions(
+    provider as KnownProvider,
+    modelId,
+    provider,
+    baseUrl || OPENROUTER_DEFAULT,
+  );
+}
+
+type DomeModelResolver = (modelId: string, baseUrl?: string) => Model<Api>;
+
+/** Known Dome Settings providers → Model builders (default handled separately). */
+const DOME_PROVIDER_RESOLVERS: Record<string, DomeModelResolver> = {
+  openai: resolveOpenaiModel,
+  anthropic: (modelId) => anthropicModel(modelId),
+  // Same Anthropic Messages API; OAuth vs API key is detected from the token shape.
+  'claude-oauth': (modelId) => anthropicModel(modelId),
+  'openai-codex': resolveOpenaiCodexModel,
+  google: (modelId) => googleModel(modelId),
+  ollama: resolveOllamaModel,
+  openrouter: resolveOpenrouterModel,
+  copilot: resolveCopilotModel,
+  minimax: (modelId, baseUrl) => minimaxModel(modelId, baseUrl),
+  dome: resolveDomeProviderModel,
+  deepseek: (modelId, baseUrl) =>
+    resolveOpenAiCompatProvider('deepseek', modelId, baseUrl, DEEPSEEK_DEFAULT),
+  moonshot: (modelId, baseUrl) =>
+    resolveOpenAiCompatProvider('moonshot', modelId, baseUrl, MOONSHOT_DEFAULT),
+  qwen: (modelId, baseUrl) => resolveOpenAiCompatProvider('qwen', modelId, baseUrl, QWEN_DEFAULT),
+  opencode: resolveOpencodeModel,
+  'opencode-go': resolveOpencodeGoModel,
+};
+
 /**
  * Map Dome Settings provider + model id to a provider `Model` for `stream()` / `complete()`.
  */
 export function resolveDomeModel(opts: ResolveDomeModelOptions): Model<Api> {
   const { provider, model, baseUrl } = opts;
   const modelId = model || 'gpt-4o-mini';
-
-  switch (provider) {
-    case 'openai': {
-      const fromCatalog = getModel('openai', modelId as never);
-      if (fromCatalog) return fromCatalog;
-      return openAiCompletionsModel(modelId, 'openai', baseUrl || 'https://api.openai.com/v1');
-    }
-    case 'anthropic':
-      return anthropicModel(modelId);
-    case 'claude-oauth':
-      // Same Anthropic Messages API; OAuth vs API key is detected from the token shape.
-      return anthropicModel(modelId);
-    case 'openai-codex': {
-      const fromCodex = getModel('openai-codex', modelId as never);
-      if (fromCodex) {
-        return baseUrl ? { ...fromCodex, baseUrl } : fromCodex;
-      }
-      // Same model ids as OpenAI API / ChatGPT (GPT-5.6 Sol/Terra/Luna) — Codex Responses.
-      return {
-        id: modelId,
-        name: modelId,
-        api: 'openai-codex-responses',
-        provider: 'openai-codex',
-        baseUrl: baseUrl || 'https://chatgpt.com/backend-api',
-        reasoning: true,
-        input: ['text', 'image'],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 1_050_000,
-        maxTokens: 128_000,
-      };
-    }
-    case 'google':
-      return googleModel(modelId);
-    case 'ollama':
-      return openAiCompletionsModel(
-        modelId,
-        'ollama',
-        baseUrl ? (baseUrl.endsWith('/v1') ? baseUrl : `${baseUrl.replace(/\/$/, '')}/v1`) : OLLAMA_DEFAULT,
-        { supportsUsageInStreaming: false, supportsStore: false },
-      );
-    case 'openrouter': {
-      const fromCatalog = getModel('openrouter', modelId as never);
-      if (fromCatalog) return fromCatalog;
-      return openAiCompletionsModel(modelId, 'openrouter', baseUrl || OPENROUTER_DEFAULT, {
-        thinkingFormat: 'openrouter',
-      });
-    }
-    case 'copilot': {
-      const fromCatalog = getModel('github-copilot', modelId as never);
-      if (fromCatalog) {
-        return baseUrl ? { ...fromCatalog, baseUrl } : fromCatalog;
-      }
-      return {
-        id: modelId,
-        name: modelId,
-        api: 'openai-responses',
-        provider: 'github-copilot',
-        baseUrl: baseUrl || 'https://api.githubcopilot.com',
-        reasoning: false,
-        input: ['text'],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 128_000,
-        maxTokens: 8192,
-      };
-    }
-    case 'minimax':
-      return minimaxModel(modelId, baseUrl);
-    case 'dome':
-      return openAiCompletionsModel(modelId || 'dome/auto', 'minimax', baseUrl || MINIMAX_OPENAI, {
-        supportsUsageInStreaming: true,
-        supportsStore: false,
-        maxTokensField: 'max_tokens',
-      });
-    case 'deepseek':
-      return openAiCompletionsModel(modelId, 'deepseek', baseUrl || DEEPSEEK_DEFAULT);
-    case 'moonshot':
-      return openAiCompletionsModel(modelId, 'moonshot', baseUrl || MOONSHOT_DEFAULT);
-    case 'qwen':
-      return openAiCompletionsModel(modelId, 'qwen', baseUrl || QWEN_DEFAULT);
-    case 'opencode': {
-      const fromCatalog = getModel('opencode', modelId as never);
-      if (fromCatalog) return fromCatalog;
-      return openAiCompletionsModel(modelId, 'opencode', baseUrl || OPENCODE_DEFAULT);
-    }
-    case 'opencode-go': {
-      const fromCatalog = getModel('opencode-go', modelId as never);
-      if (fromCatalog) return fromCatalog;
-      return openAiCompletionsModel(modelId, 'opencode-go', baseUrl || OPENCODE_GO_DEFAULT);
-    }
-    default: {
-      const fromCatalog = getModel(provider as KnownProvider, modelId as never);
-      if (fromCatalog) return fromCatalog;
-      return openAiCompletionsModel(modelId, provider, baseUrl || OPENROUTER_DEFAULT);
-    }
-  }
+  const resolve = DOME_PROVIDER_RESOLVERS[provider];
+  if (resolve) return resolve(modelId, baseUrl);
+  return resolveDefaultProviderModel(provider, modelId, baseUrl);
 }
 
 /** Legacy llm-service usage shape. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `resolveDomeModel` in `packages/ai/src/dome-bridge.ts` to drop Sonar `typescript:S3776` cognitive complexity (21 → ≤15).
- Extracts per-provider helpers and a dispatch map; IPC/bridge contracts and outputs are unchanged.
- Adds `packages/ai/src/dome-bridge.test.ts` covering provider defaults, Ollama `/v1` normalization, usage conversion, and text extraction.

## Sonar

| Key | Rule | File | Issue |
| --- | --- | --- | --- |
| `b3641c58-ddd4-455f-b53b-9d06499e38ed` | typescript:S3776 | `packages/ai/src/dome-bridge.ts:128` | #796 |

Closes #796

## Type
- [x] Refactor

## Why this is safe
- Same provider → `Model` mapping (catalog hit, OpenAI-completions fallbacks, Ollama URL normalization, Codex/Copilot baseUrl overlay, dome/minimax compat flags).
- No changes to exported API surface beyond internal helpers.
- Unit tests lock the resolution behavior that `llm-service` / agent-runtime rely on.

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes (`@dome/ai` includes new `dome-bridge` tests)
- [ ] i18n keys — N/A
- [ ] No hardcoded colors — N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87554d85-c45f-4ddd-b052-9aa7ef84d447?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87554d85-c45f-4ddd-b052-9aa7ef84d447&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

