### PR TITLE
fix(sonar): lower FolderTabView cognitive complexity (S3776, #760)

### DIFF
--- a/app/components/shell/FolderTabView.tsx
+++ b/app/components/shell/FolderTabView.tsx
@@ -1,86 +1,53 @@
-import { useMemo, useCallback, useState, useRef, useEffect, Fragment } from 'react';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import {
-  ArrowRight01Icon,
-  ArrowLeft01Icon,
-  Upload04Icon,
-  FolderAddIcon,
-  FolderExportIcon,
-  LinkSquare01Icon,
-  FileEditIcon,
-  Search01Icon,
-  Cancel01Icon,
-  Add01Icon,
-  MoreHorizontalIcon,
-  PaintBoardIcon,
-  LayoutGridIcon,
-  Menu01Icon,
-  Tag01Icon,
-} from '@hugeicons/core-free-icons';
-import { HugeiconsIcon } from '@hugeicons/react';
+import { useMemo, useCallback, useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useShallow } from 'zustand/react/shallow';
 import { useResources, type Resource } from '@/lib/hooks/useResources';
 import { useTabStore, FOLDER_TAB_PREFIX } from '@/lib/store/useTabStore';
 import { useFolderNavigationHistory } from '@/lib/hooks/useFolderNavigationHistory';
 import { useAppStore } from '@/lib/store/useAppStore';
-import { lazyRef } from '@/lib/utils/lazyRef';
-import MoveToProjectModal from '@/components/workspace/MoveToProjectModal';
-import MoveFolderModal from '@/components/workspace/MoveFolderModal';
-import {
-  BulkDeleteConfirmModal,
-  DeleteConfirmModal,
-  UrlInputModal,
-} from '@/components/workspace/sidebar/SidebarModals';
 import { filterMoveProjectRoots } from '@/lib/workspace/filterMoveProjectRoots';
 import SelectionActionBar from '@/components/home/SelectionActionBar';
-import { Button } from '@/components/ui/button';
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-} from '@/components/ui/input-group';
-import { Separator } from '@/components/ui/separator';
 import { Spinner } from '@/components/ui/spinner';
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { cn } from '@/lib/utils';
 import '@/styles/folder-view.css';
 
-import { getFolderColor, resolveFolderTabView, FOLDER_COLOR_DEFAULT } from './folder-tab/folderTabShared';
+import { resolveFolderTabView, FOLDER_COLOR_DEFAULT } from './folder-tab/folderTabShared';
 import ColorPickerPopover from './folder-tab/ColorPickerPopover';
