### PR TITLE
fix(ci): run Sonar via sonar-scanner-npm (fix dome-sonar ENOENT)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,15 +106,8 @@ pipeline {
     stage('SonarQube analysis') {
       steps {
         withSonarQubeEnv('SonarQube') {
-          sh '''
-            set -eux
-            if [ ! -s coverage/lcov.info ]; then
-              echo "WARN: coverage/lcov.info missing or empty — running scanner without fresh coverage"
-              mkdir -p coverage
-              touch coverage/lcov.info
-            fi
-            pnpm --package=@sonar/scan dlx sonar-scanner
-          '''
+          // @sonar/scan v5 only ships sonar-scanner-npm (sonar-scanner alias removed → ENOENT on PATH).
+          sh 'bash scripts/jenkins/run-sonar-scanner.sh'
         }
       }
     }

--- a/docs/automation/sonar-quality-loop.md
+++ b/docs/automation/sonar-quality-loop.md
@@ -6,7 +6,7 @@ Automated correction loop: SonarQube → GitHub Issues → OpenCode CLI (MiniMax
 
 | Component | Role |
 |-----------|------|
-| Jenkins `dome-sonar` | Sonar analysis on push to `main` (`test:coverage` → lcov + pattern guards + scanner) |
+| Jenkins `dome-sonar` | Sonar analysis on push to `main` (`test:coverage` → lcov + pattern guards + scanner via `scripts/jenkins/run-sonar-scanner.sh` → `pnpm --package=@sonar/scan dlx sonar-scanner-npm`) |
 | Jenkins `dome-quality-loop` | Cron hourly with **modes** (`issues` / `coverage` / `hotspots`): OpenCode fixer or coverage tests → PR; post always reviews hotspots + closes resolved |
 | OpenCode CLI | `sonar-fix` (issues), `sonar-coverage` (tests), `sonar-reviewer` (read-only) |
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test:coverage": "pnpm run build:packages && pnpm run test:coverage:electron && pnpm run test:coverage:renderer && pnpm run test:coverage:agent-core && pnpm run test:coverage:ai && node scripts/sonar/merge-coverage.mjs",
     "sonar:review-hotspots": "node scripts/sonar/review-hotspots.mjs",
     "test:sonar-hotspots": "node --test scripts/sonar/__tests__/review-hotspots.test.mjs",
-    "test:sonar-quality-loop": "node --test scripts/sonar/__tests__/batch-eligibility.test.mjs scripts/sonar/__tests__/sync-dedupe-closed.test.mjs scripts/sonar/__tests__/resolve-loop-mode.test.mjs scripts/jenkins/__tests__/run-fast-gates.test.mjs",
+    "test:sonar-quality-loop": "node --test scripts/sonar/__tests__/batch-eligibility.test.mjs scripts/sonar/__tests__/sync-dedupe-closed.test.mjs scripts/sonar/__tests__/resolve-loop-mode.test.mjs scripts/jenkins/__tests__/run-fast-gates.test.mjs scripts/jenkins/__tests__/run-sonar-scanner.test.mjs",
     "sonar:resolve-mode": "node scripts/sonar/resolve-loop-mode.mjs",
     "sonar:pick-coverage": "node scripts/sonar/pick-coverage-batch.mjs",
     "sonar:fetch-issues": "node scripts/sonar/fetch-issues.mjs",

--- a/scripts/jenkins/__tests__/run-sonar-scanner.test.mjs
+++ b/scripts/jenkins/__tests__/run-sonar-scanner.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const SCRIPT = path.join(ROOT, 'scripts/jenkins/run-sonar-scanner.sh');
+
+/**
+ * @param {{ lcov?: string | null }} opts
+ */
+function prepWorkspace(opts = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'run-sonar-scanner-'));
+  const bin = path.join(dir, 'bin');
+  fs.mkdirSync(bin);
+  const logPath = path.join(dir, 'pnpm-argv.log');
+  // Record argv and succeed — do not download @sonar/scan in unit tests.
+  fs.writeFileSync(
+    path.join(bin, 'pnpm'),
+    `#!/bin/sh\nprintf '%s\\n' "$*" > "${logPath}"\nexit 0\n`,
+    { mode: 0o755 },
+  );
+  fs.mkdirSync(path.join(dir, 'scripts/jenkins'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'scripts/jenkins/run-sonar-scanner.sh'), fs.readFileSync(SCRIPT, 'utf8'), {
+    mode: 0o755,
+  });
+  if (opts.lcov != null) {
+    fs.mkdirSync(path.join(dir, 'coverage'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'coverage/lcov.info'), opts.lcov);
+  }
+  return { dir, bin, logPath };
+}
+
+describe('run-sonar-scanner.sh', () => {
+  it('invokes pnpm dlx sonar-scanner-npm (not bare sonar-scanner)', () => {
+    const { dir, bin, logPath } = prepWorkspace({ lcov: 'TN:\nSF:x.ts\nend_of_record\n' });
+    const r = spawnSync('bash', ['scripts/jenkins/run-sonar-scanner.sh', dir], {
+      cwd: dir,
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+      encoding: 'utf8',
+    });
+    assert.equal(r.status, 0, r.stderr || r.stdout);
+    const argv = fs.readFileSync(logPath, 'utf8').trim();
+    assert.equal(argv, '--package=@sonar/scan dlx sonar-scanner-npm');
+    assert.doesNotMatch(argv, /(^|\s)sonar-scanner(\s|$)/);
+  });
+
+  it('creates empty coverage/lcov.info when missing and still runs the scanner', () => {
+    const { dir, bin, logPath } = prepWorkspace({ lcov: null });
+    const r = spawnSync('bash', ['scripts/jenkins/run-sonar-scanner.sh', dir], {
+      cwd: dir,
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+      encoding: 'utf8',
+    });
+    assert.equal(r.status, 0, r.stderr || r.stdout);
+    assert.match(r.stdout + r.stderr, /WARN: coverage\/lcov\.info missing or empty/);
+    assert.ok(fs.existsSync(path.join(dir, 'coverage/lcov.info')));
+    assert.equal(fs.readFileSync(path.join(dir, 'coverage/lcov.info'), 'utf8'), '');
+    assert.equal(fs.readFileSync(logPath, 'utf8').trim(), '--package=@sonar/scan dlx sonar-scanner-npm');
+  });
+
+  it('creates empty coverage/lcov.info when the file is empty and still runs the scanner', () => {
+    const { dir, bin, logPath } = prepWorkspace({ lcov: '' });
+    const r = spawnSync('bash', ['scripts/jenkins/run-sonar-scanner.sh', dir], {
+      cwd: dir,
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+      encoding: 'utf8',
+    });
+    assert.equal(r.status, 0, r.stderr || r.stdout);
+    assert.match(r.stdout + r.stderr, /WARN: coverage\/lcov\.info missing or empty/);
+    assert.equal(fs.readFileSync(logPath, 'utf8').trim(), '--package=@sonar/scan dlx sonar-scanner-npm');
+  });
+});

