### PR TITLE
fix(ci): match Sonar line hashes (strip spaces) in pick-batch

### DIFF
--- a/scripts/sonar/__tests__/batch-eligibility.test.mjs
+++ b/scripts/sonar/__tests__/batch-eligibility.test.mjs
@@ -26,9 +26,28 @@ describe('isOpenSonarStatus', () => {
 });
 
 describe('sonarLineHash / isStaleSonarHash', () => {
-  it('matches MD5 of the line content', () => {
+  it('matches MD5 of the line content with spaces and tabs stripped', () => {
     const line = 'function syncBlobs() {';
-    assert.equal(sonarLineHash(line), crypto.createHash('md5').update(line, 'utf8').digest('hex'));
+    const stripped = line.replace(/[\t ]/g, '');
+    assert.equal(sonarLineHash(line), crypto.createHash('md5').update(stripped, 'utf8').digest('hex'));
+  });
+
+  it('hashes spaced and compact lines the same', () => {
+    const spaced = 'export default function CardDetailModal({';
+    const compact = 'exportdefaultfunctionCardDetailModal({';
+    assert.equal(sonarLineHash(spaced), sonarLineHash(compact));
+  });
+
+  it('returns empty hash for whitespace-only lines', () => {
+    assert.equal(sonarLineHash('   \t  '), '');
+  });
+
+  it('matches live CardDetailModal Sonar issue hash (strip spaces, not raw MD5)', () => {
+    const line = 'export default function CardDetailModal({';
+    const sonarHash = '8e63e3367d6c970b1c72383f66e94e8d';
+    const rawMd5 = crypto.createHash('md5').update(line, 'utf8').digest('hex');
+    assert.equal(sonarLineHash(line), sonarHash);
+    assert.notEqual(sonarLineHash(line), rawMd5);
   });
 
   it('detects stale hash when disk line differs', () => {

--- a/scripts/sonar/batch-eligibility.mjs
+++ b/scripts/sonar/batch-eligibility.mjs
@@ -15,11 +15,14 @@ export const OPEN_SONAR_STATUSES = new Set(['OPEN', 'CONFIRMED', 'REOPENED']);
 export const DEFAULT_RECENT_FIX_DAYS = 30;
 
 /**
- * Sonar stores MD5 of the source line (DigestUtils.md5Hex).
+ * Sonar stores MD5 of the source line with spaces/tabs removed
+ * (SourceLineHashesComputer: StringUtils.replaceChars(line, "\t ", "")).
  * @param {string} lineContent
  */
 export function sonarLineHash(lineContent) {
-  return crypto.createHash('md5').update(String(lineContent), 'utf8').digest('hex');
+  const reduced = String(lineContent).replace(/[\t ]/g, '');
+  if (!reduced) return '';
+  return crypto.createHash('md5').update(reduced, 'utf8').digest('hex');
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Align `sonarLineHash()` with SonarQube's `SourceLineHashesComputer`: MD5 UTF-8 of the line with spaces and tabs removed; empty reduced line → `''`.
- Fixes Jenkins dome-quality-loop #1314 marking all 50 open GitHub Sonar issues as `stale_sonar_hash` despite matching disk content (e.g. CardDetailModal.tsx:189).
- Add regression tests for stripped hashing, whitespace-only lines, and the live CardDetailModal fixture.

## Type
- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs / config

## Checklist
- [x] Unit tests: `node --test scripts/sonar/__tests__/batch-eligibility.test.mjs` (15/15 pass)
- [ ] `pnpm run typecheck` passes (N/A — scripts-only change)
- [ ] `pnpm run lint` passes (N/A — scripts-only change)
- [ ] `pnpm run build` passes (N/A — scripts-only change)
- [ ] i18n keys added in all 4 languages (en, es, fr, pt) if new user-visible strings
- [ ] No hardcoded colors (CSS variables only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a72f45ba-1a4b-4ef1-ba44-80ea1e0b93cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a72f45ba-1a4b-4ef1-ba44-80ea1e0b93cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