-import FolderListRow from './folder-tab/FolderListRow';
-import FolderCard from './folder-tab/FolderCard';
-import NewFolderInline from './folder-tab/NewFolderInline';
-
-type FolderViewMode = 'grid' | 'list';
-const FOLDER_VIEW_MODE_KEY = 'dome:folder-view-mode';
-const FOLDER_VIEW_MODE_DEFAULT: FolderViewMode = 'grid';
-
-type ProjectTag = {
-  id: string;
-  name: string;
-  color?: string | null;
-  resource_count: number;
-};
-
-function readFolderViewMode(): FolderViewMode {
-  if (typeof window === 'undefined') return FOLDER_VIEW_MODE_DEFAULT;
-  try {
-    const raw = window.localStorage.getItem(FOLDER_VIEW_MODE_KEY);
-    return raw === 'list' || raw === 'grid' ? raw : FOLDER_VIEW_MODE_DEFAULT;
-  } catch {
-    return FOLDER_VIEW_MODE_DEFAULT;
-  }
-}
+import FolderTabToolbar from './folder-tab/FolderTabToolbar';
+import FolderTabBody from './folder-tab/FolderTabBody';
+import FolderTabDialogs from './folder-tab/FolderTabDialogs';
+import FolderTabDropOverlay from './folder-tab/FolderTabDropOverlay';
+import { useFolderOsDrop } from './folder-tab/useFolderOsDrop';
+import { useFolderTabSearchController } from './folder-tab/useFolderTabSearch';
+import {
+  useFolderNavAltArrowKeys,
+  useProjectTagsLoader,
+  useTaggedResourcesLoader,
+} from './folder-tab/useFolderTabEffects';
+import {
+  useToggleSelectId,
+  useBulkMoveToFolder,
+  useBulkDelete,
+  useFolderTabResourceActions,
+} from './folder-tab/useFolderTabActions';
+import {
+  type FolderViewMode,
+  type ProjectTag,
+  readFolderViewMode,
+  partitionFolderChildren,
+  buildResourceMapForSelection,
+  buildFolderListItems,
+  filterListItemsBySearch,
+  resolveEffectiveProjectId,
+  folderSearchModHint,
+  folderRevealLabel,
+  computeFolderViewStatus,
+  colorPickerPositionFromRect,
+  resolveFolderChromeColor,
+  buildTabColorKey,
+  canOpenResourceInSplit,
+  buildBreadcrumbExcludingCurrent,
+  persistFolderViewMode,
+} from './folder-tab/folderTabViewHelpers';
 
 interface FolderTabViewProps {
   folderId: string;
@@ -109,7 +76,7 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
 
   const setFolderViewMode = useCallback((next: FolderViewMode) => {
     setViewMode(next);
-    try { window.localStorage.setItem(FOLDER_VIEW_MODE_KEY, next); } catch { /* ignore */ }
+    persistFolderViewMode(next);
   }, []);
 
   const [colorPickerPos, setColorPickerPos] = useState<{ top: number; left: number } | null>(null);
@@ -122,11 +89,14 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
   const [projectTags, setProjectTags] = useState<ProjectTag[]>([]);
   const [taggedResourceIds, setTaggedResourceIds] = useState<Set<string>>(() => new Set());
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const rowRefs = useRef<Map<string, HTMLDivElement> | null>(null);
-  const rowRefMap = lazyRef(rowRefs, () => new Map());
 
-  const searchModHint =
-    typeof navigator !== 'undefined' && /Mac|iPhone|iPad/i.test(navigator.platform) ? '⌘F' : 'Ctrl+F';
+  const platform = typeof navigator === 'undefined' ? undefined : navigator.platform;
+  const searchModHint = folderSearchModHint(platform);
+  const revealLabel = folderRevealLabel(
+    platform,
+    t('folder.reveal_in_finder'),
+    t('folder.reveal_in_explorer'),
+  );
 
   const {
     resources: allResources,
@@ -153,102 +123,74 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
     [folderId, folderResource],
   );
 
-  const { subfolders, files } = useMemo(() => {
-    let list = allResources;
-    if (viewCtx.isProjectRoot) {
-      list = list.filter((r) => r.project_id === viewCtx.projectId && !r.folder_id);
-    } else {
-      list = list.filter((r) => r.folder_id === folderId);
-      if (viewCtx.projectId) {
-        list = list.filter((r) => r.project_id === viewCtx.projectId);
-      }
-    }
-    return {
-      subfolders: list.filter((r) => r.type === 'folder'),
-      files: list.filter((r) => r.type !== 'folder'),
-    };
-  }, [allResources, viewCtx, folderId]);
+  const { subfolders, files } = useMemo(
+    () => partitionFolderChildren(allResources, viewCtx, folderId),
+    [allResources, viewCtx, folderId],
+  );
 
   const currentFolder = viewCtx.isProjectRoot ? undefined : folderResource;
   const displayTitle = currentFolder?.title ?? folderTitle;
   // Breadcrumb root = the project (vault root), never "Home".
   const projectRootLabel = currentProject?.name || 'Library';
-  const effectiveProjectId = viewCtx.isProjectRoot
-    ? viewCtx.projectId
-    : (currentFolder?.project_id ?? currentProject?.id ?? 'default');
+  const effectiveProjectId = resolveEffectiveProjectId({
+    isProjectRoot: viewCtx.isProjectRoot,
+    viewProjectId: viewCtx.projectId,
+    currentFolderProjectId: currentFolder?.project_id,
+    currentProjectId: currentProject?.id,
+  });
   const listFolderId = viewCtx.listFolderId;
 
-  const resourceMapForSelection = useMemo(() => {
-    const m = new Map<string, Resource>();
-    for (const f of subfolders) m.set(f.id, f);
-    for (const f of files) m.set(f.id, f);
-    if (!viewCtx.isProjectRoot) {
-      for (const p of getBreadcrumbPath(folderId)) m.set(p.id, p);
-      const cur = getFolderById(folderId);
-      if (cur) m.set(cur.id, cur);
-    }
-    return m;
-  }, [subfolders, files, folderId, getBreadcrumbPath, getFolderById, viewCtx.isProjectRoot]);
-
-  const toggleSelectId = useCallback((id: string) => {
-    setSelectedIds((prev) => {
-      const n = new Set(prev);
-      if (n.has(id)) n.delete(id);
-      else n.add(id);
-      return n;
-    });
-  }, []);
-
-  const handleBulkMoveToFolder = useCallback(
-    async (targetFolderId: string | null) => {
-      // Single-card move targets `folderMoveIds`; otherwise move the selection.
-      const roots = folderMoveIds ?? filterMoveProjectRoots(selectedIds, resourceMapForSelection);
-      for (const rid of roots) {
-        const ok = await moveToFolder(rid, targetFolderId);
-        if (!ok) break;
-      }
-      if (!folderMoveIds) setSelectedIds(new Set());
-      setFolderMoveIds(null);
-      setFolderPickOpen(false);
-      await refetch();
-    },
-    [folderMoveIds, selectedIds, resourceMapForSelection, moveToFolder, refetch],
+  const resourceMapForSelection = useMemo(
+    () =>
+      buildResourceMapForSelection({
+        subfolders,
+        files,
+        folderId,
+        isProjectRoot: viewCtx.isProjectRoot,
+        getBreadcrumbPath,
+        getFolderById,
+      }),
+    [subfolders, files, folderId, getBreadcrumbPath, getFolderById, viewCtx.isProjectRoot],
   );
 
-  // Open the folder picker for a single resource (per-card menu action).
+  const toggleSelectId = useToggleSelectId(setSelectedIds);
+  const handleBulkMoveToFolder = useBulkMoveToFolder({
+    folderMoveIds,
+    selectedIds,
+    resourceMapForSelection,
+    moveToFolder,
+    refetch,
+    setSelectedIds,
+    setFolderMoveIds,
+    setFolderPickOpen,
+  });
+
   const openFolderPickerFor = useCallback((id: string) => {
     setFolderMoveIds([id]);
     setFolderPickOpen(true);
   }, []);
 
-  const handleBulkDelete = useCallback(async () => {
-    if (selectedIds.size === 0) return;
-    setBulkDeleting(true);
-    try {
-      const res = await window.electron?.db?.resources?.bulkDelete([...selectedIds]);
-      if (res?.success) {
-        setSelectedIds(new Set());
-        await refetch();
-      }
-    } finally {
-      setBulkDeleting(false);
-      setBulkDeleteOpen(false);
-    }
-  }, [selectedIds, refetch]);
+  const handleBulkDelete = useBulkDelete({
+    selectedIds,
+    refetch,
+    setSelectedIds,
+    setBulkDeleting,
+    setBulkDeleteOpen,
+  });
 
-  const { openResourceTab, openResourceInSplit, navigateFolderTab, updateTab, activeTabId, tabs } = useTabStore(
-    useShallow((s) => ({
-      openResourceTab: s.openResourceTab,
-      openResourceInSplit: s.openResourceInSplit,
-      navigateFolderTab: s.navigateFolderTab,
-      updateTab: s.updateTab,
-      activeTabId: s.activeTabId,
-      tabs: s.tabs,
-    })),
-  );
+  const { openResourceTab, openResourceInSplit, navigateFolderTab, updateTab, activeTabId, tabs } =
+    useTabStore(
+      useShallow((s) => ({
+        openResourceTab: s.openResourceTab,
+        openResourceInSplit: s.openResourceInSplit,
+        navigateFolderTab: s.navigateFolderTab,
+        updateTab: s.updateTab,
+        activeTabId: s.activeTabId,
+        tabs: s.tabs,
+      })),
+    );
 
-  const canOpenInSplit = activeTabId !== null && activeTabId !== 'home' &&
-    Boolean(tabs.find((tb) => tb.id === activeTabId)?.resourceId);
+  const canOpenInSplit = canOpenResourceInSplit(activeTabId, tabs);
 
   const tabId = `${FOLDER_TAB_PREFIX}${folderId}`;
   const navLocation = useMemo(
@@ -264,34 +206,7 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
   const { canGoBack, canGoForward, navigate: navigateToFolder, goBack, goForward } =
     useFolderNavigationHistory(tabId, navLocation, navigateFolderTabWithProject);
 
-  const handleNavigateToFolder = useCallback(
-    (id: string, title: string, color?: string) => {
-      // Only persist real hex colors on the tab; uncolored folders stay neutral.
-      const tabColor = color?.startsWith('#') ? color : undefined;
-      navigateToFolder({ id, title, color: tabColor });
-    },
-    [navigateToFolder],
-  );
-
-  const handleNavigateToProjectRoot = useCallback(() => {
-    if (!effectiveProjectId) return;
-    handleNavigateToFolder(effectiveProjectId, projectRootLabel, 'var(--primary)');
-  }, [effectiveProjectId, projectRootLabel, handleNavigateToFolder]);
-
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (!e.altKey || e.metaKey || e.ctrlKey || e.shiftKey) return;
-      if (e.key === 'ArrowLeft') {
-        e.preventDefault();
-        goBack();
-      } else if (e.key === 'ArrowRight') {
-        e.preventDefault();
-        goForward();
-      }
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [goBack, goForward]);
+  useFolderNavAltArrowKeys(goBack, goForward);
 
   const prevListFolderIdRef = useRef<string | null | undefined>(listFolderId);
   if (prevListFolderIdRef.current !== listFolderId) {
@@ -301,276 +216,92 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
 
   useEffect(() => () => { setCurrentFolderId(null); }, [setCurrentFolderId]);
 
-  useEffect(() => {
-    let cancelled = false;
-    void window.electron?.db?.tags?.getAll(effectiveProjectId).then((res) => {
-      if (cancelled || !res?.success) return;
-      setProjectTags((res.data as ProjectTag[] | undefined) ?? []);
-    });
-    return () => { cancelled = true; };
-  }, [effectiveProjectId]);
-
-  useEffect(() => {
-    if (!tagFilterId) {
-      setTaggedResourceIds(new Set());
-      return;
-    }
-    let cancelled = false;
-    void window.electron?.db?.tags?.getResources(tagFilterId, effectiveProjectId).then((res) => {
-      if (cancelled || !res?.success) return;
-      setTaggedResourceIds(new Set((res.data ?? []).map((r) => r.id)));
-    });
-    return () => { cancelled = true; };
-  }, [tagFilterId, effectiveProjectId]);
+  useProjectTagsLoader(effectiveProjectId, setProjectTags);
+  useTaggedResourcesLoader(tagFilterId, effectiveProjectId, setTaggedResourceIds);
 
   const breadcrumb = useMemo(
-    () => (viewCtx.isProjectRoot ? [] : getBreadcrumbPath(folderId).filter((f) => f.id !== folderId)),
+    () => buildBreadcrumbExcludingCurrent(viewCtx.isProjectRoot, folderId, getBreadcrumbPath),
     [folderId, getBreadcrumbPath, viewCtx.isProjectRoot],
   );
 
-  const folderColor = currentFolder ? getFolderColor(currentFolder) : 'var(--primary)';
-  const folderColorHex = folderColor.startsWith('#') ? folderColor : null;
-
-  const tabColorKey =
-    folderColorHex && !viewCtx.isProjectRoot ? `${folderId}:${folderColorHex}` : '';
+  const { folderColorHex } = resolveFolderChromeColor(currentFolder);
+  const tabColorKey = buildTabColorKey(folderId, folderColorHex, viewCtx.isProjectRoot);
   const prevTabColorKeyRef = useRef('');
   if (tabColorKey && tabColorKey !== prevTabColorKeyRef.current) {
     prevTabColorKeyRef.current = tabColorKey;
     updateTab(`folder:${folderId}`, { color: folderColorHex! });
   }
 
-  const handleCurrentFolderColor = async (color: string) => {
-    if (!currentFolder) return;
-    const currentMeta = (currentFolder.metadata as Record<string, unknown>) ?? {};
-    await updateResource(folderId, { metadata: { ...currentMeta, color } });
-    updateTab(`folder:${folderId}`, { color });
-    setColorPickerPos(null);
-  };
+  const actions = useFolderTabResourceActions({
+    canOpenInSplit,
+    openResourceInSplit,
+    createResource,
+    effectiveProjectId,
+    listFolderId,
+    createFolderParentId,
+    setCreatingFolder,
+    setCreateFolderParentId,
+    openResourceTab,
+    untitledNoteTitle: t('dashboard.untitled_note', 'Nota sin título'),
+    refetch,
+    updateResource,
+    updateTab,
+    deleteResource,
+    deleteTarget,
+    setDeleteTarget,
+    viewCtxIsProjectRoot: viewCtx.isProjectRoot,
+    currentFolder,
+    folderId,
+    setColorPickerPos,
+    navigateToFolder,
+    projectRootLabel,
+    tUntitled: t('folder.untitled'),
+  });
 
-  const handleCreateFolder = useCallback(async (name: string) => {
-    await createResource({
-      type: 'folder',
-      title: name,
-      project_id: effectiveProjectId,
-      content: '',
-      folder_id: createFolderParentId ?? listFolderId,
-      metadata: {},
-    });
-    setCreatingFolder(false);
-    setCreateFolderParentId(null);
-  }, [createResource, effectiveProjectId, listFolderId, createFolderParentId]);
+  const {
+    osDropActive,
+    handleOsDragEnter,
+    handleOsDragOver,
+    handleOsDragLeave,
+    handleOsDrop,
+  } = useFolderOsDrop(actions.importPathsIntoView);
 
-  const handleOpenInSplit = useCallback((item: Resource) => {
-    if (!canOpenInSplit) return;
-    openResourceInSplit(item.id, item.type, item.title ?? '');
-  }, [canOpenInSplit, openResourceInSplit]);
-
-  const handleOpenInWindow = useCallback(async (item: Resource) => {
-    if (!window.electron?.invoke || item.type !== 'note') return;
-    try {
-      await window.electron.invoke('window:create', {
-        id: `note-focus:${item.id}`,
-        route: `/focus/note/${encodeURIComponent(item.id)}`,
-        options: {
-          width: 960,
-          height: 760,
-          minWidth: 560,
-          minHeight: 480,
-          title: `${item.title || 'Nota'} — Dome`,
-          transparent: false,
-        },
-      });
-    } catch (err) {
-      console.error('[FolderTabView] Failed to open popout:', err);
-    }
-  }, []);
-
-  const handleNewSubfolder = useCallback((parentId: string) => {
-    setCreateFolderParentId(parentId);
-    setCreatingFolder(true);
-  }, []);
-
-  const handleNewNote = useCallback(async () => {
-    if (!window.electron?.db?.resources?.create) return;
-    const now = Date.now();
-    const res = {
-      id: `res_${now}_${Math.random().toString(36).substr(2, 9)}`,
-      type: 'note' as const,
-      title: t('dashboard.untitled_note', 'Nota sin título'),
-      content: '',
-      project_id: effectiveProjectId,
-      folder_id: listFolderId,
-      created_at: now,
-      updated_at: now,
-    };
-    const result = await window.electron.db.resources.create(res);
-    if (result.success && result.data) {
-      openResourceTab(result.data.id, 'note', result.data.title, effectiveProjectId);
-    }
-  }, [effectiveProjectId, listFolderId, t, openResourceTab]);
-
-  const importPathsIntoView = useCallback(async (paths: string[]) => {
-    if (!paths.length || !window.electron?.resource?.importMultiple) return;
-    const result = await window.electron.resource.importMultiple(paths, effectiveProjectId);
-    if (listFolderId && result?.data?.length) {
-      const moves: Promise<unknown>[] = [];
-      for (const entry of result.data) {
-        if (!entry.success || !entry.data?.id) continue;
-        moves.push(window.electron?.db?.resources?.moveToFolder(entry.data.id, listFolderId));
-      }
-      await Promise.all(moves);
-    }
-    await refetch();
-  }, [effectiveProjectId, listFolderId, refetch]);
-
-  const handleUpload = useCallback(async () => {
-    if (!window.electron?.selectFiles) return;
-    const paths = await window.electron.selectFiles({ properties: ['openFile', 'multiSelections'] });
-    if (!paths?.length) return;
-    await importPathsIntoView(paths);
-  }, [importPathsIntoView]);
-
-  // ── Drag & drop import from Finder / OS file explorer ─────────────────────
-  // dragenter/dragleave fire on every child; a depth counter keeps the overlay
-  // stable until the pointer actually leaves the view.
-  const dragDepthRef = useRef(0);
-  const [osDropActive, setOsDropActive] = useState(false);
-
-  const isOsFileDrag = useCallback((e: React.DragEvent) => {
-    return Array.from(e.dataTransfer?.types ?? []).includes('Files');
-  }, []);
-
-  const handleOsDragEnter = useCallback((e: React.DragEvent) => {
-    if (!isOsFileDrag(e)) return;
-    e.preventDefault();
-    dragDepthRef.current += 1;
-    setOsDropActive(true);
-  }, [isOsFileDrag]);
-
-  const handleOsDragOver = useCallback((e: React.DragEvent) => {
-    if (!isOsFileDrag(e)) return;
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'copy';
-  }, [isOsFileDrag]);
-
-  const handleOsDragLeave = useCallback((e: React.DragEvent) => {
-    if (!isOsFileDrag(e)) return;
-    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
-    if (dragDepthRef.current === 0) setOsDropActive(false);
-  }, [isOsFileDrag]);
-
-  const handleOsDrop = useCallback(async (e: React.DragEvent) => {
-    if (!isOsFileDrag(e)) return;
-    e.preventDefault();
-    dragDepthRef.current = 0;
-    setOsDropActive(false);
-    const files = Array.from(e.dataTransfer.files ?? []);
-    if (!files.length) return;
-    const paths = (window.electron?.getPathsForFiles?.(files) ?? []).filter(Boolean) as string[];
-    if (!paths.length) return;
-    await importPathsIntoView(paths);
-  }, [isOsFileDrag, importPathsIntoView]);
-
-  const handleAddUrl = useCallback((url: string) => {
-    if (url && window.electron?.db?.resources?.create) {
-      const now = Date.now();
-      void window.electron.db.resources.create({
-        id: `res_${now}_${Math.random().toString(36).substr(2, 9)}`,
-        type: 'url',
-        title: url.replace(/^https?:\/\/(www\.)?/, '').split('/')[0],
-        project_id: effectiveProjectId,
-        folder_id: listFolderId,
-        content: url,
-        created_at: now,
-        updated_at: now,
-      });
-    }
-  }, [effectiveProjectId, listFolderId]);
-
-  const handleDeleteConfirm = useCallback(async () => {
-    if (!deleteTarget) return;
-    await deleteResource(deleteTarget.id);
-    setDeleteTarget(null);
-  }, [deleteTarget, deleteResource]);
-
-  const revealLabel =
-    typeof navigator !== 'undefined' && /Mac|iPhone|iPad/i.test(navigator.platform)
-      ? t('folder.reveal_in_finder')
-      : t('folder.reveal_in_explorer');
-
-  // Open the current folder (or the project vault root) in Finder/Explorer.
-  const handleRevealCurrentFolder = useCallback(async () => {
-    if (viewCtx.isProjectRoot || !currentFolder) {
-      await window.electron?.resource?.openVaultRoot(effectiveProjectId);
-      return;
-    }
-    const res = await window.electron?.resource?.getFilePath(currentFolder.id);
-    if (res?.success && typeof res.data === 'string') {
-      await window.electron?.openPath?.(res.data);
-    } else {
-      await window.electron?.resource?.openVaultRoot(effectiveProjectId);
-    }
-  }, [viewCtx.isProjectRoot, currentFolder, effectiveProjectId]);
-
-  const handleRenameFile = useCallback(async (id: string, newTitle: string) => {
-    await updateResource(id, { title: newTitle });
-  }, [updateResource]);
-
-  const handleSubfolderRename = useCallback(async (id: string, newTitle: string) => {
-    await updateResource(id, { title: newTitle });
-    updateTab(`folder:${id}`, { title: newTitle });
-  }, [updateResource, updateTab]);
-
-
-  const handleSubfolderColor = useCallback(async (id: string, color: string, folder: Resource) => {
-    const currentMeta = (folder.metadata as Record<string, unknown>) ?? {};
-    await updateResource(id, { metadata: { ...currentMeta, color } });
-    updateTab(`folder:${id}`, { color });
-  }, [updateResource, updateTab]);
-
-  const listItems = useMemo(() => {
-    if (tagFilterId) {
-      return allResources
-        .filter(
-          (r) => r.project_id === effectiveProjectId && taggedResourceIds.has(r.id) && r.type !== 'folder',
-        )
-        .map((item) => ({ item, isFolder: false as const }));
-    }
-    const folders = subfolders.map((f) => ({ item: f, isFolder: true as const }));
-    const docs = files.map((f) => ({ item: f, isFolder: false as const }));
-    return [...folders, ...docs];
-  }, [tagFilterId, allResources, effectiveProjectId, taggedResourceIds, subfolders, files]);
+  const listItems = useMemo(
+    () =>
+      buildFolderListItems({
+        tagFilterId,
+        allResources,
+        effectiveProjectId,
+        taggedResourceIds,
+        subfolders,
+        files,
+      }),
+    [tagFilterId, allResources, effectiveProjectId, taggedResourceIds, subfolders, files],
+  );
 
   const normalizedSearchQuery = searchQuery.trim().toLowerCase();
   const isFiltering = normalizedSearchQuery.length > 0;
   const isTagFiltering = tagFilterId !== null;
   const activeTag = projectTags.find((tag) => tag.id === tagFilterId);
 
-  const filteredListItems = useMemo(() => {
-    if (!isFiltering) return listItems;
-    return listItems.filter(({ item }) =>
-      (item.title ?? t('folder.untitled')).toLowerCase().includes(normalizedSearchQuery),
-    );
-  }, [listItems, isFiltering, normalizedSearchQuery, t]);
-
-  const closeSearch = useCallback(() => {
-    setSearchOpen(false);
-    setSearchQuery('');
-    setSearchFocusIndex(0);
-  }, []);
-
-  const openSearch = useCallback(() => {
-    setSearchOpen(true);
-    requestAnimationFrame(() => searchInputRef.current?.focus());
-  }, []);
-
-  const openListItem = useCallback(
-    ({ item, isFolder }: { item: Resource; isFolder: boolean }) => {
-      if (isFolder) handleNavigateToFolder(item.id, item.title, getFolderColor(item));
-      else openResourceTab(item.id, item.type, item.title ?? t('folder.untitled'), effectiveProjectId);
-    },
-    [handleNavigateToFolder, openResourceTab, t, effectiveProjectId],
+  const filteredListItems = useMemo(
+    () => filterListItemsBySearch(listItems, normalizedSearchQuery, t('folder.untitled')),
+    [listItems, normalizedSearchQuery, t],
   );
+
+  const { setRowRef, closeSearch, openSearch, handleSearchKeyDown } = useFolderTabSearchController({
+    searchOpen,
+    searchQuery,
+    setSearchQuery,
+    setSearchOpen,
+    searchFocusIndex,
+    setSearchFocusIndex,
+    searchInputRef,
+    filteredListItems,
+    normalizedSearchQuery,
+    isFiltering,
+    openListItem: actions.openListItem,
+  });
 
   const prevFolderIdRef = useRef(folderId);
   if (folderId !== prevFolderIdRef.current) {
@@ -579,70 +310,15 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
     setTagFilterId(null);
   }
 
-  useEffect(() => {
-    setSearchFocusIndex(0);
-  }, [normalizedSearchQuery]);
-
-  useEffect(() => {
-    if (!isFiltering || filteredListItems.length === 0) return;
-    const focused = filteredListItems[Math.min(searchFocusIndex, filteredListItems.length - 1)];
-    if (!focused) return;
-    rowRefMap.get(focused.item.id)?.scrollIntoView({ block: 'nearest' });
-  }, [searchFocusIndex, filteredListItems, isFiltering, rowRefMap]);
-
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
-        e.preventDefault();
-        if (searchOpen) {
-          searchInputRef.current?.focus();
-          searchInputRef.current?.select();
-        } else {
-          openSearch();
-        }
-      }
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [searchOpen, openSearch]);
-
-  const handleSearchKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        closeSearch();
-        return;
-      }
-      if (filteredListItems.length === 0) return;
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        setSearchFocusIndex((i) => Math.min(i + 1, filteredListItems.length - 1));
-        return;
-      }
-      if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        setSearchFocusIndex((i) => Math.max(i - 1, 0));
-        return;
-      }
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        const target = filteredListItems[searchFocusIndex] ?? filteredListItems[0];
-        if (target) openListItem(target);
-      }
-    },
-    [closeSearch, filteredListItems, openListItem, searchFocusIndex],
-  );
-
   const openFolderColorPicker = useCallback(() => {
-    if (!folderMenuBtnRef.current) return;
-    const rect = folderMenuBtnRef.current.getBoundingClientRect();
-    const popoverWidth = 196;
-    const left = Math.min(
-      Math.max(8, rect.right - popoverWidth),
-      window.innerWidth - popoverWidth - 8,
-    );
-    const top = Math.min(rect.bottom + 6, window.innerHeight - 100);
-    setColorPickerPos({ top, left });
+    const btn = folderMenuBtnRef.current;
+    if (!btn) return;
+    setColorPickerPos(colorPickerPositionFromRect(btn.getBoundingClientRect()));
+  }, []);
+
+  const onCancelCreateFolder = useCallback(() => {
+    setCreatingFolder(false);
+    setCreateFolderParentId(null);
   }, []);
 
   if (isLoading) {
@@ -653,35 +329,21 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
     );
   }
 