--- a/scripts/jenkins/run-sonar-scanner.sh
+++ b/scripts/jenkins/run-sonar-scanner.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Run SonarQube analysis via @sonar/scan (SonarScanner for NPM).
+#
+# Do NOT invoke a bare `sonar-scanner` binary: @sonar/scan v5 removed the
+# `sonar` / `sonar-scanner` aliases. Spawning `sonar-scanner` looks on PATH and
+# fails with ENOENT on agents that only have Node/pnpm (Jenkins build #280).
+#
+# Correct pnpm form (official docs):
+#   pnpm --package=@sonar/scan dlx sonar-scanner-npm
+#
+# Usage (from repo root, inside withSonarQubeEnv):
+#   bash scripts/jenkins/run-sonar-scanner.sh
+#   bash scripts/jenkins/run-sonar-scanner.sh /path/to/checkout
+set -euo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT"
+
+if [ ! -s coverage/lcov.info ]; then
+  echo "WARN: coverage/lcov.info missing or empty — running scanner without fresh coverage"
+  mkdir -p coverage
+  touch coverage/lcov.info
+fi
+
+# Explicit package + v5 bin name — never relies on a globally installed CLI.
+exec pnpm --package=@sonar/scan dlx sonar-scanner-npm


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Jenkins `dome-sonar` build #280 failed at **SonarQube analysis** with `spawn sonar-scanner ENOENT` after #1358 stopped skipping the scanner.
- Root cause: `pnpm --package=@sonar/scan dlx sonar-scanner` targets a **removed** v5 bin alias. `@sonar/scan@5` only ships `sonar-scanner-npm`; the bare name is looked up on PATH and fails on the agent.
- Fix: wrapper `scripts/jenkins/run-sonar-scanner.sh` runs `pnpm --package=@sonar/scan dlx sonar-scanner-npm` (official pnpm form). Still creates empty `coverage/lcov.info` when missing — never skips the scan. Python3 install path unchanged (best-effort only).

## Type
- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [x] Docs / config

## Evidence
Local reproduction of Jenkins #280 vs fixed bin:

```
pnpm --package=@sonar/scan dlx sonar-scanner --help
→ ENOENT  Command failed with ENOENT: sonar-scanner --help
  spawn sonar-scanner ENOENT

pnpm --package=@sonar/scan dlx sonar-scanner-npm --help
→ Usage: sonar-scanner [options]
```

`@sonar/scan@5.0.0` bins: only `sonar-scanner-npm`. `@sonar/scan@4.4.0` still had `sonar` / `sonar-scanner` aliases.

## Checklist
- [x] `pnpm run test:sonar-quality-loop` — 21 tests pass (includes new `run-sonar-scanner` suite)
- [x] No product/app source changes
- [x] Coverage-missing path still runs the scanner

## Test plan
- [ ] Merge → next `dome-sonar` run on `main` should pass SonarQube analysis and publish a fresh snapshot (not stuck on 2026-07-20)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d23c484-62d9-44a4-b8c7-cc962cf79a13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d23c484-62d9-44a4-b8c7-cc962cf79a13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