-  const itemCount = tagFilterId ? listItems.length : subfolders.length + files.length;
-  const visibleCount = isFiltering || isTagFiltering ? filteredListItems.length : itemCount;
-  const isEmpty = !isTagFiltering && itemCount === 0 && !creatingFolder;
-  const showNoResults = (isFiltering || isTagFiltering) && filteredListItems.length === 0;
-  const rowsToRender = isFiltering || isTagFiltering ? filteredListItems : listItems;
-
-  const statusLabel = isTagFiltering && activeTag
-    ? t('folder.tagFilterActive', { name: activeTag.name, count: visibleCount, defaultValue: '{{name}} · {{count}}' })
-    : isFiltering
-      ? t('folder.searchResultCount', { count: visibleCount, total: itemCount })
-      : t('folder.itemCount', { count: itemCount });
-
-  // Per-card callback factories. Extracted from `renderCard` so its cognitive
-  // complexity stays under the Sonar limit; the inline `isFolder ? ... : ...`
-  // ternaries previously nested inside JSX-prop arrows pushed it over 15.
-  const buildCardRefHandler = (id: string) => (el: HTMLDivElement | null) => {
-    if (el) rowRefMap.set(id, el as unknown as HTMLDivElement);
-    else rowRefMap.delete(id);
-  };
-  const buildRenameHandler = (item: Resource, isFolder: boolean) => (newTitle: string) =>
-    void (isFolder ? handleSubfolderRename(item.id, newTitle) : handleRenameFile(item.id, newTitle));
-  const buildChangeColorHandler = (item: Resource, isFolder: boolean) =>
-    isFolder ? (color: string) => void handleSubfolderColor(item.id, color, item) : undefined;
-  const buildOpenInSplitHandler = (item: Resource, isFolder: boolean) =>
-    !isFolder && canOpenInSplit ? () => handleOpenInSplit(item) : undefined;
-  const buildOpenInWindowHandler = (item: Resource, isFolder: boolean) =>
-    !isFolder ? () => void handleOpenInWindow(item) : undefined;
-  const buildNewSubfolderHandler = (item: Resource, isFolder: boolean) =>
-    isFolder ? () => handleNewSubfolder(item.id) : undefined;
+  const { isEmpty, showNoResults, rowsToRender, statusLabel } = computeFolderViewStatus({
+    tagFilterId,
+    listItems,
+    subfoldersLen: subfolders.length,
+    filesLen: files.length,
+    creatingFolder,
+    isFiltering,
+    isTagFiltering,
+    filteredListItems,
+    activeTagName: activeTag?.name,
+    statusTag: ({ name, count }) =>
+      t('folder.tagFilterActive', { name, count, defaultValue: '{{name}} · {{count}}' }),
+    statusSearch: ({ count, total }) => t('folder.searchResultCount', { count, total }),
+    statusCount: ({ count }) => t('folder.itemCount', { count }),
+  });
 
   return (
     <div
@@ -691,305 +353,51 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
       onDragLeave={handleOsDragLeave}
       onDrop={handleOsDrop}
     >
-      {osDropActive && (
-        <div className="dome-folder-view__drop-overlay" aria-hidden>
-          <div className="dome-folder-view__drop-overlay-card">
-            <HugeiconsIcon icon={Upload04Icon} className="size-6" aria-hidden />
-            <span>{t('folder.dropToImport', 'Suelta para importar aquí')}</span>
-          </div>
-        </div>
-      )}
-      <div className="dome-folder-view__toolbar">
-        <div className="dome-folder-view__nav-controls">
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={goBack}
-                  disabled={!canGoBack}
-                  aria-label={t('folder.navBack', 'Atrás')}
-                />
-              }
-            >
-              <HugeiconsIcon icon={ArrowLeft01Icon} />
-            </TooltipTrigger>
-            <TooltipContent>{t('folder.navBack', 'Atrás')}</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={goForward}
-                  disabled={!canGoForward}
-                  aria-label={t('folder.navForward', 'Adelante')}
-                />
-              }
-            >
-              <HugeiconsIcon icon={ArrowRight01Icon} />
-            </TooltipTrigger>
-            <TooltipContent>{t('folder.navForward', 'Adelante')}</TooltipContent>
-          </Tooltip>
-        </div>
+      <FolderTabDropOverlay active={osDropActive} />
 
-        <Separator orientation="vertical" className="h-5" />
-
-        <nav className="dome-folder-view__breadcrumb" aria-label={t('folder.breadcrumb', 'Ruta')}>
-          {viewCtx.isProjectRoot ? (
-            <span
-              className="dome-folder-view__breadcrumb-current"
-              title={projectRootLabel}
-              aria-current="page"
-            >
-              {projectRootLabel}
-            </span>
-          ) : (
-            <>
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                onClick={handleNavigateToProjectRoot}
-                className="h-6 max-w-28 shrink-0 truncate px-1.5 text-muted-foreground"
-                title={projectRootLabel}
-              >
-                {projectRootLabel}
-              </Button>
-              {breadcrumb.map((folder) => (
-                <Fragment key={folder.id}>
-                  <HugeiconsIcon icon={ArrowRight01Icon} className="size-3 shrink-0 text-muted-foreground/60" />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="xs"
-                    onClick={() => handleNavigateToFolder(folder.id, folder.title, getFolderColor(folder))}
-                    className="h-6 max-w-28 shrink truncate px-1.5 text-muted-foreground"
-                    title={folder.title}
-                  >
-                    {folder.title}
-                  </Button>
-                </Fragment>
-              ))}
-              {breadcrumb.length > 0 && (
-                <HugeiconsIcon icon={ArrowRight01Icon} className="size-3 shrink-0 text-muted-foreground/60" />
-              )}
-              <span className="dome-folder-view__breadcrumb-current" title={displayTitle} aria-current="page">
-                {displayTitle}
-              </span>
-            </>
-          )}
-        </nav>
-
-        <div className="dome-folder-view__toolbar-end">
-          <ToggleGroup
-            value={[viewMode]}
-            onValueChange={(values) => {
-              const next = values[0];
-              if (next === 'grid' || next === 'list') setFolderViewMode(next);
-            }}
-            variant="outline"
-            size="sm"
-            spacing={0}
-            aria-label={t('folder.viewMode', 'Modo de vista')}
-          >
-            <ToggleGroupItem value="grid" aria-label={t('folder.gridView', 'Vista de cuadrícula')}>
-              <HugeiconsIcon icon={LayoutGridIcon} />
-            </ToggleGroupItem>
-            <ToggleGroupItem value="list" aria-label={t('folder.listView', 'Vista de lista')}>
-              <HugeiconsIcon icon={Menu01Icon} />
-            </ToggleGroupItem>
-          </ToggleGroup>
-
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <DropdownMenuTrigger
-                    render={
-                      <Button
-                        type="button"
-                        variant={isTagFiltering ? 'secondary' : 'ghost'}
-                        size="icon-sm"
-                        aria-label={t('folder.tagFilter', 'Filtrar por tag')}
-                      />
-                    }
-                  />
-                }
-              >
-                <HugeiconsIcon icon={Tag01Icon} />
-              </TooltipTrigger>
-              <TooltipContent>
-                {activeTag ? activeTag.name : t('folder.tagFilter', 'Filtrar por tag')}
-              </TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent side="bottom" align="end" sideOffset={4} className="w-52">
-              <DropdownMenuGroup>
-                <DropdownMenuItem onClick={() => setTagFilterId(null)}>
-                  {t('folder.tagFilterAll', 'Todos los tags')}
-                </DropdownMenuItem>
-                {projectTags.length === 0 ? (
-                  <DropdownMenuItem disabled>
-                    {t('tags.no_tags', 'Sin tags')}
-                  </DropdownMenuItem>
-                ) : (
-                  projectTags.map((tag) => (
-                    <DropdownMenuItem
-                      key={tag.id}
-                      className={cn(tagFilterId === tag.id && 'font-semibold')}
-                      onClick={() => setTagFilterId(tag.id)}
-                    >
-                      <span className="truncate">{tag.name}</span>
-                      <span className="ml-auto text-muted-foreground tabular-nums">{tag.resource_count}</span>
-                    </DropdownMenuItem>
-                  ))
-                )}
-              </DropdownMenuGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          {searchOpen ? (
-            <InputGroup className="w-[min(240px,42vw)] min-w-36">
-              <InputGroupAddon align="inline-start">
-                <HugeiconsIcon icon={Search01Icon} />
-              </InputGroupAddon>
-              <InputGroupInput
-                ref={searchInputRef}
-                type="search"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                onKeyDown={handleSearchKeyDown}
-                placeholder={t('folder.searchPlaceholder', { shortcut: searchModHint })}
-                aria-label={t('folder.searchAria', { shortcut: searchModHint })}
-                autoComplete="off"
-                spellCheck={false}
-              />
-              <InputGroupAddon align="inline-end">
-                <InputGroupButton
-                  size="icon-xs"
-                  onClick={() => {
-                    if (searchQuery) {
-                      setSearchQuery('');
-                      searchInputRef.current?.focus();
-                    } else {
-                      closeSearch();
-                    }
-                  }}
-                  aria-label={t('folder.searchClear', 'Clear search')}
-                >
-                  <HugeiconsIcon icon={Cancel01Icon} />
-                </InputGroupButton>
-              </InputGroupAddon>
-            </InputGroup>
-          ) : (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={openSearch}
-                    aria-label={t('folder.searchAria', { shortcut: searchModHint })}
-                  />
-                }
-              >
-                <HugeiconsIcon icon={Search01Icon} />
-              </TooltipTrigger>
-              <TooltipContent>
-                {t('folder.searchPlaceholder', { shortcut: searchModHint })}
-              </TooltipContent>
-            </Tooltip>
-          )}
-
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <DropdownMenuTrigger
-                    render={
-                      <Button
-                        ref={folderMenuBtnRef}
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        aria-label={t('folder.folderMenu', 'Opciones de carpeta')}
-                      />
-                    }
-                  />
-                }
-              >
-                <HugeiconsIcon icon={MoreHorizontalIcon} />
-              </TooltipTrigger>
-              <TooltipContent>{t('folder.folderMenu', 'Opciones de carpeta')}</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent side="bottom" align="end" sideOffset={4} className="w-52">
-              <DropdownMenuGroup>
-                {!viewCtx.isProjectRoot && currentFolder ? (
-                  <DropdownMenuItem onClick={openFolderColorPicker}>
-                    <HugeiconsIcon icon={PaintBoardIcon} data-icon="inline-start" />
-                    {t('folder.changeColor', 'Cambiar color')}
-                  </DropdownMenuItem>
-                ) : null}
-                <DropdownMenuItem onClick={() => void handleRevealCurrentFolder()}>
-                  <HugeiconsIcon icon={FolderExportIcon} data-icon="inline-start" />
-                  {revealLabel}
-                </DropdownMenuItem>
-              </DropdownMenuGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <DropdownMenuTrigger
-                    render={
-                      <Button
-                        type="button"
-                        size="icon-sm"
-                        aria-label={t('folder.addBtn', 'Añadir')}
-                      />
-                    }
-                  />
-                }
-              >
-                <HugeiconsIcon icon={Add01Icon} strokeWidth={2.25} />
-              </TooltipTrigger>
-              <TooltipContent>{t('folder.addBtn', 'Añadir')}</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent side="bottom" align="end" sideOffset={4} className="w-48">
-              <DropdownMenuGroup>
-                <DropdownMenuItem onClick={() => setCreatingFolder(true)}>
-                  <HugeiconsIcon icon={FolderAddIcon} data-icon="inline-start" />
-                  {t('folder.newFolderBtn')}
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={handleNewNote}>
-                  <HugeiconsIcon icon={FileEditIcon} data-icon="inline-start" />
-                  {t('toolbar.note', 'Nota')}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={handleUpload}>
-                  <HugeiconsIcon icon={Upload04Icon} data-icon="inline-start" />
-                  {t('toolbar.import', 'Importar')}
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setUrlModalOpen(true)}>
-                  <HugeiconsIcon icon={LinkSquare01Icon} data-icon="inline-start" />
-                  {t('toolbar.link', 'URL')}
-                </DropdownMenuItem>
-              </DropdownMenuGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
+      <FolderTabToolbar
+        canGoBack={canGoBack}
+        canGoForward={canGoForward}
+        goBack={goBack}
+        goForward={goForward}
+        isProjectRoot={viewCtx.isProjectRoot}
+        projectRootLabel={projectRootLabel}
+        breadcrumb={breadcrumb}
+        displayTitle={displayTitle}
+        handleNavigateToProjectRoot={actions.handleNavigateToProjectRoot}
+        handleNavigateToFolder={actions.handleNavigateToFolder}
+        viewMode={viewMode}
+        setFolderViewMode={setFolderViewMode}
+        isTagFiltering={isTagFiltering}
+        tagFilterId={tagFilterId}
+        setTagFilterId={setTagFilterId}
+        projectTags={projectTags}
+        activeTag={activeTag}
+        searchOpen={searchOpen}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        searchInputRef={searchInputRef}
+        handleSearchKeyDown={handleSearchKeyDown}
+        searchModHint={searchModHint}
+        openSearch={openSearch}
+        closeSearch={closeSearch}
+        folderMenuBtnRef={folderMenuBtnRef}
+        currentFolder={currentFolder}
+        openFolderColorPicker={openFolderColorPicker}
+        handleRevealCurrentFolder={actions.handleRevealCurrentFolder}
+        revealLabel={revealLabel}
+        setCreatingFolder={setCreatingFolder}
+        handleNewNote={actions.handleNewNote}
+        handleUpload={actions.handleUpload}
+        setUrlModalOpen={setUrlModalOpen}
+      />
 
       <SelectionActionBar
         count={selectedIds.size}
-        onMoveToFolder={() => { setFolderMoveIds(null); setFolderPickOpen(true); }}
+        onMoveToFolder={() => {
+          setFolderMoveIds(null);
+          setFolderPickOpen(true);
+        }}
         onMoveToProject={() =>
           setMoveProjectIds([...filterMoveProjectRoots(selectedIds, resourceMapForSelection)])
         }
@@ -1001,7 +409,7 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
         <ColorPickerPopover
           pos={colorPickerPos}
           currentColor={folderColorHex ?? FOLDER_COLOR_DEFAULT}
-          onSave={handleCurrentFolderColor}
+          onSave={actions.handleCurrentFolderColor}
           onClose={() => setColorPickerPos(null)}
         />
       ) : null}
@@ -1010,167 +418,74 @@ export default function FolderTabView({ folderId, folderTitle }: FolderTabViewPr
         className={`dome-folder-view__list dome-folder-view__list--${viewMode}`}
         data-view-mode={viewMode}
       >
-        {showNoResults ? (
-          <p className="dome-folder-view__empty dome-folder-view__empty--search">
-            {isTagFiltering
-              ? t('folder.tagFilterEmpty', 'Ningún recurso con este tag')
-              : t('folder.searchNoResults', { query: searchQuery.trim() })}
-          </p>
-        ) : !isEmpty || isTagFiltering ? (
-          viewMode === 'list' ? (
-            <>
-              <div className="dome-folder-view__list-header">
-                <span className="dome-folder-view__list-header-name">
-                  {t('folder.colName', 'Nombre')}
-                  <span className="dome-folder-view__list-header-count">{statusLabel}</span>
-                </span>
-                <span className="dome-folder-view__col-modified">{t('folder.colModified', 'Modificado')}</span>
-                <span aria-hidden />
-              </div>
-
-              {rowsToRender.map(({ item, isFolder }, idx) => (
-                <FolderListRow
-                  key={item.id}
-                  item={item}
-                  isFolder={isFolder}
-                  isLast={idx === rowsToRender.length - 1 && !creatingFolder}
-                  rowRef={(el) => {
-                    if (el) rowRefMap.set(item.id, el);
-                    else rowRefMap.delete(item.id);
-                  }}
-                  onOpen={() => {
-                    if (isFolder) handleNavigateToFolder(item.id, item.title, getFolderColor(item));
-                    else openResourceTab(item.id, item.type, item.title ?? t('folder.untitled'), effectiveProjectId);
-                  }}
-                  onDelete={() => setDeleteTarget(item)}
-                  onRename={(newTitle) => void (isFolder ? handleSubfolderRename(item.id, newTitle) : handleRenameFile(item.id, newTitle))}
-                  onChangeColor={isFolder ? (color) => void handleSubfolderColor(item.id, color, item) : undefined}
-                  onMoveToProject={() => setMoveProjectIds([item.id])}
-                  onMoveToFolder={() => openFolderPickerFor(item.id)}
-                  onOpenInSplit={!isFolder && canOpenInSplit ? () => handleOpenInSplit(item) : undefined}
-                  onOpenInWindow={!isFolder ? () => void handleOpenInWindow(item) : undefined}
-                  onNewSubfolder={isFolder ? () => handleNewSubfolder(item.id) : undefined}
-                  selected={selectedIds.has(item.id)}
-                  showSelectionChrome={showSelectionChrome}
-                  onToggleSelect={(e) => {
-                    e.stopPropagation();
-                    toggleSelectId(item.id);
-                  }}
-                  searchQuery={isFiltering ? normalizedSearchQuery : undefined}
-                  searchFocused={isFiltering && idx === searchFocusIndex}
-                />
-              ))}
-
-              {creatingFolder ? (
-                <div className="dome-folder-view__inline-create">
-                  <NewFolderInline
-                    variant="list"
-                    onConfirm={handleCreateFolder}
-                    onCancel={() => { setCreatingFolder(false); setCreateFolderParentId(null); }}
-                  />
-                </div>
-              ) : null}
-            </>
-          ) : (
-            <>
-              <div className="dome-folder-view__grid-header">
-                <span className="dome-folder-view__list-header-count">{statusLabel}</span>
-              </div>
-              <div className="dome-folder-view__grid">
-                {rowsToRender.map(({ item, isFolder }, idx) => (
-                  <FolderCard
-                    key={item.id}
-                    item={item}
-                    isFolder={isFolder}
-                    isLast={idx === rowsToRender.length - 1 && !creatingFolder}
-                    cardRef={buildCardRefHandler(item.id)}
-                    onOpen={() => openListItem({ item, isFolder })}
-                    onDelete={() => setDeleteTarget(item)}
-                    onRename={buildRenameHandler(item, isFolder)}
-                    onChangeColor={buildChangeColorHandler(item, isFolder)}
-                    onMoveToProject={() => setMoveProjectIds([item.id])}
-                    onMoveToFolder={() => openFolderPickerFor(item.id)}
-                    onOpenInSplit={buildOpenInSplitHandler(item, isFolder)}
-                    onOpenInWindow={buildOpenInWindowHandler(item, isFolder)}
-                    onNewSubfolder={buildNewSubfolderHandler(item, isFolder)}
-                    selected={selectedIds.has(item.id)}
-                    showSelectionChrome={showSelectionChrome}
-                    onToggleSelect={(e) => {
-                      e.stopPropagation();
-                      toggleSelectId(item.id);
-                    }}
-                    searchQuery={isFiltering ? normalizedSearchQuery : undefined}
-                    searchFocused={isFiltering && idx === searchFocusIndex}
-                  />
-                ))}
-                {creatingFolder ? (
-                  <div className="dome-folder-view__inline-create dome-folder-view__inline-create--grid">
-                    <NewFolderInline
-                      variant="grid"
-                      onConfirm={handleCreateFolder}
-                      onCancel={() => { setCreatingFolder(false); setCreateFolderParentId(null); }}
-                    />
-                  </div>
-                ) : null}
-              </div>
-            </>
-          )
-        ) : creatingFolder ? (
-          <div className="dome-folder-view__grid dome-folder-view__grid--empty-create">
-            <div className="dome-folder-view__inline-create dome-folder-view__inline-create--grid">
-              <NewFolderInline
-                variant="grid"
-                onConfirm={handleCreateFolder}
-                onCancel={() => { setCreatingFolder(false); setCreateFolderParentId(null); }}
-              />
-            </div>
-          </div>
-        ) : (
-          <p className="dome-folder-view__empty">{t('folder.emptyFolderShort', 'Carpeta vacía')}</p>
-        )}
+        <FolderTabBody
+          viewMode={viewMode}
+          showNoResults={showNoResults}
+          isEmpty={isEmpty}
+          isTagFiltering={isTagFiltering}
+          isFiltering={isFiltering}
+          creatingFolder={creatingFolder}
+          statusLabel={statusLabel}
+          searchQuery={searchQuery}
+          normalizedSearchQuery={normalizedSearchQuery}
+          rowsToRender={rowsToRender}
+          searchFocusIndex={searchFocusIndex}
+          selectedIds={selectedIds}
+          showSelectionChrome={showSelectionChrome}
+          canOpenInSplit={canOpenInSplit}
+          effectiveProjectId={effectiveProjectId}
+          setRowRef={setRowRef}
+          openListItem={actions.openListItem}
+          handleNavigateToFolder={actions.handleNavigateToFolder}
+          openResourceTab={openResourceTab}
+          setDeleteTarget={setDeleteTarget}
+          handleSubfolderRename={actions.handleSubfolderRename}
+          handleRenameFile={actions.handleRenameFile}
+          handleSubfolderColor={actions.handleSubfolderColor}
+          setMoveProjectIds={setMoveProjectIds}
+          openFolderPickerFor={openFolderPickerFor}
+          handleOpenInSplit={actions.handleOpenInSplit}
+          handleOpenInWindow={actions.handleOpenInWindow}
+          handleNewSubfolder={actions.handleNewSubfolder}
+          toggleSelectId={toggleSelectId}
+          handleCreateFolder={actions.handleCreateFolder}
+          onCancelCreateFolder={onCancelCreateFolder}
+        />
       </div>
 
-      <MoveFolderModal
-        open={folderPickOpen}
-        onClose={() => { setFolderPickOpen(false); setFolderMoveIds(null); }}
-        resourceIds={folderMoveIds ?? filterMoveProjectRoots(selectedIds, resourceMapForSelection)}
+      <FolderTabDialogs
+        folderPickOpen={folderPickOpen}
+        onCloseFolderPick={() => {
+          setFolderPickOpen(false);
+          setFolderMoveIds(null);
+        }}
+        folderMoveIds={folderMoveIds}
+        selectedIds={selectedIds}
+        resourceMapForSelection={resourceMapForSelection}
         allFolders={allFolders}
-        projectId={effectiveProjectId}
-        currentFolderId={listFolderId}
-        onConfirm={handleBulkMoveToFolder}
+        effectiveProjectId={effectiveProjectId}
+        listFolderId={listFolderId}
+        onConfirmBulkMove={handleBulkMoveToFolder}
+        moveProjectIds={moveProjectIds}
+        onCloseMoveProject={() => setMoveProjectIds([])}
+        onMoveProjectCompleted={() => {
+          void refetch();
+        }}
+        deleteTarget={deleteTarget}
+        onConfirmDelete={() => {
+          void actions.handleDeleteConfirm();
+        }}
+        onCloseDelete={() => setDeleteTarget(null)}
+        bulkDeleteOpen={bulkDeleteOpen}
+        bulkDeleting={bulkDeleting}
+        onConfirmBulkDelete={() => {
+          void handleBulkDelete();
+        }}
+        onCloseBulkDelete={() => setBulkDeleteOpen(false)}
+        urlModalOpen={urlModalOpen}
+        onConfirmUrl={actions.handleAddUrl}
+        onCloseUrl={() => setUrlModalOpen(false)}
       />
-
-      <MoveToProjectModal
-        opened={moveProjectIds.length > 0}
-        onClose={() => setMoveProjectIds([])}
-        resourceIds={moveProjectIds}
-        resourcesById={resourceMapForSelection}
-        onCompleted={() => void refetch()}
-      />
-
-      {deleteTarget && (
-        <DeleteConfirmModal
-          resource={deleteTarget}
-          onConfirm={() => void handleDeleteConfirm()}
-          onClose={() => setDeleteTarget(null)}
-        />
-      )}
-
-      {bulkDeleteOpen && (
-        <BulkDeleteConfirmModal
-          count={selectedIds.size}
-          busy={bulkDeleting}
-          onConfirm={() => void handleBulkDelete()}
-          onClose={() => setBulkDeleteOpen(false)}
-        />
-      )}
-
-      {urlModalOpen && (
-        <UrlInputModal
-          onConfirm={handleAddUrl}
-          onClose={() => setUrlModalOpen(false)}
-        />
-      )}
     </div>
   );
 }

--- a/app/components/shell/folder-tab/FolderTabBody.tsx
+++ b/app/components/shell/folder-tab/FolderTabBody.tsx
@@ -1,0 +1,239 @@
+/** Folder tab list/grid body (extracted from FolderTabView for Sonar S3776). */
+
+import { useTranslation } from 'react-i18next';
+import type { Resource } from '@/lib/hooks/useResources';
+import { getFolderColor } from './folderTabShared';
+import FolderListRow from './FolderListRow';
+import FolderCard from './FolderCard';
+import NewFolderInline from './NewFolderInline';
+import type { FolderListEntry, FolderViewMode } from './folderTabViewHelpers';
+
+export interface FolderTabBodyProps {
+  viewMode: FolderViewMode;
+  showNoResults: boolean;
+  isEmpty: boolean;
+  isTagFiltering: boolean;
+  isFiltering: boolean;
+  creatingFolder: boolean;
+  statusLabel: string;
+  searchQuery: string;
+  normalizedSearchQuery: string;
+  rowsToRender: FolderListEntry[];
+  searchFocusIndex: number;
+  selectedIds: Set<string>;
+  showSelectionChrome: boolean;
+  canOpenInSplit: boolean;
+  effectiveProjectId: string;
+  setRowRef: (id: string) => (el: HTMLDivElement | null) => void;
+  openListItem: (entry: FolderListEntry) => void;
+  handleNavigateToFolder: (id: string, title: string, color?: string) => void;
+  openResourceTab: (
+    id: string,
+    type: string,
+    title: string,
+    projectId: string,
+  ) => void;
+  setDeleteTarget: (item: Resource) => void;
+  handleSubfolderRename: (id: string, title: string) => void | Promise<void>;
+  handleRenameFile: (id: string, title: string) => void | Promise<void>;
+  handleSubfolderColor: (id: string, color: string, folder: Resource) => void | Promise<void>;
+  setMoveProjectIds: (ids: string[]) => void;
+  openFolderPickerFor: (id: string) => void;
+  handleOpenInSplit: (item: Resource) => void;
+  handleOpenInWindow: (item: Resource) => void | Promise<void>;
+  handleNewSubfolder: (parentId: string) => void;
+  toggleSelectId: (id: string) => void;
+  handleCreateFolder: (name: string) => void | Promise<void>;
+  onCancelCreateFolder: () => void;
+}
+
+export default function FolderTabBody(props: FolderTabBodyProps) {
+  const { t } = useTranslation();
+  const {
+    viewMode,
+    showNoResults,
+    isEmpty,
+    isTagFiltering,
+    isFiltering,
+    creatingFolder,
+    statusLabel,
+    searchQuery,
+    normalizedSearchQuery,
+    rowsToRender,
+    searchFocusIndex,
+    selectedIds,
+    showSelectionChrome,
+    canOpenInSplit,
+    effectiveProjectId,
+    setRowRef,
+    openListItem,
+    handleNavigateToFolder,
+    openResourceTab,
+    setDeleteTarget,
+    handleSubfolderRename,
+    handleRenameFile,
+    handleSubfolderColor,
+    setMoveProjectIds,
+    openFolderPickerFor,
+    handleOpenInSplit,
+    handleOpenInWindow,
+    handleNewSubfolder,
+    toggleSelectId,
+    handleCreateFolder,
+    onCancelCreateFolder,
+  } = props;
+
+  // Per-card callback factories — kept out of inline JSX so complexity stays low.
+  const buildRenameHandler = (item: Resource, isFolder: boolean) => (newTitle: string) => {
+    void (isFolder ? handleSubfolderRename(item.id, newTitle) : handleRenameFile(item.id, newTitle));
+  };
+  const buildChangeColorHandler = (item: Resource, isFolder: boolean) =>
+    isFolder
+      ? (color: string) => {
+          void handleSubfolderColor(item.id, color, item);
+        }
+      : undefined;
+  const buildOpenInSplitHandler = (item: Resource, isFolder: boolean) =>
+    !isFolder && canOpenInSplit ? () => handleOpenInSplit(item) : undefined;
+  const buildOpenInWindowHandler = (item: Resource, isFolder: boolean) =>
+    !isFolder
+      ? () => {
+          void handleOpenInWindow(item);
+        }
+      : undefined;
+  const buildNewSubfolderHandler = (item: Resource, isFolder: boolean) =>
+    isFolder ? () => handleNewSubfolder(item.id) : undefined;
+
+  if (showNoResults) {
+    return (
+      <p className="dome-folder-view__empty dome-folder-view__empty--search">
+        {isTagFiltering
+          ? t('folder.tagFilterEmpty', 'Ningún recurso con este tag')
+          : t('folder.searchNoResults', { query: searchQuery.trim() })}
+      </p>
+    );
+  }
+
+  if (isEmpty && !isTagFiltering) {
+    if (creatingFolder) {
+      return (
+        <div className="dome-folder-view__grid dome-folder-view__grid--empty-create">
+          <div className="dome-folder-view__inline-create dome-folder-view__inline-create--grid">
+            <NewFolderInline
+              variant="grid"
+              onConfirm={handleCreateFolder}
+              onCancel={onCancelCreateFolder}
+            />
+          </div>
+        </div>
+      );
+    }
+    return <p className="dome-folder-view__empty">{t('folder.emptyFolderShort', 'Carpeta vacía')}</p>;
+  }
+
+  if (viewMode === 'list') {
+    return (
+      <>
+        <div className="dome-folder-view__list-header">
+          <span className="dome-folder-view__list-header-name">
+            {t('folder.colName', 'Nombre')}
+            <span className="dome-folder-view__list-header-count">{statusLabel}</span>
+          </span>
+          <span className="dome-folder-view__col-modified">{t('folder.colModified', 'Modificado')}</span>
+          <span aria-hidden />
+        </div>
+
+        {rowsToRender.map(({ item, isFolder }, idx) => (
+          <FolderListRow
+            key={item.id}
+            item={item}
+            isFolder={isFolder}
+            isLast={idx === rowsToRender.length - 1 && !creatingFolder}
+            rowRef={setRowRef(item.id)}
+            onOpen={() => {
+              if (isFolder) handleNavigateToFolder(item.id, item.title, getFolderColor(item));
+              else
+                openResourceTab(
+                  item.id,
+                  item.type,
+                  item.title ?? t('folder.untitled'),
+                  effectiveProjectId,
+                );
+            }}
+            onDelete={() => setDeleteTarget(item)}
+            onRename={buildRenameHandler(item, isFolder)}
+            onChangeColor={buildChangeColorHandler(item, isFolder)}
+            onMoveToProject={() => setMoveProjectIds([item.id])}
+            onMoveToFolder={() => openFolderPickerFor(item.id)}
+            onOpenInSplit={buildOpenInSplitHandler(item, isFolder)}
+            onOpenInWindow={buildOpenInWindowHandler(item, isFolder)}
+            onNewSubfolder={buildNewSubfolderHandler(item, isFolder)}
+            selected={selectedIds.has(item.id)}
+            showSelectionChrome={showSelectionChrome}
+            onToggleSelect={(e) => {
+              e.stopPropagation();
+              toggleSelectId(item.id);
+            }}
+            searchQuery={isFiltering ? normalizedSearchQuery : undefined}
+            searchFocused={isFiltering && idx === searchFocusIndex}
+          />
+        ))}
+
+        {creatingFolder ? (
+          <div className="dome-folder-view__inline-create">
+            <NewFolderInline
+              variant="list"
+              onConfirm={handleCreateFolder}
+              onCancel={onCancelCreateFolder}
+            />
+          </div>
+        ) : null}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="dome-folder-view__grid-header">
+        <span className="dome-folder-view__list-header-count">{statusLabel}</span>
+      </div>
+      <div className="dome-folder-view__grid">
+        {rowsToRender.map(({ item, isFolder }, idx) => (
+          <FolderCard
+            key={item.id}
+            item={item}
+            isFolder={isFolder}
+            isLast={idx === rowsToRender.length - 1 && !creatingFolder}
+            cardRef={setRowRef(item.id)}
+            onOpen={() => openListItem({ item, isFolder })}
+            onDelete={() => setDeleteTarget(item)}
+            onRename={buildRenameHandler(item, isFolder)}
+            onChangeColor={buildChangeColorHandler(item, isFolder)}
+            onMoveToProject={() => setMoveProjectIds([item.id])}
+            onMoveToFolder={() => openFolderPickerFor(item.id)}
+            onOpenInSplit={buildOpenInSplitHandler(item, isFolder)}
+            onOpenInWindow={buildOpenInWindowHandler(item, isFolder)}
+            onNewSubfolder={buildNewSubfolderHandler(item, isFolder)}
+            selected={selectedIds.has(item.id)}
+            showSelectionChrome={showSelectionChrome}
+            onToggleSelect={(e) => {
+              e.stopPropagation();
+              toggleSelectId(item.id);
+            }}
+            searchQuery={isFiltering ? normalizedSearchQuery : undefined}
+            searchFocused={isFiltering && idx === searchFocusIndex}
+          />
+        ))}
+        {creatingFolder ? (
+          <div className="dome-folder-view__inline-create dome-folder-view__inline-create--grid">
+            <NewFolderInline
+              variant="grid"
+              onConfirm={handleCreateFolder}
+              onCancel={onCancelCreateFolder}
+            />
+          </div>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/app/components/shell/folder-tab/FolderTabDialogs.tsx
+++ b/app/components/shell/folder-tab/FolderTabDialogs.tsx
@@ -1,0 +1,106 @@
+/** Modals owned by FolderTabView (extracted for Sonar S3776). */
+
+import type { Resource } from '@/lib/hooks/useResources';
+import MoveToProjectModal from '@/components/workspace/MoveToProjectModal';
+import MoveFolderModal from '@/components/workspace/MoveFolderModal';
+import {
+  BulkDeleteConfirmModal,
+  DeleteConfirmModal,
+  UrlInputModal,
+} from '@/components/workspace/sidebar/SidebarModals';
+import { filterMoveProjectRoots } from '@/lib/workspace/filterMoveProjectRoots';
+
+export interface FolderTabDialogsProps {
+  folderPickOpen: boolean;
+  onCloseFolderPick: () => void;
+  folderMoveIds: string[] | null;
+  selectedIds: Set<string>;
+  resourceMapForSelection: Map<string, Resource>;
+  allFolders: Resource[];
+  effectiveProjectId: string;
+  listFolderId: string | null;
+  onConfirmBulkMove: (targetFolderId: string | null) => void | Promise<void>;
+  moveProjectIds: string[];
+  onCloseMoveProject: () => void;
+  onMoveProjectCompleted: () => void;
+  deleteTarget: Resource | null;
+  onConfirmDelete: () => void;
+  onCloseDelete: () => void;
+  bulkDeleteOpen: boolean;
+  bulkDeleting: boolean;
+  onConfirmBulkDelete: () => void;
+  onCloseBulkDelete: () => void;
+  urlModalOpen: boolean;
+  onConfirmUrl: (url: string) => void;
+  onCloseUrl: () => void;
+}
+
+export default function FolderTabDialogs(props: FolderTabDialogsProps) {
+  const {
+    folderPickOpen,
+    onCloseFolderPick,
+    folderMoveIds,
+    selectedIds,
+    resourceMapForSelection,
+    allFolders,
+    effectiveProjectId,
+    listFolderId,
+    onConfirmBulkMove,
+    moveProjectIds,
+    onCloseMoveProject,
+    onMoveProjectCompleted,
+    deleteTarget,
+    onConfirmDelete,
+    onCloseDelete,
+    bulkDeleteOpen,
+    bulkDeleting,
+    onConfirmBulkDelete,
+    onCloseBulkDelete,
+    urlModalOpen,
+    onConfirmUrl,
+    onCloseUrl,
+  } = props;
+
+  return (
+    <>
+      <MoveFolderModal
+        open={folderPickOpen}
+        onClose={onCloseFolderPick}
+        resourceIds={folderMoveIds ?? filterMoveProjectRoots(selectedIds, resourceMapForSelection)}
+        allFolders={allFolders}
+        projectId={effectiveProjectId}
+        currentFolderId={listFolderId}
+        onConfirm={onConfirmBulkMove}
+      />
+
+      <MoveToProjectModal
+        opened={moveProjectIds.length > 0}
+        onClose={onCloseMoveProject}
+        resourceIds={moveProjectIds}
+        resourcesById={resourceMapForSelection}
+        onCompleted={onMoveProjectCompleted}
+      />
+
+      {deleteTarget ? (
+        <DeleteConfirmModal
+          resource={deleteTarget}
+          onConfirm={onConfirmDelete}
+          onClose={onCloseDelete}
+        />
+      ) : null}
+
+      {bulkDeleteOpen ? (
+        <BulkDeleteConfirmModal
+          count={selectedIds.size}
+          busy={bulkDeleting}
+          onConfirm={onConfirmBulkDelete}
+          onClose={onCloseBulkDelete}
+        />
+      ) : null}
+
+      {urlModalOpen ? (
+        <UrlInputModal onConfirm={onConfirmUrl} onClose={onCloseUrl} />
+      ) : null}
+    </>
+  );
+}

--- a/app/components/shell/folder-tab/FolderTabDropOverlay.tsx
+++ b/app/components/shell/folder-tab/FolderTabDropOverlay.tsx
@@ -1,0 +1,18 @@
+/** Drop overlay when OS files are dragged over the folder view. */
+
+import { Upload04Icon } from '@hugeicons/core-free-icons';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { useTranslation } from 'react-i18next';
+
+export default function FolderTabDropOverlay({ active }: { active: boolean }) {
+  const { t } = useTranslation();
+  if (!active) return null;
+  return (
+    <div className="dome-folder-view__drop-overlay" aria-hidden>
+      <div className="dome-folder-view__drop-overlay-card">
+        <HugeiconsIcon icon={Upload04Icon} className="size-6" aria-hidden />
+        <span>{t('folder.dropToImport', 'Suelta para importar aquí')}</span>
+      </div>
+    </div>
+  );
+}

--- a/app/components/shell/folder-tab/FolderTabToolbar.tsx
+++ b/app/components/shell/folder-tab/FolderTabToolbar.tsx
@@ -1,0 +1,423 @@
+/** Folder tab toolbar (nav, breadcrumb, view mode, tags, search, menus). */
+
+import { Fragment, type RefObject } from 'react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  ArrowRight01Icon,
+  ArrowLeft01Icon,
+  Upload04Icon,
+  FolderAddIcon,
+  FolderExportIcon,
+  LinkSquare01Icon,
+  FileEditIcon,
+  Search01Icon,
+  Cancel01Icon,
+  Add01Icon,
+  MoreHorizontalIcon,
+  PaintBoardIcon,
+  LayoutGridIcon,
+  Menu01Icon,
+  Tag01Icon,
+} from '@hugeicons/core-free-icons';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { useTranslation } from 'react-i18next';
+import type { Resource } from '@/lib/hooks/useResources';
+import { Button } from '@/components/ui/button';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/input-group';
+import { Separator } from '@/components/ui/separator';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import { getFolderColor } from './folderTabShared';
+import type { FolderViewMode, ProjectTag } from './folderTabViewHelpers';
+
+export interface FolderTabToolbarProps {
+  canGoBack: boolean;
+  canGoForward: boolean;
+  goBack: () => void;
+  goForward: () => void;
+  isProjectRoot: boolean;
+  projectRootLabel: string;
+  breadcrumb: Resource[];
+  displayTitle: string;
+  handleNavigateToProjectRoot: () => void;
+  handleNavigateToFolder: (id: string, title: string, color?: string) => void;
+  viewMode: FolderViewMode;
+  setFolderViewMode: (mode: FolderViewMode) => void;
+  isTagFiltering: boolean;
+  tagFilterId: string | null;
+  setTagFilterId: (id: string | null) => void;
+  projectTags: ProjectTag[];
+  activeTag: ProjectTag | undefined;
+  searchOpen: boolean;
+  searchQuery: string;
+  setSearchQuery: (q: string) => void;
+  searchInputRef: RefObject<HTMLInputElement>;
+  handleSearchKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  searchModHint: string;
+  openSearch: () => void;
+  closeSearch: () => void;
+  folderMenuBtnRef: RefObject<HTMLButtonElement>;
+  currentFolder: Resource | undefined;
+  openFolderColorPicker: () => void;
+  handleRevealCurrentFolder: () => void | Promise<void>;
+  revealLabel: string;
+  setCreatingFolder: (v: boolean) => void;
+  handleNewNote: () => void | Promise<void>;
+  handleUpload: () => void | Promise<void>;
+  setUrlModalOpen: (v: boolean) => void;
+}
+
+export default function FolderTabToolbar(props: FolderTabToolbarProps) {
+  const { t } = useTranslation();
+  const {
+    canGoBack,
+    canGoForward,
+    goBack,
+    goForward,
+    isProjectRoot,
+    projectRootLabel,
+    breadcrumb,
+    displayTitle,
+    handleNavigateToProjectRoot,
+    handleNavigateToFolder,
+    viewMode,
+    setFolderViewMode,
+    isTagFiltering,
+    tagFilterId,
+    setTagFilterId,
+    projectTags,
+    activeTag,
+    searchOpen,
+    searchQuery,
+    setSearchQuery,
+    searchInputRef,
+    handleSearchKeyDown,
+    searchModHint,
+    openSearch,
+    closeSearch,
+    folderMenuBtnRef,
+    currentFolder,
+    openFolderColorPicker,
+    handleRevealCurrentFolder,
+    revealLabel,
+    setCreatingFolder,
+    handleNewNote,
+    handleUpload,
+    setUrlModalOpen,
+  } = props;
+
+  return (
+    <div className="dome-folder-view__toolbar">
+      <div className="dome-folder-view__nav-controls">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={goBack}
+                disabled={!canGoBack}
+                aria-label={t('folder.navBack', 'Atrás')}
+              />
+            }
+          >
+            <HugeiconsIcon icon={ArrowLeft01Icon} />
+          </TooltipTrigger>
+          <TooltipContent>{t('folder.navBack', 'Atrás')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={goForward}
+                disabled={!canGoForward}
+                aria-label={t('folder.navForward', 'Adelante')}
+              />
+            }
+          >
+            <HugeiconsIcon icon={ArrowRight01Icon} />
+          </TooltipTrigger>
+          <TooltipContent>{t('folder.navForward', 'Adelante')}</TooltipContent>
+        </Tooltip>
+      </div>
+
+      <Separator orientation="vertical" className="h-5" />
+
+      <nav className="dome-folder-view__breadcrumb" aria-label={t('folder.breadcrumb', 'Ruta')}>
+        {isProjectRoot ? (
+          <span
+            className="dome-folder-view__breadcrumb-current"
+            title={projectRootLabel}
+            aria-current="page"
+          >
+            {projectRootLabel}
+          </span>
+        ) : (
+          <>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={handleNavigateToProjectRoot}
+              className="h-6 max-w-28 shrink-0 truncate px-1.5 text-muted-foreground"
+              title={projectRootLabel}
+            >
+              {projectRootLabel}
+            </Button>
+            {breadcrumb.map((folder) => (
+              <Fragment key={folder.id}>
+                <HugeiconsIcon
+                  icon={ArrowRight01Icon}
+                  className="size-3 shrink-0 text-muted-foreground/60"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  onClick={() =>
+                    handleNavigateToFolder(folder.id, folder.title, getFolderColor(folder))
+                  }
+                  className="h-6 max-w-28 shrink truncate px-1.5 text-muted-foreground"
+                  title={folder.title}
+                >
+                  {folder.title}
+                </Button>
+              </Fragment>
+            ))}
+            {breadcrumb.length > 0 && (
+              <HugeiconsIcon
+                icon={ArrowRight01Icon}
+                className="size-3 shrink-0 text-muted-foreground/60"
+              />
+            )}
+            <span
+              className="dome-folder-view__breadcrumb-current"
+              title={displayTitle}
+              aria-current="page"
+            >
+              {displayTitle}
+            </span>
+          </>
+        )}
+      </nav>
+
+      <div className="dome-folder-view__toolbar-end">
+        <ToggleGroup
+          value={[viewMode]}
+          onValueChange={(values) => {
+            const next = values[0];
+            if (next === 'grid' || next === 'list') setFolderViewMode(next);
+          }}
+          variant="outline"
+          size="sm"
+          spacing={0}
+          aria-label={t('folder.viewMode', 'Modo de vista')}
+        >
+          <ToggleGroupItem value="grid" aria-label={t('folder.gridView', 'Vista de cuadrícula')}>
+            <HugeiconsIcon icon={LayoutGridIcon} />
+          </ToggleGroupItem>
+          <ToggleGroupItem value="list" aria-label={t('folder.listView', 'Vista de lista')}>
+            <HugeiconsIcon icon={Menu01Icon} />
+          </ToggleGroupItem>
+        </ToggleGroup>
+
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      type="button"
+                      variant={isTagFiltering ? 'secondary' : 'ghost'}
+                      size="icon-sm"
+                      aria-label={t('folder.tagFilter', 'Filtrar por tag')}
+                    />
+                  }
+                />
+              }
+            >
+              <HugeiconsIcon icon={Tag01Icon} />
+            </TooltipTrigger>
+            <TooltipContent>
+              {activeTag ? activeTag.name : t('folder.tagFilter', 'Filtrar por tag')}
+            </TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent side="bottom" align="end" sideOffset={4} className="w-52">
+            <DropdownMenuGroup>
+              <DropdownMenuItem onClick={() => setTagFilterId(null)}>
+                {t('folder.tagFilterAll', 'Todos los tags')}
+              </DropdownMenuItem>
+              {projectTags.length === 0 ? (
+                <DropdownMenuItem disabled>{t('tags.no_tags', 'Sin tags')}</DropdownMenuItem>
+              ) : (
+                projectTags.map((tag) => (
+                  <DropdownMenuItem
+                    key={tag.id}
+                    className={cn(tagFilterId === tag.id && 'font-semibold')}
+                    onClick={() => setTagFilterId(tag.id)}
+                  >
+                    <span className="truncate">{tag.name}</span>
+                    <span className="ml-auto text-muted-foreground tabular-nums">
+                      {tag.resource_count}
+                    </span>
+                  </DropdownMenuItem>
+                ))
+              )}
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {searchOpen ? (
+          <InputGroup className="w-[min(240px,42vw)] min-w-36">
+            <InputGroupAddon align="inline-start">
+              <HugeiconsIcon icon={Search01Icon} />
+            </InputGroupAddon>
+            <InputGroupInput
+              ref={searchInputRef}
+              type="search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              placeholder={t('folder.searchPlaceholder', { shortcut: searchModHint })}
+              aria-label={t('folder.searchAria', { shortcut: searchModHint })}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <InputGroupAddon align="inline-end">
+              <InputGroupButton
+                size="icon-xs"
+                onClick={() => {
+                  if (searchQuery) {
+                    setSearchQuery('');
+                    searchInputRef.current?.focus();
+                  } else {
+                    closeSearch();
+                  }
+                }}
+                aria-label={t('folder.searchClear', 'Clear search')}
+              >
+                <HugeiconsIcon icon={Cancel01Icon} />
+              </InputGroupButton>
+            </InputGroupAddon>
+          </InputGroup>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={openSearch}
+                  aria-label={t('folder.searchAria', { shortcut: searchModHint })}
+                />
+              }
+            >
+              <HugeiconsIcon icon={Search01Icon} />
+            </TooltipTrigger>
+            <TooltipContent>
+              {t('folder.searchPlaceholder', { shortcut: searchModHint })}
+            </TooltipContent>
+          </Tooltip>
+        )}
+
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      ref={folderMenuBtnRef}
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label={t('folder.folderMenu', 'Opciones de carpeta')}
+                    />
+                  }
+                />
+              }
+            >
+              <HugeiconsIcon icon={MoreHorizontalIcon} />
+            </TooltipTrigger>
+            <TooltipContent>{t('folder.folderMenu', 'Opciones de carpeta')}</TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent side="bottom" align="end" sideOffset={4} className="w-52">
+            <DropdownMenuGroup>
+              {!isProjectRoot && currentFolder ? (
+                <DropdownMenuItem onClick={openFolderColorPicker}>
+                  <HugeiconsIcon icon={PaintBoardIcon} data-icon="inline-start" />
+                  {t('folder.changeColor', 'Cambiar color')}
+                </DropdownMenuItem>
+              ) : null}
+              <DropdownMenuItem
+                onClick={() => {
+                  void handleRevealCurrentFolder();
+                }}
+              >
+                <HugeiconsIcon icon={FolderExportIcon} data-icon="inline-start" />
+                {revealLabel}
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <DropdownMenuTrigger
+                  render={
+                    <Button type="button" size="icon-sm" aria-label={t('folder.addBtn', 'Añadir')} />
+                  }
+                />
+              }
+            >
+              <HugeiconsIcon icon={Add01Icon} strokeWidth={2.25} />
+            </TooltipTrigger>
+            <TooltipContent>{t('folder.addBtn', 'Añadir')}</TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent side="bottom" align="end" sideOffset={4} className="w-48">
+            <DropdownMenuGroup>
+              <DropdownMenuItem onClick={() => setCreatingFolder(true)}>
+                <HugeiconsIcon icon={FolderAddIcon} data-icon="inline-start" />
+                {t('folder.newFolderBtn')}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleNewNote}>
+                <HugeiconsIcon icon={FileEditIcon} data-icon="inline-start" />
+                {t('toolbar.note', 'Nota')}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={handleUpload}>
+                <HugeiconsIcon icon={Upload04Icon} data-icon="inline-start" />
+                {t('toolbar.import', 'Importar')}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setUrlModalOpen(true)}>
+                <HugeiconsIcon icon={LinkSquare01Icon} data-icon="inline-start" />
+                {t('toolbar.link', 'URL')}
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}

--- a/app/components/shell/folder-tab/folderTabViewHelpers.test.ts
+++ b/app/components/shell/folder-tab/folderTabViewHelpers.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildFolderListItems,
+  buildTabColorKey,
+  canOpenResourceInSplit,
+  computeFolderViewStatus,
+  filterListItemsBySearch,
+  partitionFolderChildren,
+  resolveEffectiveProjectId,
+  toggleIdInSet,
+  type FolderListEntry,
+} from './folderTabViewHelpers';
+import type { Resource } from '@/lib/hooks/useResources';
+import type { FolderTabViewContext } from './folderTabShared';
+
+function res(partial: Partial<Resource> & Pick<Resource, 'id' | 'type'>): Resource {
+  return {
+    title: partial.title ?? partial.id,
+    project_id: partial.project_id ?? 'proj',
+    folder_id: partial.folder_id ?? null,
+    content: '',
+    created_at: 0,
+    updated_at: 0,
+    ...partial,
+  } as Resource;
+}
+
+describe('partitionFolderChildren', () => {
+  const all = [
+    res({ id: 'f1', type: 'folder', project_id: 'p1', folder_id: null }),
+    res({ id: 'n1', type: 'note', project_id: 'p1', folder_id: null }),
+    res({ id: 'f2', type: 'folder', project_id: 'p1', folder_id: 'parent' }),
+    res({ id: 'n2', type: 'note', project_id: 'p1', folder_id: 'parent' }),
+    res({ id: 'n3', type: 'note', project_id: 'p2', folder_id: null }),
+  ];
+
+  it('lists project-root children without folder_id', () => {
+    const ctx: FolderTabViewContext = {
+      isProjectRoot: true,
+      listFolderId: null,
+      projectId: 'p1',
+    };
+    const { subfolders, files } = partitionFolderChildren(all, ctx, 'p1');
+    expect(subfolders.map((r) => r.id)).toEqual(['f1']);
+    expect(files.map((r) => r.id)).toEqual(['n1']);
+  });
+
+  it('lists folder children scoped to project when set', () => {
+    const ctx: FolderTabViewContext = {
+      isProjectRoot: false,
+      listFolderId: 'parent',
+      projectId: 'p1',
+    };
+    const { subfolders, files } = partitionFolderChildren(all, ctx, 'parent');
+    expect(subfolders.map((r) => r.id)).toEqual(['f2']);
+    expect(files.map((r) => r.id)).toEqual(['n2']);
+  });
+});
+
+describe('buildFolderListItems / filterListItemsBySearch', () => {
+  const folders = [res({ id: 'f1', type: 'folder', title: 'Alpha' })];
+  const files = [res({ id: 'n1', type: 'note', title: 'Beta Note' })];
+
+  it('concatenates folders then files when not tag-filtering', () => {
+    const items = buildFolderListItems({
+      tagFilterId: null,
+      allResources: [...folders, ...files],
+      effectiveProjectId: 'p1',
+      taggedResourceIds: new Set(),
+      subfolders: folders,
+      files,
+    });
+    expect(items).toEqual([
+      { item: folders[0], isFolder: true },
+      { item: files[0], isFolder: false },
+    ]);
+  });
+
+  it('filters tagged non-folder resources for a tag filter', () => {
+    const tagged = new Set(['n1']);
+    const items = buildFolderListItems({
+      tagFilterId: 'tag-1',
+      allResources: [...folders, ...files],
+      effectiveProjectId: 'proj',
+      taggedResourceIds: tagged,
+      subfolders: folders,
+      files,
+    });
+    expect(items).toEqual([{ item: files[0], isFolder: false }]);
+  });
+
+  it('filters by normalized search query', () => {
+    const list: FolderListEntry[] = [
+      { item: folders[0], isFolder: true },
+      { item: files[0], isFolder: false },
+    ];
+    expect(filterListItemsBySearch(list, 'beta', 'Untitled').map((e) => e.item.id)).toEqual([
+      'n1',
+    ]);
+    expect(filterListItemsBySearch(list, '', 'Untitled')).toEqual(list);
+  });
+});
+
+describe('computeFolderViewStatus', () => {
+  const listItems: FolderListEntry[] = [
+    { item: res({ id: 'a', type: 'note' }), isFolder: false },
+  ];
+
+  it('prefers tag status label when tag-filtering', () => {
+    const status = computeFolderViewStatus({
+      tagFilterId: 't1',
+      listItems,
+      subfoldersLen: 0,
+      filesLen: 0,
+      creatingFolder: false,
+      isFiltering: false,
+      isTagFiltering: true,
+      filteredListItems: listItems,
+      activeTagName: 'Research',
+      statusTag: ({ name, count }) => `${name}:${count}`,
+      statusSearch: ({ count, total }) => `s:${count}/${total}`,
+      statusCount: ({ count }) => `c:${count}`,
+    });
+    expect(status.statusLabel).toBe('Research:1');
+    expect(status.showNoResults).toBe(false);
+  });
+});
+
+describe('small pure helpers', () => {
+  it('toggleIdInSet adds and removes', () => {
+    const a = toggleIdInSet(new Set(), 'x');
+    expect([...a]).toEqual(['x']);
+    expect([...toggleIdInSet(a, 'x')]).toEqual([]);
+  });
+
+  it('resolveEffectiveProjectId prefers folder then project then default', () => {
+    expect(
+      resolveEffectiveProjectId({
+        isProjectRoot: true,
+        viewProjectId: 'root',
+      }),
+    ).toBe('root');
+    expect(
+      resolveEffectiveProjectId({
+        isProjectRoot: false,
+        viewProjectId: 'root',
+        currentFolderProjectId: 'fp',
+        currentProjectId: 'cp',
+      }),
+    ).toBe('fp');
+    expect(
+      resolveEffectiveProjectId({
+        isProjectRoot: false,
+        viewProjectId: 'root',
+      }),
+    ).toBe('default');
+  });
+
+  it('buildTabColorKey and canOpenResourceInSplit', () => {
+    expect(buildTabColorKey('f1', '#fff', false)).toBe('f1:#fff');
+    expect(buildTabColorKey('f1', '#fff', true)).toBe('');
+    expect(buildTabColorKey('f1', null, false)).toBe('');
+    expect(canOpenResourceInSplit(null, [])).toBe(false);
+    expect(canOpenResourceInSplit('home', [{ id: 'home' }])).toBe(false);
+    expect(
+      canOpenResourceInSplit('t1', [{ id: 't1', resourceId: 'r1' }]),
+    ).toBe(true);
+  });
+});

--- a/app/components/shell/folder-tab/folderTabViewHelpers.ts
+++ b/app/components/shell/folder-tab/folderTabViewHelpers.ts
@@ -1,0 +1,442 @@
+/**
+ * Pure helpers extracted from FolderTabView for Sonar S3776
+ * (cognitive complexity). Behavior must stay identical to the prior inlines.
+ */
+
+import type { Resource } from '@/lib/hooks/useResources';
+import { getFolderColor, type FolderTabViewContext } from './folderTabShared';
+
+export type FolderViewMode = 'grid' | 'list';
+export const FOLDER_VIEW_MODE_KEY = 'dome:folder-view-mode';
+export const FOLDER_VIEW_MODE_DEFAULT: FolderViewMode = 'grid';
+
+export type ProjectTag = {
+  id: string;
+  name: string;
+  color?: string | null;
+  resource_count: number;
+};
+
+export type FolderListEntry = { item: Resource; isFolder: boolean };
+
+export function readFolderViewMode(): FolderViewMode {
+  if (typeof globalThis.window === 'undefined') return FOLDER_VIEW_MODE_DEFAULT;
+  try {
+    const raw = globalThis.window.localStorage.getItem(FOLDER_VIEW_MODE_KEY);
+    return raw === 'list' || raw === 'grid' ? raw : FOLDER_VIEW_MODE_DEFAULT;
+  } catch {
+    return FOLDER_VIEW_MODE_DEFAULT;
+  }
+}
+
+export function partitionFolderChildren(
+  allResources: Resource[],
+  viewCtx: FolderTabViewContext,
+  folderId: string,
+): { subfolders: Resource[]; files: Resource[] } {
+  let list = allResources;
+  if (viewCtx.isProjectRoot) {
+    list = list.filter((r) => r.project_id === viewCtx.projectId && !r.folder_id);
+  } else {
+    list = list.filter((r) => r.folder_id === folderId);
+    if (viewCtx.projectId) {
+      list = list.filter((r) => r.project_id === viewCtx.projectId);
+    }
+  }
+  return {
+    subfolders: list.filter((r) => r.type === 'folder'),
+    files: list.filter((r) => r.type !== 'folder'),
+  };
+}
+
+export function buildResourceMapForSelection(opts: {
+  subfolders: Resource[];
+  files: Resource[];
+  folderId: string;
+  isProjectRoot: boolean;
+  getBreadcrumbPath: (id: string) => Resource[];
+  getFolderById: (id: string) => Resource | undefined;
+}): Map<string, Resource> {
+  const m = new Map<string, Resource>();
+  for (const f of opts.subfolders) m.set(f.id, f);
+  for (const f of opts.files) m.set(f.id, f);
+  if (!opts.isProjectRoot) {
+    for (const p of opts.getBreadcrumbPath(opts.folderId)) m.set(p.id, p);
+    const cur = opts.getFolderById(opts.folderId);
+    if (cur) m.set(cur.id, cur);
+  }
+  return m;
+}
+
+export function buildFolderListItems(opts: {
+  tagFilterId: string | null;
+  allResources: Resource[];
+  effectiveProjectId: string;
+  taggedResourceIds: Set<string>;
+  subfolders: Resource[];
+  files: Resource[];
+}): FolderListEntry[] {
+  if (opts.tagFilterId) {
+    return opts.allResources
+      .filter(
+        (r) =>
+          r.project_id === opts.effectiveProjectId &&
+          opts.taggedResourceIds.has(r.id) &&
+          r.type !== 'folder',
+      )
+      .map((item) => ({ item, isFolder: false as const }));
+  }
+  const folders = opts.subfolders.map((f) => ({ item: f, isFolder: true as const }));
+  const docs = opts.files.map((f) => ({ item: f, isFolder: false as const }));
+  return [...folders, ...docs];
+}
+
+export function filterListItemsBySearch(
+  listItems: FolderListEntry[],
+  normalizedSearchQuery: string,
+  untitledLabel: string,
+): FolderListEntry[] {
+  if (!normalizedSearchQuery) return listItems;
+  return listItems.filter(({ item }) =>
+    (item.title ?? untitledLabel).toLowerCase().includes(normalizedSearchQuery),
+  );
+}
+
+export function resolveEffectiveProjectId(opts: {
+  isProjectRoot: boolean;
+  viewProjectId: string;
+  currentFolderProjectId?: string | null;
+  currentProjectId?: string | null;
+}): string {
+  if (opts.isProjectRoot) return opts.viewProjectId;
+  return opts.currentFolderProjectId ?? opts.currentProjectId ?? 'default';
+}
+
+export function folderSearchModHint(platform: string | undefined): string {
+  return platform !== undefined && /Mac|iPhone|iPad/i.test(platform) ? '⌘F' : 'Ctrl+F';
+}
+
+export function folderRevealLabel(
+  platform: string | undefined,
+  finderLabel: string,
+  explorerLabel: string,
+): string {
+  return platform !== undefined && /Mac|iPhone|iPad/i.test(platform)
+    ? finderLabel
+    : explorerLabel;
+}
+
+export type FolderViewStatus = {
+  itemCount: number;
+  visibleCount: number;
+  isEmpty: boolean;
+  showNoResults: boolean;
+  rowsToRender: FolderListEntry[];
+  statusLabel: string;
+};
+
+export function computeFolderViewStatus(opts: {
+  tagFilterId: string | null;
+  listItems: FolderListEntry[];
+  subfoldersLen: number;
+  filesLen: number;
+  creatingFolder: boolean;
+  isFiltering: boolean;
+  isTagFiltering: boolean;
+  filteredListItems: FolderListEntry[];
+  activeTagName?: string;
+  statusTag: (args: { name: string; count: number }) => string;
+  statusSearch: (args: { count: number; total: number }) => string;
+  statusCount: (args: { count: number }) => string;
+}): FolderViewStatus {
+  const itemCount = opts.tagFilterId
+    ? opts.listItems.length
+    : opts.subfoldersLen + opts.filesLen;
+  const visibleCount =
+    opts.isFiltering || opts.isTagFiltering ? opts.filteredListItems.length : itemCount;
+  const isEmpty = !opts.isTagFiltering && itemCount === 0 && !opts.creatingFolder;
+  const showNoResults =
+    (opts.isFiltering || opts.isTagFiltering) && opts.filteredListItems.length === 0;
+  const rowsToRender =
+    opts.isFiltering || opts.isTagFiltering ? opts.filteredListItems : opts.listItems;
+
+  let statusLabel: string;
+  if (opts.isTagFiltering && opts.activeTagName) {
+    statusLabel = opts.statusTag({ name: opts.activeTagName, count: visibleCount });
+  } else if (opts.isFiltering) {
+    statusLabel = opts.statusSearch({ count: visibleCount, total: itemCount });
+  } else {
+    statusLabel = opts.statusCount({ count: itemCount });
+  }
+
+  return { itemCount, visibleCount, isEmpty, showNoResults, rowsToRender, statusLabel };
+}
+
+/** Color picker anchor from the folder menu button rect. */
+export function colorPickerPositionFromRect(rect: DOMRect): { top: number; left: number } {
+  const popoverWidth = 196;
+  const left = Math.min(
+    Math.max(8, rect.right - popoverWidth),
+    globalThis.window.innerWidth - popoverWidth - 8,
+  );
+  const top = Math.min(rect.bottom + 6, globalThis.window.innerHeight - 100);
+  return { top, left };
+}
+
+export function tabColorFromFolderMeta(color: string | undefined): string | undefined {
+  return color?.startsWith('#') ? color : undefined;
+}
+
+export async function revealFolderOrVault(opts: {
+  isProjectRoot: boolean;
+  currentFolder: Resource | undefined;
+  effectiveProjectId: string;
+}): Promise<void> {
+  if (opts.isProjectRoot || !opts.currentFolder) {
+    await globalThis.window.electron?.resource?.openVaultRoot(opts.effectiveProjectId);
+    return;
+  }
+  const res = await globalThis.window.electron?.resource?.getFilePath(opts.currentFolder.id);
+  if (res?.success && typeof res.data === 'string') {
+    await globalThis.window.electron?.openPath?.(res.data);
+  } else {
+    await globalThis.window.electron?.resource?.openVaultRoot(opts.effectiveProjectId);
+  }
+}
+
+export async function importPathsIntoFolderView(opts: {
+  paths: string[];
+  effectiveProjectId: string;
+  listFolderId: string | null;
+  refetch: () => Promise<unknown>;
+}): Promise<void> {
+  if (!opts.paths.length || !globalThis.window.electron?.resource?.importMultiple) return;
+  const result = await globalThis.window.electron.resource.importMultiple(
+    opts.paths,
+    opts.effectiveProjectId,
+  );
+  if (opts.listFolderId && result?.data?.length) {
+    const moves: Promise<unknown>[] = [];
+    for (const entry of result.data) {
+      if (!entry.success || !entry.data?.id) continue;
+      moves.push(
+        globalThis.window.electron?.db?.resources?.moveToFolder(entry.data.id, opts.listFolderId),
+      );
+    }
+    await Promise.all(moves);
+  }
+  await opts.refetch();
+}
+
+export async function openNoteInWindow(item: Resource): Promise<void> {
+  if (!globalThis.window.electron?.invoke || item.type !== 'note') return;
+  try {
+    await globalThis.window.electron.invoke('window:create', {
+      id: `note-focus:${item.id}`,
+      route: `/focus/note/${encodeURIComponent(item.id)}`,
+      options: {
+        width: 960,
+        height: 760,
+        minWidth: 560,
+        minHeight: 480,
+        title: `${item.title || 'Nota'} — Dome`,
+        transparent: false,
+      },
+    });
+  } catch (err) {
+    console.error('[FolderTabView] Failed to open popout:', err);
+  }
+}
+
+export function createUrlResourcePayload(opts: {
+  url: string;
+  effectiveProjectId: string;
+  listFolderId: string | null;
+}): Record<string, unknown> | null {
+  if (!opts.url || !globalThis.window.electron?.db?.resources?.create) return null;
+  const now = Date.now();
+  return {
+    id: `res_${now}_${Math.random().toString(36).substr(2, 9)}`,
+    type: 'url',
+    title: opts.url.replace(/^https?:\/\/(www\.)?/, '').split('/')[0],
+    project_id: opts.effectiveProjectId,
+    folder_id: opts.listFolderId,
+    content: opts.url,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+export function createUntitledNotePayload(opts: {
+  title: string;
+  effectiveProjectId: string;
+  listFolderId: string | null;
+}): {
+  id: string;
+  type: 'note';
+  title: string;
+  content: string;
+  project_id: string;
+  folder_id: string | null;
+  created_at: number;
+  updated_at: number;
+} {
+  const now = Date.now();
+  return {
+    id: `res_${now}_${Math.random().toString(36).substr(2, 9)}`,
+    type: 'note' as const,
+    title: opts.title,
+    content: '',
+    project_id: opts.effectiveProjectId,
+    folder_id: opts.listFolderId,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+export function toggleIdInSet(prev: Set<string>, id: string): Set<string> {
+  const n = new Set(prev);
+  if (n.has(id)) n.delete(id);
+  else n.add(id);
+  return n;
+}
+
+export async function runBulkMoveToFolder(opts: {
+  folderMoveIds: string[] | null;
+  selectedIds: Set<string>;
+  resourceMapForSelection: Map<string, Resource>;
+  targetFolderId: string | null;
+  moveToFolder: (id: string, folderId: string | null) => Promise<boolean>;
+  filterRoots: (
+    selectedIds: Set<string>,
+    map: Map<string, Resource>,
+  ) => string[];
+}): Promise<'cleared-selection' | 'kept-selection'> {
+  const roots =
+    opts.folderMoveIds ?? opts.filterRoots(opts.selectedIds, opts.resourceMapForSelection);
+  for (const rid of roots) {
+    const ok = await opts.moveToFolder(rid, opts.targetFolderId);
+    if (!ok) break;
+  }
+  return opts.folderMoveIds ? 'kept-selection' : 'cleared-selection';
+}
+
+export async function runBulkDelete(
+  selectedIds: Set<string>,
+  refetch: () => Promise<unknown>,
+): Promise<boolean> {
+  if (selectedIds.size === 0) return false;
+  const res = await globalThis.window.electron?.db?.resources?.bulkDelete([...selectedIds]);
+  if (!res?.success) return false;
+  await refetch();
+  return true;
+}
+
+export async function runCreateUntitledNote(opts: {
+  title: string;
+  effectiveProjectId: string;
+  listFolderId: string | null;
+  openResourceTab: (id: string, type: string, title: string, projectId: string) => void;
+}): Promise<void> {
+  if (!globalThis.window.electron?.db?.resources?.create) return;
+  const res = createUntitledNotePayload({
+    title: opts.title,
+    effectiveProjectId: opts.effectiveProjectId,
+    listFolderId: opts.listFolderId,
+  });
+  const result = await globalThis.window.electron.db.resources.create(res);
+  if (result.success && result.data) {
+    opts.openResourceTab(result.data.id, 'note', result.data.title, opts.effectiveProjectId);
+  }
+}
+
+export async function runUploadIntoView(
+  importPathsIntoView: (paths: string[]) => Promise<void>,
+): Promise<void> {
+  if (!globalThis.window.electron?.selectFiles) return;
+  const paths = await globalThis.window.electron.selectFiles({
+    properties: ['openFile', 'multiSelections'],
+  });
+  if (!paths?.length) return;
+  await importPathsIntoView(paths);
+}
+
+export function runAddUrl(opts: {
+  url: string;
+  effectiveProjectId: string;
+  listFolderId: string | null;
+}): void {
+  const payload = createUrlResourcePayload(opts);
+  if (payload) {
+    void globalThis.window.electron?.db?.resources?.create(payload);
+  }
+}
+
+export async function runApplyFolderColor(opts: {
+  currentFolder: Resource | undefined;
+  folderId: string;
+  color: string;
+  updateResource: (id: string, patch: Partial<Resource>) => Promise<unknown>;
+  updateTab: (id: string, patch: { color: string }) => void;
+}): Promise<boolean> {
+  if (!opts.currentFolder) return false;
+  const currentMeta = (opts.currentFolder.metadata as Record<string, unknown>) ?? {};
+  await opts.updateResource(opts.folderId, { metadata: { ...currentMeta, color: opts.color } });
+  opts.updateTab(`folder:${opts.folderId}`, { color: opts.color });
+  return true;
+}
+
+export async function runSubfolderColor(opts: {
+  id: string;
+  color: string;
+  folder: Resource;
+  updateResource: (id: string, patch: Partial<Resource>) => Promise<unknown>;
+  updateTab: (id: string, patch: { color: string }) => void;
+}): Promise<void> {
+  const currentMeta = (opts.folder.metadata as Record<string, unknown>) ?? {};
+  await opts.updateResource(opts.id, { metadata: { ...currentMeta, color: opts.color } });
+  opts.updateTab(`folder:${opts.id}`, { color: opts.color });
+}
+
+export function resolveFolderChromeColor(currentFolder: Resource | undefined): {
+  folderColor: string;
+  folderColorHex: string | null;
+} {
+  const folderColor = currentFolder ? getFolderColor(currentFolder) : 'var(--primary)';
+  const folderColorHex = folderColor.startsWith('#') ? folderColor : null;
+  return { folderColor, folderColorHex };
+}
+
+export function buildTabColorKey(
+  folderId: string,
+  folderColorHex: string | null,
+  isProjectRoot: boolean,
+): string {
+  if (!folderColorHex || isProjectRoot) return '';
+  return `${folderId}:${folderColorHex}`;
+}
+
+export function canOpenResourceInSplit(
+  activeTabId: string | null,
+  tabs: Array<{ id: string; resourceId?: string | null }>,
+): boolean {
+  if (activeTabId === null || activeTabId === 'home') return false;
+  return Boolean(tabs.find((tb) => tb.id === activeTabId)?.resourceId);
+}
+
+export function buildBreadcrumbExcludingCurrent(
+  isProjectRoot: boolean,
+  folderId: string,
+  getBreadcrumbPath: (id: string) => Resource[],
+): Resource[] {
+  if (isProjectRoot) return [];
+  return getBreadcrumbPath(folderId).filter((f) => f.id !== folderId);
+}
+
+export function persistFolderViewMode(next: FolderViewMode): void {
+  try {
+    globalThis.window.localStorage.setItem(FOLDER_VIEW_MODE_KEY, next);
+  } catch {
+    /* ignore */
+  }
+}

--- a/app/components/shell/folder-tab/useFolderOsDrop.ts
+++ b/app/components/shell/folder-tab/useFolderOsDrop.ts
@@ -1,0 +1,67 @@
+/** OS file drag-and-drop for FolderTabView (extracted for Sonar S3776). */
+
+import { useCallback, useRef, useState } from 'react';
+
+export function useFolderOsDrop(importPathsIntoView: (paths: string[]) => Promise<void>) {
+  // dragenter/dragleave fire on every child; a depth counter keeps the overlay
+  // stable until the pointer actually leaves the view.
+  const dragDepthRef = useRef(0);
+  const [osDropActive, setOsDropActive] = useState(false);
+
+  const isOsFileDrag = useCallback((e: React.DragEvent) => {
+    return Array.from(e.dataTransfer?.types ?? []).includes('Files');
+  }, []);
+
+  const handleOsDragEnter = useCallback(
+    (e: React.DragEvent) => {
+      if (!isOsFileDrag(e)) return;
+      e.preventDefault();
+      dragDepthRef.current += 1;
+      setOsDropActive(true);
+    },
+    [isOsFileDrag],
+  );
+
+  const handleOsDragOver = useCallback(
+    (e: React.DragEvent) => {
+      if (!isOsFileDrag(e)) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+    },
+    [isOsFileDrag],
+  );
+
+  const handleOsDragLeave = useCallback(
+    (e: React.DragEvent) => {
+      if (!isOsFileDrag(e)) return;
+      dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+      if (dragDepthRef.current === 0) setOsDropActive(false);
+    },
+    [isOsFileDrag],
+  );
+
+  const handleOsDrop = useCallback(
+    async (e: React.DragEvent) => {
+      if (!isOsFileDrag(e)) return;
+      e.preventDefault();
+      dragDepthRef.current = 0;
+      setOsDropActive(false);
+      const files = Array.from(e.dataTransfer.files ?? []);
+      if (!files.length) return;
+      const paths = (globalThis.window.electron?.getPathsForFiles?.(files) ?? []).filter(
+        Boolean,
+      ) as string[];
+      if (!paths.length) return;
+      await importPathsIntoView(paths);
+    },
+    [isOsFileDrag, importPathsIntoView],
+  );
+
+  return {
+    osDropActive,
+    handleOsDragEnter,
+    handleOsDragOver,
+    handleOsDragLeave,
+    handleOsDrop,
+  };
+}

--- a/app/components/shell/folder-tab/useFolderTabActions.ts
+++ b/app/components/shell/folder-tab/useFolderTabActions.ts
@@ -1,0 +1,321 @@
+/** Action callbacks for FolderTabView (extracted for Sonar S3776). */
+
+import { useCallback, type Dispatch, type SetStateAction } from 'react';
+import type { Resource } from '@/lib/hooks/useResources';
+import { filterMoveProjectRoots } from '@/lib/workspace/filterMoveProjectRoots';
+import { getFolderColor } from './folderTabShared';
+import {
+  importPathsIntoFolderView,
+  openNoteInWindow,
+  revealFolderOrVault,
+  runAddUrl,
+  runApplyFolderColor,
+  runBulkDelete,
+  runBulkMoveToFolder,
+  runCreateUntitledNote,
+  runSubfolderColor,
+  runUploadIntoView,
+  tabColorFromFolderMeta,
+  toggleIdInSet,
+} from './folderTabViewHelpers';
+
+export function useToggleSelectId(setSelectedIds: Dispatch<SetStateAction<Set<string>>>) {
+  return useCallback(
+    (id: string) => {
+      setSelectedIds((prev) => toggleIdInSet(prev, id));
+    },
+    [setSelectedIds],
+  );
+}
+
+export function useBulkMoveToFolder(opts: {
+  folderMoveIds: string[] | null;
+  selectedIds: Set<string>;
+  resourceMapForSelection: Map<string, Resource>;
+  moveToFolder: (id: string, folderId: string | null) => Promise<boolean>;
+  refetch: () => Promise<unknown>;
+  setSelectedIds: Dispatch<SetStateAction<Set<string>>>;
+  setFolderMoveIds: Dispatch<SetStateAction<string[] | null>>;
+  setFolderPickOpen: Dispatch<SetStateAction<boolean>>;
+}) {
+  const {
+    folderMoveIds,
+    selectedIds,
+    resourceMapForSelection,
+    moveToFolder,
+    refetch,
+    setSelectedIds,
+    setFolderMoveIds,
+    setFolderPickOpen,
+  } = opts;
+
+  return useCallback(
+    async (targetFolderId: string | null) => {
+      const outcome = await runBulkMoveToFolder({
+        folderMoveIds,
+        selectedIds,
+        resourceMapForSelection,
+        targetFolderId,
+        moveToFolder,
+        filterRoots: filterMoveProjectRoots,
+      });
+      if (outcome === 'cleared-selection') setSelectedIds(new Set());
+      setFolderMoveIds(null);
+      setFolderPickOpen(false);
+      await refetch();
+    },
+    [
+      folderMoveIds,
+      selectedIds,
+      resourceMapForSelection,
+      moveToFolder,
+      refetch,
+      setSelectedIds,
+      setFolderMoveIds,
+      setFolderPickOpen,
+    ],
+  );
+}
+
+export function useBulkDelete(opts: {
+  selectedIds: Set<string>;
+  refetch: () => Promise<unknown>;
+  setSelectedIds: Dispatch<SetStateAction<Set<string>>>;
+  setBulkDeleting: Dispatch<SetStateAction<boolean>>;
+  setBulkDeleteOpen: Dispatch<SetStateAction<boolean>>;
+}) {
+  const { selectedIds, refetch, setSelectedIds, setBulkDeleting, setBulkDeleteOpen } = opts;
+  return useCallback(async () => {
+    setBulkDeleting(true);
+    try {
+      const ok = await runBulkDelete(selectedIds, refetch);
+      if (ok) setSelectedIds(new Set());
+    } finally {
+      setBulkDeleting(false);
+      setBulkDeleteOpen(false);
+    }
+  }, [selectedIds, refetch, setSelectedIds, setBulkDeleting, setBulkDeleteOpen]);
+}
+
+type CreateResource = (resource: Omit<Resource, 'id' | 'created_at' | 'updated_at'>) => Promise<unknown>;
+type UpdateResource = (id: string, updates: Partial<Resource>) => Promise<unknown>;
+
+export function useFolderTabResourceActions(opts: {
+  canOpenInSplit: boolean;
+  openResourceInSplit: (id: string, type: string, title: string) => void;
+  createResource: CreateResource;
+  effectiveProjectId: string;
+  listFolderId: string | null;
+  createFolderParentId: string | null;
+  setCreatingFolder: Dispatch<SetStateAction<boolean>>;
+  setCreateFolderParentId: Dispatch<SetStateAction<string | null>>;
+  openResourceTab: (id: string, type: string, title: string, projectId: string) => void;
+  untitledNoteTitle: string;
+  refetch: () => Promise<unknown>;
+  updateResource: UpdateResource;
+  updateTab: (id: string, patch: { title?: string; color?: string }) => void;
+  deleteResource: (id: string) => Promise<unknown>;
+  deleteTarget: Resource | null;
+  setDeleteTarget: Dispatch<SetStateAction<Resource | null>>;
+  viewCtxIsProjectRoot: boolean;
+  currentFolder: Resource | undefined;
+  folderId: string;
+  setColorPickerPos: Dispatch<SetStateAction<{ top: number; left: number } | null>>;
+  navigateToFolder: (loc: { id: string; title: string; color?: string }) => void;
+  projectRootLabel: string;
+  tUntitled: string;
+}) {
+  const {
+    canOpenInSplit,
+    openResourceInSplit,
+    createResource,
+    effectiveProjectId,
+    listFolderId,
+    createFolderParentId,
+    setCreatingFolder,
+    setCreateFolderParentId,
+    openResourceTab,
+    untitledNoteTitle,
+    refetch,
+    updateResource,
+    updateTab,
+    deleteResource,
+    deleteTarget,
+    setDeleteTarget,
+    viewCtxIsProjectRoot,
+    currentFolder,
+    folderId,
+    setColorPickerPos,
+    navigateToFolder,
+    projectRootLabel,
+    tUntitled,
+  } = opts;
+
+  const handleNavigateToFolder = useCallback(
+    (id: string, title: string, color?: string) => {
+      navigateToFolder({ id, title, color: tabColorFromFolderMeta(color) });
+    },
+    [navigateToFolder],
+  );
+
+  const handleNavigateToProjectRoot = useCallback(() => {
+    if (!effectiveProjectId) return;
+    handleNavigateToFolder(effectiveProjectId, projectRootLabel, 'var(--primary)');
+  }, [effectiveProjectId, projectRootLabel, handleNavigateToFolder]);
+
+  const handleCurrentFolderColor = useCallback(
+    async (color: string) => {
+      const applied = await runApplyFolderColor({
+        currentFolder,
+        folderId,
+        color,
+        updateResource,
+        updateTab,
+      });
+      if (applied) setColorPickerPos(null);
+    },
+    [currentFolder, folderId, updateResource, updateTab, setColorPickerPos],
+  );
+
+  const handleCreateFolder = useCallback(
+    async (name: string) => {
+      await createResource({
+        type: 'folder',
+        title: name,
+        project_id: effectiveProjectId,
+        content: '',
+        folder_id: createFolderParentId ?? listFolderId,
+        metadata: {},
+      });
+      setCreatingFolder(false);
+      setCreateFolderParentId(null);
+    },
+    [
+      createResource,
+      effectiveProjectId,
+      listFolderId,
+      createFolderParentId,
+      setCreatingFolder,
+      setCreateFolderParentId,
+    ],
+  );
+
+  const handleOpenInSplit = useCallback(
+    (item: Resource) => {
+      if (!canOpenInSplit) return;
+      openResourceInSplit(item.id, item.type, item.title ?? '');
+    },
+    [canOpenInSplit, openResourceInSplit],
+  );
+
+  const handleOpenInWindow = useCallback(async (item: Resource) => {
+    await openNoteInWindow(item);
+  }, []);
+
+  const handleNewSubfolder = useCallback(
+    (parentId: string) => {
+      setCreateFolderParentId(parentId);
+      setCreatingFolder(true);
+    },
+    [setCreateFolderParentId, setCreatingFolder],
+  );
+
+  const handleNewNote = useCallback(async () => {
+    await runCreateUntitledNote({
+      title: untitledNoteTitle,
+      effectiveProjectId,
+      listFolderId,
+      openResourceTab,
+    });
+  }, [effectiveProjectId, listFolderId, untitledNoteTitle, openResourceTab]);
+
+  const importPathsIntoView = useCallback(
+    async (paths: string[]) => {
+      await importPathsIntoFolderView({
+        paths,
+        effectiveProjectId,
+        listFolderId,
+        refetch,
+      });
+    },
+    [effectiveProjectId, listFolderId, refetch],
+  );
+
+  const handleUpload = useCallback(async () => {
+    await runUploadIntoView(importPathsIntoView);
+  }, [importPathsIntoView]);
+
+  const handleAddUrl = useCallback(
+    (url: string) => {
+      runAddUrl({ url, effectiveProjectId, listFolderId });
+    },
+    [effectiveProjectId, listFolderId],
+  );
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deleteTarget) return;
+    await deleteResource(deleteTarget.id);
+    setDeleteTarget(null);
+  }, [deleteTarget, deleteResource, setDeleteTarget]);
+
+  const handleRevealCurrentFolder = useCallback(async () => {
+    await revealFolderOrVault({
+      isProjectRoot: viewCtxIsProjectRoot,
+      currentFolder,
+      effectiveProjectId,
+    });
+  }, [viewCtxIsProjectRoot, currentFolder, effectiveProjectId]);
+
+  const handleRenameFile = useCallback(
+    async (id: string, newTitle: string) => {
+      await updateResource(id, { title: newTitle });
+    },
+    [updateResource],
+  );
+
+  const handleSubfolderRename = useCallback(
+    async (id: string, newTitle: string) => {
+      await updateResource(id, { title: newTitle });
+      updateTab(`folder:${id}`, { title: newTitle });
+    },
+    [updateResource, updateTab],
+  );
+
+  const handleSubfolderColor = useCallback(
+    async (id: string, color: string, folder: Resource) => {
+      await runSubfolderColor({ id, color, folder, updateResource, updateTab });
+    },
+    [updateResource, updateTab],
+  );
+
+  const openListItem = useCallback(
+    ({ item, isFolder }: { item: Resource; isFolder: boolean }) => {
+      if (isFolder) {
+        handleNavigateToFolder(item.id, item.title, getFolderColor(item));
+        return;
+      }
+      openResourceTab(item.id, item.type, item.title ?? tUntitled, effectiveProjectId);
+    },
+    [handleNavigateToFolder, openResourceTab, tUntitled, effectiveProjectId],
+  );
+
+  return {
+    handleNavigateToFolder,
+    handleNavigateToProjectRoot,
+    handleCurrentFolderColor,
+    handleCreateFolder,
+    handleOpenInSplit,
+    handleOpenInWindow,
+    handleNewSubfolder,
+    handleNewNote,
+    importPathsIntoView,
+    handleUpload,
+    handleAddUrl,
+    handleDeleteConfirm,
+    handleRevealCurrentFolder,
+    handleRenameFile,
+    handleSubfolderRename,
+    handleSubfolderColor,
+    openListItem,
+  };
+}

--- a/app/components/shell/folder-tab/useFolderTabEffects.ts
+++ b/app/components/shell/folder-tab/useFolderTabEffects.ts
@@ -1,0 +1,60 @@
+/** Side-effects for FolderTabView (extracted for Sonar S3776). */
+
+import { useEffect, type Dispatch, type SetStateAction } from 'react';
+import type { ProjectTag } from './folderTabViewHelpers';
+
+export function useFolderNavAltArrowKeys(goBack: () => void, goForward: () => void) {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!e.altKey || e.metaKey || e.ctrlKey || e.shiftKey) return;
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        goBack();
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        goForward();
+      }
+    };
+    globalThis.window.addEventListener('keydown', onKeyDown);
+    return () => globalThis.window.removeEventListener('keydown', onKeyDown);
+  }, [goBack, goForward]);
+}
+
+export function useProjectTagsLoader(
+  effectiveProjectId: string,
+  setProjectTags: Dispatch<SetStateAction<ProjectTag[]>>,
+) {
+  useEffect(() => {
+    let cancelled = false;
+    void globalThis.window.electron?.db?.tags?.getAll(effectiveProjectId).then((res) => {
+      if (cancelled || !res?.success) return;
+      setProjectTags((res.data as ProjectTag[] | undefined) ?? []);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [effectiveProjectId, setProjectTags]);
+}
+
+export function useTaggedResourcesLoader(
+  tagFilterId: string | null,
+  effectiveProjectId: string,
+  setTaggedResourceIds: Dispatch<SetStateAction<Set<string>>>,
+) {
+  useEffect(() => {
+    if (!tagFilterId) {
+      setTaggedResourceIds(new Set());
+      return;
+    }
+    let cancelled = false;
+    void globalThis.window.electron?.db?.tags?.getResources(tagFilterId, effectiveProjectId).then(
+      (res) => {
+        if (cancelled || !res?.success) return;
+        setTaggedResourceIds(new Set((res.data ?? []).map((r) => r.id)));
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [tagFilterId, effectiveProjectId, setTaggedResourceIds]);
+}

--- a/app/components/shell/folder-tab/useFolderTabSearch.ts
+++ b/app/components/shell/folder-tab/useFolderTabSearch.ts
@@ -1,0 +1,117 @@
+/** In-folder search effects/handlers for FolderTabView (extracted for Sonar S3776). */
+
+import { useCallback, useEffect, useRef, type RefObject } from 'react';
+import { lazyRef } from '@/lib/utils/lazyRef';
+import type { FolderListEntry } from './folderTabViewHelpers';
+
+export function useFolderTabSearchController(opts: {
+  searchOpen: boolean;
+  searchQuery: string;
+  setSearchQuery: (q: string) => void;
+  setSearchOpen: (open: boolean) => void;
+  searchFocusIndex: number;
+  setSearchFocusIndex: (updater: number | ((i: number) => number)) => void;
+  searchInputRef: RefObject<HTMLInputElement>;
+  filteredListItems: FolderListEntry[];
+  normalizedSearchQuery: string;
+  isFiltering: boolean;
+  openListItem: (entry: FolderListEntry) => void;
+}) {
+  const {
+    searchOpen,
+    setSearchQuery,
+    setSearchOpen,
+    searchFocusIndex,
+    setSearchFocusIndex,
+    searchInputRef,
+    filteredListItems,
+    normalizedSearchQuery,
+    isFiltering,
+    openListItem,
+  } = opts;
+
+  const rowRefs = useRef<Map<string, HTMLDivElement> | null>(null);
+  const rowRefMap = lazyRef(rowRefs, () => new Map());
+
+  const closeSearch = useCallback(() => {
+    setSearchOpen(false);
+    setSearchQuery('');
+    setSearchFocusIndex(0);
+  }, [setSearchOpen, setSearchQuery, setSearchFocusIndex]);
+
+  const openSearch = useCallback(() => {
+    setSearchOpen(true);
+    requestAnimationFrame(() => searchInputRef.current?.focus());
+  }, [setSearchOpen, searchInputRef]);
+
+  useEffect(() => {
+    setSearchFocusIndex(0);
+  }, [normalizedSearchQuery, setSearchFocusIndex]);
+
+  useEffect(() => {
+    if (!isFiltering || filteredListItems.length === 0) return;
+    const focused =
+      filteredListItems[Math.min(searchFocusIndex, filteredListItems.length - 1)];
+    if (!focused) return;
+    rowRefMap.get(focused.item.id)?.scrollIntoView({ block: 'nearest' });
+  }, [searchFocusIndex, filteredListItems, isFiltering, rowRefMap]);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault();
+        if (searchOpen) {
+          searchInputRef.current?.focus();
+          searchInputRef.current?.select();
+        } else {
+          openSearch();
+        }
+      }
+    };
+    globalThis.window.addEventListener('keydown', onKeyDown);
+    return () => globalThis.window.removeEventListener('keydown', onKeyDown);
+  }, [searchOpen, openSearch, searchInputRef]);
+
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeSearch();
+        return;
+      }
+      if (filteredListItems.length === 0) return;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSearchFocusIndex((i) => Math.min(i + 1, filteredListItems.length - 1));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSearchFocusIndex((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const target = filteredListItems[searchFocusIndex] ?? filteredListItems[0];
+        if (target) openListItem(target);
+      }
+    },
+    [closeSearch, filteredListItems, openListItem, searchFocusIndex, setSearchFocusIndex],
+  );
+
+  const setRowRef = useCallback(
+    (id: string) => (el: HTMLDivElement | null) => {
+      if (el) rowRefMap.set(id, el as unknown as HTMLDivElement);
+      else rowRefMap.delete(id);
+    },
+    [rowRefMap],
+  );
+
+  return {
+    rowRefMap,
+    setRowRef,
+    closeSearch,
+    openSearch,
+    handleSearchKeyDown,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors `FolderTabView` in `app/components/shell/FolderTabView.tsx` to drop Sonar cognitive complexity (typescript:S3776) from 50 to ≤15.
- Extracts pure helpers (`folderTabViewHelpers.ts`), hooks (`useFolderOsDrop`, `useFolderTabSearch`, `useFolderTabEffects`, `useFolderTabActions`), and subcomponents (`FolderTabToolbar`, `FolderTabBody`, `FolderTabDialogs`, `FolderTabDropOverlay`) — same folder-tab layout, handlers, and data flow; no folder-tab rewrite.
- Adds `folderTabViewHelpers.test.ts` locking partition/list/filter/status helpers.

## Type
- [ ] New feature
- [x] Bug fix
- [x] Refactor
- [ ] Docs / config

## Sonar
| Key | Rule | File |
| --- | --- | --- |
| be032a80-cef5-4315-b12e-fc43a8224d3d | typescript:S3776 | `app/components/shell/FolderTabView.tsx` (~L56 historically; hotspot is `FolderTabView`) |

Closes #760

## Why this is safe
Helpers and subcomponents preserve the previous control flow: identical project-root vs folder listing, tag/search filtering, OS drag-drop import, bulk move/delete, breadcrumb/nav, and list/grid rendering. `FolderCard.tsx` / `useTabStore.ts` / other scoped-out files are untouched. Unit tests cover the extracted pure helpers.

## Local validation
- `pnpm run typecheck` — pass
- `pnpm run lint` — pass (0 errors; pre-existing warnings only)
- `pnpm run test:coverage` — pass
- `pnpm run check:sonar-patterns -- --diff=origin/main` — pass

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run test:coverage` passes
- [x] i18n N/A
- [x] No hardcoded colors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe42b9b9-dae5-4ee9-9de0-d26c9db7aa66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe42b9b9-dae5-4ee9-9de0-d26c9db7aa66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

