### PR TITLE
fix(sonar): S3776 openai-responses-shared processResponsesStream (cx 138)

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared-stream.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared-stream.test.ts
@@ -40,9 +40,14 @@ function emptyOutput(): AssistantMessage {
 	};
 }
 
-async function* eventsOf(...events: ResponseStreamEvent[]): AsyncIterable<ResponseStreamEvent> {
+/** Test fixtures omit SDK bookkeeping fields (sequence_number, indexes). */
+function asStreamEvent(event: object): ResponseStreamEvent {
+	return event as unknown as ResponseStreamEvent;
+}
+
+async function* eventsOf(...events: object[]): AsyncIterable<ResponseStreamEvent> {
 	for (const event of events) {
-		yield event;
+		yield asStreamEvent(event);
 	}
 }
 
@@ -75,19 +80,19 @@ describe("processResponsesStream", () => {
 				{
 					type: "response.created",
 					response: { id: "resp_1" },
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.output_item.added",
 					item: messageItem,
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.content_part.added",
 					part: { type: "output_text", text: "", annotations: [] },
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.output_text.delta",
 					delta: "Hello",
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.output_item.done",
 					item: {
@@ -95,7 +100,7 @@ describe("processResponsesStream", () => {
 						status: "completed",
 						content: [{ type: "output_text", text: "Hello", annotations: [] }],
 					},
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.completed",
 					response: {
@@ -108,7 +113,7 @@ describe("processResponsesStream", () => {
 							input_tokens_details: { cached_tokens: 4 },
 						},
 					},
-				} as ResponseStreamEvent,
+				},
 			),
 			output,
 			stream,
@@ -163,23 +168,23 @@ describe("processResponsesStream", () => {
 				{
 					type: "response.output_item.added",
 					item: toolItem,
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.function_call_arguments.delta",
 					delta: '{"x":',
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.function_call_arguments.delta",
 					delta: "1}",
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.function_call_arguments.done",
 					arguments: '{"x":1}',
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.output_item.done",
 					item: { ...toolItem, arguments: '{"x":1}', status: "completed" },
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.completed",
 					response: {
@@ -191,7 +196,7 @@ describe("processResponsesStream", () => {
 							total_tokens: 7,
 						},
 					},
-				} as ResponseStreamEvent,
+				},
 			),
 			output,
 			stream,
@@ -242,23 +247,23 @@ describe("processResponsesStream", () => {
 				{
 					type: "response.output_item.added",
 					item: reasoningItem,
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.reasoning_summary_part.added",
 					part: { type: "summary_text", text: "" },
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.reasoning_summary_text.delta",
 					delta: "think",
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.output_item.done",
 					item: doneItem,
-				} as ResponseStreamEvent,
+				},
 				{
 					type: "response.completed",
 					response: { id: "resp_r", status: "completed" },
-				} as ResponseStreamEvent,
+				},
 			),
 			output,
 			stream,
@@ -301,7 +306,7 @@ describe("processResponsesStream", () => {
 						total_tokens: 11,
 					},
 				},
-			} as ResponseStreamEvent),
+			}),
 			output,
 			stream,
 			model,
@@ -325,7 +330,7 @@ describe("processResponsesStream", () => {
 
 		await expect(
 			processResponsesStream(
-				eventsOf({ type: "error", code: "E1", message: "boom" } as ResponseStreamEvent),
+				eventsOf({ type: "error", code: "E1", message: "boom" }),
 				emptyOutput(),
 				new AssistantMessageEventStream(),
 				model,
@@ -339,7 +344,7 @@ describe("processResponsesStream", () => {
 					response: {
 						error: { code: "failed", message: "nope" },
 					},
-				} as ResponseStreamEvent),
+				}),
 				emptyOutput(),
 				new AssistantMessageEventStream(),
 				model,

--- a/packages/ai/src/providers/openai-responses-shared-stream.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared-stream.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it } from "vitest";
+import type { ResponseStreamEvent } from "openai/resources/responses/responses.js";
+import type { AssistantMessage, AssistantMessageEvent, Model, Usage } from "../types.js";
+import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { processResponsesStream } from "./openai-responses-shared.js";
+
+function baseModel(overrides: Partial<Model<"openai-responses">> = {}): Model<"openai-responses"> {
+	return {
+		id: "gpt-4o",
+		name: "GPT-4o",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+		...overrides,
+	};
+}
+
+function emptyOutput(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-4o",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+async function* eventsOf(...events: ResponseStreamEvent[]): AsyncIterable<ResponseStreamEvent> {
+	for (const event of events) {
+		yield event;
+	}
+}
+
+async function collectStreamEvents(
+	stream: AssistantMessageEventStream,
+): Promise<AssistantMessageEvent[]> {
+	const collected: AssistantMessageEvent[] = [];
+	for await (const event of stream) {
+		collected.push(event);
+	}
+	return collected;
+}
+
+describe("processResponsesStream", () => {
+	it("streams text deltas, sets usage/cost, and maps stop reason", async () => {
+		const output = emptyOutput();
+		const stream = new AssistantMessageEventStream();
+		const model = baseModel();
+
+		const messageItem = {
+			type: "message" as const,
+			id: "msg_1",
+			role: "assistant" as const,
+			status: "in_progress" as const,
+			content: [] as Array<{ type: "output_text"; text: string; annotations: [] }>,
+		};
+
+		const run = processResponsesStream(
+			eventsOf(
+				{
+					type: "response.created",
+					response: { id: "resp_1" },
+				} as ResponseStreamEvent,
+				{
+					type: "response.output_item.added",
+					item: messageItem,
+				} as ResponseStreamEvent,
+				{
+					type: "response.content_part.added",
+					part: { type: "output_text", text: "", annotations: [] },
+				} as ResponseStreamEvent,
+				{
+					type: "response.output_text.delta",
+					delta: "Hello",
+				} as ResponseStreamEvent,
+				{
+					type: "response.output_item.done",
+					item: {
+						...messageItem,
+						status: "completed",
+						content: [{ type: "output_text", text: "Hello", annotations: [] }],
+					},
+				} as ResponseStreamEvent,
+				{
+					type: "response.completed",
+					response: {
+						id: "resp_1",
+						status: "completed",
+						usage: {
+							input_tokens: 12,
+							output_tokens: 3,
+							total_tokens: 15,
+							input_tokens_details: { cached_tokens: 4 },
+						},
+					},
+				} as ResponseStreamEvent,
+			),
+			output,
+			stream,
+			model,
+		);
+
+		const collectPromise = collectStreamEvents(stream);
+		await run;
+		stream.end(output);
+		const events = await collectPromise;
+
+		expect(output.responseId).toBe("resp_1");
+		expect(output.content).toEqual([
+			{
+				type: "text",
+				text: "Hello",
+				textSignature: JSON.stringify({ v: 1, id: "msg_1" }),
+			},
+		]);
+		expect(output.usage).toMatchObject({
+			input: 8,
+			output: 3,
+			cacheRead: 4,
+			cacheWrite: 0,
+			totalTokens: 15,
+		});
+		expect(output.usage.cost.total).toBeGreaterThan(0);
+		expect(output.stopReason).toBe("stop");
+		expect(events.map((e) => e.type)).toEqual([
+			"text_start",
+			"text_delta",
+			"text_end",
+		]);
+	});
+
+	it("streams tool call args with partialJson deltas and overrides stop to toolUse", async () => {
+		const output = emptyOutput();
+		const stream = new AssistantMessageEventStream();
+		const model = baseModel();
+
+		const toolItem = {
+			type: "function_call" as const,
+			id: "fc_1",
+			call_id: "call_1",
+			name: "echo",
+			arguments: "",
+			status: "in_progress" as const,
+		};
+
+		const run = processResponsesStream(
+			eventsOf(
+				{
+					type: "response.output_item.added",
+					item: toolItem,
+				} as ResponseStreamEvent,
+				{
+					type: "response.function_call_arguments.delta",
+					delta: '{"x":',
+				} as ResponseStreamEvent,
+				{
+					type: "response.function_call_arguments.delta",
+					delta: "1}",
+				} as ResponseStreamEvent,
+				{
+					type: "response.function_call_arguments.done",
+					arguments: '{"x":1}',
+				} as ResponseStreamEvent,
+				{
+					type: "response.output_item.done",
+					item: { ...toolItem, arguments: '{"x":1}', status: "completed" },
+				} as ResponseStreamEvent,
+				{
+					type: "response.completed",
+					response: {
+						id: "resp_tool",
+						status: "completed",
+						usage: {
+							input_tokens: 5,
+							output_tokens: 2,
+							total_tokens: 7,
+						},
+					},
+				} as ResponseStreamEvent,
+			),
+			output,
+			stream,
+			model,
+		);
+
+		const collectPromise = collectStreamEvents(stream);
+		await run;
+		stream.end(output);
+		const events = await collectPromise;
+
+		expect(output.stopReason).toBe("toolUse");
+		expect(output.content).toHaveLength(1);
+		const toolCall = output.content[0];
+		expect(toolCall).toMatchObject({
+			type: "toolCall",
+			id: "call_1|fc_1",
+			name: "echo",
+			arguments: { x: 1 },
+		});
+		expect(toolCall).not.toHaveProperty("partialJson");
+		expect(events.map((e) => e.type)).toEqual([
+			"toolcall_start",
+			"toolcall_delta",
+			"toolcall_delta",
+			"toolcall_end",
+		]);
+	});
+
+	it("streams reasoning summary and sets thinkingSignature on done", async () => {
+		const output = emptyOutput();
+		const stream = new AssistantMessageEventStream();
+		const model = baseModel({ reasoning: true });
+
+		const reasoningItem = {
+			type: "reasoning" as const,
+			id: "rs_1",
+			summary: [] as Array<{ type: "summary_text"; text: string }>,
+		};
+
+		const doneItem = {
+			...reasoningItem,
+			summary: [{ type: "summary_text" as const, text: "think" }],
+		};
+
+		const run = processResponsesStream(
+			eventsOf(
+				{
+					type: "response.output_item.added",
+					item: reasoningItem,
+				} as ResponseStreamEvent,
+				{
+					type: "response.reasoning_summary_part.added",
+					part: { type: "summary_text", text: "" },
+				} as ResponseStreamEvent,
+				{
+					type: "response.reasoning_summary_text.delta",
+					delta: "think",
+				} as ResponseStreamEvent,
+				{
+					type: "response.output_item.done",
+					item: doneItem,
+				} as ResponseStreamEvent,
+				{
+					type: "response.completed",
+					response: { id: "resp_r", status: "completed" },
+				} as ResponseStreamEvent,
+			),
+			output,
+			stream,
+			model,
+		);
+
+		const collectPromise = collectStreamEvents(stream);
+		await run;
+		stream.end(output);
+		const events = await collectPromise;
+
+		expect(output.content[0]).toMatchObject({
+			type: "thinking",
+			thinking: "think",
+			thinkingSignature: JSON.stringify(doneItem),
+		});
+		expect(events.map((e) => e.type)).toEqual([
+			"thinking_start",
+			"thinking_delta",
+			"thinking_end",
+		]);
+	});
+
+	it("applies service-tier pricing hooks on completed", async () => {
+		const output = emptyOutput();
+		const stream = new AssistantMessageEventStream();
+		const model = baseModel();
+		const tiersSeen: unknown[] = [];
+
+		await processResponsesStream(
+			eventsOf({
+				type: "response.completed",
+				response: {
+					id: "resp_tier",
+					status: "completed",
+					service_tier: "priority",
+					usage: {
+						input_tokens: 10,
+						output_tokens: 1,
+						total_tokens: 11,
+					},
+				},
+			} as ResponseStreamEvent),
+			output,
+			stream,
+			model,
+			{
+				serviceTier: "default",
+				resolveServiceTier: (responseTier, requestTier) => responseTier ?? requestTier,
+				applyServiceTierPricing: (usage: Usage, serviceTier) => {
+					tiersSeen.push(serviceTier);
+					usage.cost.total += 1;
+				},
+			},
+		);
+		stream.end(output);
+
+		expect(tiersSeen).toEqual(["priority"]);
+		expect(output.usage.cost.total).toBeGreaterThan(0);
+	});
+
+	it("throws on error and response.failed events", async () => {
+		const model = baseModel();
+
+		await expect(
+			processResponsesStream(
+				eventsOf({ type: "error", code: "E1", message: "boom" } as ResponseStreamEvent),
+				emptyOutput(),
+				new AssistantMessageEventStream(),
+				model,
+			),
+		).rejects.toThrow("Error Code E1: boom");
+
+		await expect(
+			processResponsesStream(
+				eventsOf({
+					type: "response.failed",
+					response: {
+						error: { code: "failed", message: "nope" },
+					},
+				} as ResponseStreamEvent),
+				emptyOutput(),
+				new AssistantMessageEventStream(),
+				model,
+			),
+		).rejects.toThrow("failed: nope");
+	});
+});

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -284,6 +284,28 @@ export function convertResponsesTools(tools: Tool[], options?: ConvertResponsesT
 // Stream processing
 // =============================================================================
 
+type ResponsesStreamCurrentItem =
+	| ResponseReasoningItem
+	| ResponseOutputMessage
+	| ResponseFunctionToolCall
+	| null;
+
+type ResponsesStreamToolCallBlock = ToolCall & { partialJson: string };
+
+type ResponsesStreamCurrentBlock =
+	| ThinkingContent
+	| TextContent
+	| ResponsesStreamToolCallBlock
+	| null;
+
+interface ResponsesStreamState {
+	currentItem: ResponsesStreamCurrentItem;
+	currentBlock: ResponsesStreamCurrentBlock;
+	output: AssistantMessage;
+	stream: AssistantMessageEventStream;
+	blockIndex: () => number;
+}
+
 export async function processResponsesStream<TApi extends Api>(
 	openaiStream: AsyncIterable<ResponseStreamEvent>,
 	output: AssistantMessage,
@@ -291,250 +313,422 @@ export async function processResponsesStream<TApi extends Api>(
 	model: Model<TApi>,
 	options?: OpenAIResponsesStreamOptions,
 ): Promise<void> {
-	let currentItem: ResponseReasoningItem | ResponseOutputMessage | ResponseFunctionToolCall | null = null;
-	let currentBlock: ThinkingContent | TextContent | (ToolCall & { partialJson: string }) | null = null;
-	const blocks = output.content;
-	const blockIndex = () => blocks.length - 1;
+	const state: ResponsesStreamState = {
+		currentItem: null,
+		currentBlock: null,
+		output,
+		stream,
+		blockIndex: () => output.content.length - 1,
+	};
 
 	for await (const event of openaiStream) {
-		if (event.type === "response.created") {
-			output.responseId = event.response.id;
-		} else if (event.type === "response.output_item.added") {
-			const item = event.item;
-			if (item.type === "reasoning") {
-				currentItem = item;
-				currentBlock = { type: "thinking", thinking: "" };
-				output.content.push(currentBlock);
-				stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
-			} else if (item.type === "message") {
-				currentItem = item;
-				currentBlock = { type: "text", text: "" };
-				output.content.push(currentBlock);
-				stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
-			} else if (item.type === "function_call") {
-				currentItem = item;
-				currentBlock = {
-					type: "toolCall",
-					id: `${item.call_id}|${item.id}`,
-					name: item.name,
-					arguments: {},
-					partialJson: item.arguments || "",
-				};
-				output.content.push(currentBlock);
-				stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
-			}
-		} else if (event.type === "response.reasoning_summary_part.added") {
-			if (currentItem && currentItem.type === "reasoning") {
-				currentItem.summary = currentItem.summary || [];
-				currentItem.summary.push(event.part);
-			}
-		} else if (event.type === "response.reasoning_summary_text.delta") {
-			if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
-				currentItem.summary = currentItem.summary || [];
-				const lastPart = currentItem.summary[currentItem.summary.length - 1];
-				if (lastPart) {
-					currentBlock.thinking += event.delta;
-					lastPart.text += event.delta;
-					stream.push({
-						type: "thinking_delta",
-						contentIndex: blockIndex(),
-						delta: event.delta,
-						partial: output,
-					});
-				}
-			}
-		} else if (event.type === "response.reasoning_summary_part.done") {
-			if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
-				currentItem.summary = currentItem.summary || [];
-				const lastPart = currentItem.summary[currentItem.summary.length - 1];
-				if (lastPart) {
-					currentBlock.thinking += "\n\n";
-					lastPart.text += "\n\n";
-					stream.push({
-						type: "thinking_delta",
-						contentIndex: blockIndex(),
-						delta: "\n\n",
-						partial: output,
-					});
-				}
-			}
-		} else if (event.type === "response.reasoning_text.delta") {
-			if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
-				currentBlock.thinking += event.delta;
-				stream.push({
-					type: "thinking_delta",
-					contentIndex: blockIndex(),
-					delta: event.delta,
-					partial: output,
-				});
-			}
-		} else if (event.type === "response.content_part.added") {
-			if (currentItem?.type === "message") {
-				currentItem.content = currentItem.content || [];
-				// Filter out ReasoningText, only accept output_text and refusal
-				if (event.part.type === "output_text" || event.part.type === "refusal") {
-					currentItem.content.push(event.part);
-				}
-			}
-		} else if (event.type === "response.output_text.delta") {
-			if (currentItem?.type === "message" && currentBlock?.type === "text") {
-				if (!currentItem.content || currentItem.content.length === 0) {
-					continue;
-				}
-				const lastPart = currentItem.content[currentItem.content.length - 1];
-				if (lastPart?.type === "output_text") {
-					currentBlock.text += event.delta;
-					lastPart.text += event.delta;
-					stream.push({
-						type: "text_delta",
-						contentIndex: blockIndex(),
-						delta: event.delta,
-						partial: output,
-					});
-				}
-			}
-		} else if (event.type === "response.refusal.delta") {
-			if (currentItem?.type === "message" && currentBlock?.type === "text") {
-				if (!currentItem.content || currentItem.content.length === 0) {
-					continue;
-				}
-				const lastPart = currentItem.content[currentItem.content.length - 1];
-				if (lastPart?.type === "refusal") {
-					currentBlock.text += event.delta;
-					lastPart.refusal += event.delta;
-					stream.push({
-						type: "text_delta",
-						contentIndex: blockIndex(),
-						delta: event.delta,
-						partial: output,
-					});
-				}
-			}
-		} else if (event.type === "response.function_call_arguments.delta") {
-			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
-				currentBlock.partialJson += event.delta;
-				currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
-				stream.push({
-					type: "toolcall_delta",
-					contentIndex: blockIndex(),
-					delta: event.delta,
-					partial: output,
-				});
-			}
-		} else if (event.type === "response.function_call_arguments.done") {
-			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
-				const previousPartialJson = currentBlock.partialJson;
-				currentBlock.partialJson = event.arguments;
-				currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
-
-				if (event.arguments.startsWith(previousPartialJson)) {
-					const delta = event.arguments.slice(previousPartialJson.length);
-					if (delta.length > 0) {
-						stream.push({
-							type: "toolcall_delta",
-							contentIndex: blockIndex(),
-							delta,
-							partial: output,
-						});
-					}
-				}
-			}
-		} else if (event.type === "response.output_item.done") {
-			const item = event.item;
-
-			if (item.type === "reasoning" && currentBlock?.type === "thinking") {
-				const summaryText = item.summary?.map((s) => s.text).join("\n\n") || "";
-				const contentText = item.content?.map((c) => c.text).join("\n\n") || "";
-				currentBlock.thinking = summaryText || contentText || currentBlock.thinking;
-				currentBlock.thinkingSignature = JSON.stringify(item);
-				stream.push({
-					type: "thinking_end",
-					contentIndex: blockIndex(),
-					content: currentBlock.thinking,
-					partial: output,
-				});
-				currentBlock = null;
-			} else if (item.type === "message" && currentBlock?.type === "text") {
-				currentBlock.text = item.content.map((c) => (c.type === "output_text" ? c.text : c.refusal)).join("");
-				currentBlock.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
-				stream.push({
-					type: "text_end",
-					contentIndex: blockIndex(),
-					content: currentBlock.text,
-					partial: output,
-				});
-				currentBlock = null;
-			} else if (item.type === "function_call") {
-				const args =
-					currentBlock?.type === "toolCall" && currentBlock.partialJson
-						? parseStreamingJson(currentBlock.partialJson)
-						: parseStreamingJson(item.arguments || "{}");
-
-				let toolCall: ToolCall;
-				if (currentBlock?.type === "toolCall") {
-					// Finalize in-place and strip the scratch buffer so replay only
-					// carries parsed arguments.
-					currentBlock.arguments = args;
-					delete (currentBlock as { partialJson?: string }).partialJson;
-					toolCall = currentBlock;
-				} else {
-					toolCall = {
-						type: "toolCall",
-						id: `${item.call_id}|${item.id}`,
-						name: item.name,
-						arguments: args,
-					};
-				}
-
-				currentBlock = null;
-				stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
-			}
-		} else if (event.type === "response.completed") {
-			const response = event.response;
-			if (response?.id) {
-				output.responseId = response.id;
-			}
-			if (response?.usage) {
-				const cachedTokens = response.usage.input_tokens_details?.cached_tokens || 0;
-				output.usage = {
-					// OpenAI includes cached tokens in input_tokens, so subtract to get non-cached input
-					input: (response.usage.input_tokens || 0) - cachedTokens,
-					output: response.usage.output_tokens || 0,
-					cacheRead: cachedTokens,
-					cacheWrite: 0,
-					totalTokens: response.usage.total_tokens || 0,
-					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-				};
-			}
-			calculateCost(model, output.usage);
-			if (options?.applyServiceTierPricing) {
-				const serviceTier = options.resolveServiceTier
-					? options.resolveServiceTier(response?.service_tier, options.serviceTier)
-					: (response?.service_tier ?? options.serviceTier);
-				options.applyServiceTierPricing(output.usage, serviceTier);
-			}
-			// Map status to stop reason
-			output.stopReason = mapStopReason(response?.status);
-			if (output.content.some((b) => b.type === "toolCall") && output.stopReason === "stop") {
-				output.stopReason = "toolUse";
-			}
-		} else if (event.type === "error") {
-			throw new Error(
-				event.message
-					? `Error Code ${event.code}: ${event.message}`
-					: "Unknown error",
-			);
-		} else if (event.type === "response.failed") {
-			const error = event.response?.error;
-			const details = event.response?.incomplete_details;
-			const msg = error
-				? `${error.code || "unknown"}: ${error.message || "no message"}`
-				: details?.reason
-					? `incomplete: ${details.reason}`
-					: "Unknown error (no error details in response)";
-			throw new Error(msg);
-		}
+		dispatchResponsesStreamEvent(event, state, model, options);
 	}
+}
+
+function dispatchResponsesStreamEvent<TApi extends Api>(
+	event: ResponseStreamEvent,
+	state: ResponsesStreamState,
+	model: Model<TApi>,
+	options?: OpenAIResponsesStreamOptions,
+): void {
+	switch (event.type) {
+		case "response.created":
+			state.output.responseId = event.response.id;
+			return;
+		case "response.output_item.added":
+			handleOutputItemAdded(event, state);
+			return;
+		case "response.reasoning_summary_part.added":
+			handleReasoningSummaryPartAdded(event, state);
+			return;
+		case "response.reasoning_summary_text.delta":
+			handleReasoningSummaryTextDelta(event, state);
+			return;
+		case "response.reasoning_summary_part.done":
+			handleReasoningSummaryPartDone(state);
+			return;
+		case "response.reasoning_text.delta":
+			handleReasoningTextDelta(event, state);
+			return;
+		case "response.content_part.added":
+			handleContentPartAdded(event, state);
+			return;
+		case "response.output_text.delta":
+			handleOutputTextDelta(event, state);
+			return;
+		case "response.refusal.delta":
+			handleRefusalDelta(event, state);
+			return;
+		case "response.function_call_arguments.delta":
+			handleFunctionCallArgumentsDelta(event, state);
+			return;
+		case "response.function_call_arguments.done":
+			handleFunctionCallArgumentsDone(event, state);
+			return;
+		case "response.output_item.done":
+			handleOutputItemDone(event, state);
+			return;
+		case "response.completed":
+			handleResponseCompleted(event, state, model, options);
+			return;
+		case "error":
+			throwResponsesStreamError(event);
+			return;
+		case "response.failed":
+			throwResponsesStreamFailed(event);
+			return;
+		default:
+			return;
+	}
+}
+
+function handleOutputItemAdded(
+	event: Extract<ResponseStreamEvent, { type: "response.output_item.added" }>,
+	state: ResponsesStreamState,
+): void {
+	const item = event.item;
+	const { output, stream, blockIndex } = state;
+
+	if (item.type === "reasoning") {
+		state.currentItem = item;
+		state.currentBlock = { type: "thinking", thinking: "" };
+		output.content.push(state.currentBlock);
+		stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+		return;
+	}
+	if (item.type === "message") {
+		state.currentItem = item;
+		state.currentBlock = { type: "text", text: "" };
+		output.content.push(state.currentBlock);
+		stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+		return;
+	}
+	if (item.type === "function_call") {
+		state.currentItem = item;
+		state.currentBlock = {
+			type: "toolCall",
+			id: `${item.call_id}|${item.id}`,
+			name: item.name,
+			arguments: {},
+			partialJson: item.arguments || "",
+		};
+		output.content.push(state.currentBlock);
+		stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+	}
+}
+
+function handleReasoningSummaryPartAdded(
+	event: Extract<ResponseStreamEvent, { type: "response.reasoning_summary_part.added" }>,
+	state: ResponsesStreamState,
+): void {
+	if (state.currentItem && state.currentItem.type === "reasoning") {
+		state.currentItem.summary = state.currentItem.summary || [];
+		state.currentItem.summary.push(event.part);
+	}
+}
+
+function handleReasoningSummaryTextDelta(
+	event: Extract<ResponseStreamEvent, { type: "response.reasoning_summary_text.delta" }>,
+	state: ResponsesStreamState,
+): void {
+	const { currentItem, currentBlock, output, stream, blockIndex } = state;
+	if (currentItem?.type !== "reasoning" || currentBlock?.type !== "thinking") return;
+
+	currentItem.summary = currentItem.summary || [];
+	const lastPart = currentItem.summary[currentItem.summary.length - 1];
+	if (!lastPart) return;
+
+	currentBlock.thinking += event.delta;
+	lastPart.text += event.delta;
+	stream.push({
+		type: "thinking_delta",
+		contentIndex: blockIndex(),
+		delta: event.delta,
+		partial: output,
+	});
+}
+
+function handleReasoningSummaryPartDone(state: ResponsesStreamState): void {
+	const { currentItem, currentBlock, output, stream, blockIndex } = state;
+	if (currentItem?.type !== "reasoning" || currentBlock?.type !== "thinking") return;
+
+	currentItem.summary = currentItem.summary || [];
+	const lastPart = currentItem.summary[currentItem.summary.length - 1];
+	if (!lastPart) return;
+
+	currentBlock.thinking += "\n\n";
+	lastPart.text += "\n\n";
+	stream.push({
+		type: "thinking_delta",
+		contentIndex: blockIndex(),
+		delta: "\n\n",
+		partial: output,
+	});
+}
+
+function handleReasoningTextDelta(
+	event: Extract<ResponseStreamEvent, { type: "response.reasoning_text.delta" }>,
+	state: ResponsesStreamState,
+): void {
+	const { currentItem, currentBlock, output, stream, blockIndex } = state;
+	if (currentItem?.type !== "reasoning" || currentBlock?.type !== "thinking") return;
+
+	currentBlock.thinking += event.delta;
+	stream.push({
+		type: "thinking_delta",
+		contentIndex: blockIndex(),
+		delta: event.delta,
+		partial: output,
+	});
+}
+
+function handleContentPartAdded(
+	event: Extract<ResponseStreamEvent, { type: "response.content_part.added" }>,
+	state: ResponsesStreamState,
+): void {
+	const { currentItem } = state;
+	if (currentItem?.type !== "message") return;
+
+	currentItem.content = currentItem.content || [];
+	// Filter out ReasoningText, only accept output_text and refusal
+	if (event.part.type === "output_text" || event.part.type === "refusal") {
+		currentItem.content.push(event.part);
+	}
+}
+
+function handleOutputTextDelta(
+	event: Extract<ResponseStreamEvent, { type: "response.output_text.delta" }>,
+	state: ResponsesStreamState,
+): void {
+	const { currentItem, currentBlock, output, stream, blockIndex } = state;
+	if (currentItem?.type !== "message" || currentBlock?.type !== "text") return;
+	if (!currentItem.content || currentItem.content.length === 0) return;
+
+	const lastPart = currentItem.content[currentItem.content.length - 1];
+	if (lastPart?.type !== "output_text") return;
+
+	currentBlock.text += event.delta;
+	lastPart.text += event.delta;
+	stream.push({
+		type: "text_delta",
+		contentIndex: blockIndex(),
+		delta: event.delta,
+		partial: output,
+	});
+}
+
+function handleRefusalDelta(
+	event: Extract<ResponseStreamEvent, { type: "response.refusal.delta" }>,
+	state: ResponsesStreamState,
+): void {
+	const { currentItem, currentBlock, output, stream, blockIndex } = state;
+	if (currentItem?.type !== "message" || currentBlock?.type !== "text") return;
+	if (!currentItem.content || currentItem.content.length === 0) return;
+
+	const lastPart = currentItem.content[currentItem.content.length - 1];
+	if (lastPart?.type !== "refusal") return;
+
+	currentBlock.text += event.delta;
+	lastPart.refusal += event.delta;
+	stream.push({
+		type: "text_delta",
+		contentIndex: blockIndex(),
+		delta: event.delta,
+		partial: output,
+	});
+}
+
+function handleFunctionCallArgumentsDelta(
+	event: Extract<ResponseStreamEvent, { type: "response.function_call_arguments.delta" }>,
+	state: ResponsesStreamState,
+): void {
+	const { currentItem, currentBlock, output, stream, blockIndex } = state;
+	if (currentItem?.type !== "function_call" || currentBlock?.type !== "toolCall") return;
+
+	currentBlock.partialJson += event.delta;
+	currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+	stream.push({
+		type: "toolcall_delta",
+		contentIndex: blockIndex(),
+		delta: event.delta,
+		partial: output,
+	});
+}
+
+function handleFunctionCallArgumentsDone(
+	event: Extract<ResponseStreamEvent, { type: "response.function_call_arguments.done" }>,
+	state: ResponsesStreamState,
+): void {
+	const { currentItem, currentBlock, output, stream, blockIndex } = state;
+	if (currentItem?.type !== "function_call" || currentBlock?.type !== "toolCall") return;
+
+	const previousPartialJson = currentBlock.partialJson;
+	currentBlock.partialJson = event.arguments;
+	currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+
+	if (!event.arguments.startsWith(previousPartialJson)) return;
+
+	const delta = event.arguments.slice(previousPartialJson.length);
+	if (delta.length === 0) return;
+
+	stream.push({
+		type: "toolcall_delta",
+		contentIndex: blockIndex(),
+		delta,
+		partial: output,
+	});
+}
+
+function handleOutputItemDone(
+	event: Extract<ResponseStreamEvent, { type: "response.output_item.done" }>,
+	state: ResponsesStreamState,
+): void {
+	const item = event.item;
+
+	if (item.type === "reasoning" && state.currentBlock?.type === "thinking") {
+		finalizeReasoningItem(item, state);
+		return;
+	}
+	if (item.type === "message" && state.currentBlock?.type === "text") {
+		finalizeMessageItem(item, state);
+		return;
+	}
+	if (item.type === "function_call") {
+		finalizeFunctionCallItem(item, state);
+	}
+}
+
+function finalizeReasoningItem(item: ResponseReasoningItem, state: ResponsesStreamState): void {
+	const currentBlock = state.currentBlock;
+	if (currentBlock?.type !== "thinking") return;
+
+	const summaryText = item.summary?.map((s) => s.text).join("\n\n") || "";
+	const contentText = item.content?.map((c) => c.text).join("\n\n") || "";
+	currentBlock.thinking = summaryText || contentText || currentBlock.thinking;
+	currentBlock.thinkingSignature = JSON.stringify(item);
+	state.stream.push({
+		type: "thinking_end",
+		contentIndex: state.blockIndex(),
+		content: currentBlock.thinking,
+		partial: state.output,
+	});
+	state.currentBlock = null;
+}
+
+function finalizeMessageItem(item: ResponseOutputMessage, state: ResponsesStreamState): void {
+	const currentBlock = state.currentBlock;
+	if (currentBlock?.type !== "text") return;
+
+	currentBlock.text = item.content.map((c) => (c.type === "output_text" ? c.text : c.refusal)).join("");
+	currentBlock.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
+	state.stream.push({
+		type: "text_end",
+		contentIndex: state.blockIndex(),
+		content: currentBlock.text,
+		partial: state.output,
+	});
+	state.currentBlock = null;
+}
+
+function finalizeFunctionCallItem(item: ResponseFunctionToolCall, state: ResponsesStreamState): void {
+	const currentBlock = state.currentBlock;
+	const args =
+		currentBlock?.type === "toolCall" && currentBlock.partialJson
+			? parseStreamingJson(currentBlock.partialJson)
+			: parseStreamingJson(item.arguments || "{}");
+
+	let toolCall: ToolCall;
+	if (currentBlock?.type === "toolCall") {
+		// Finalize in-place and strip the scratch buffer so replay only
+		// carries parsed arguments.
+		currentBlock.arguments = args;
+		delete (currentBlock as { partialJson?: string }).partialJson;
+		toolCall = currentBlock;
+	} else {
+		toolCall = {
+			type: "toolCall",
+			id: `${item.call_id}|${item.id}`,
+			name: item.name,
+			arguments: args,
+		};
+	}
+
+	state.currentBlock = null;
+	state.stream.push({
+		type: "toolcall_end",
+		contentIndex: state.blockIndex(),
+		toolCall,
+		partial: state.output,
+	});
+}
+
+function handleResponseCompleted<TApi extends Api>(
+	event: Extract<ResponseStreamEvent, { type: "response.completed" }>,
+	state: ResponsesStreamState,
+	model: Model<TApi>,
+	options?: OpenAIResponsesStreamOptions,
+): void {
+	const response = event.response;
+	const { output } = state;
+
+	if (response?.id) {
+		output.responseId = response.id;
+	}
+	if (response?.usage) {
+		const cachedTokens = response.usage.input_tokens_details?.cached_tokens || 0;
+		output.usage = {
+			// OpenAI includes cached tokens in input_tokens, so subtract to get non-cached input
+			input: (response.usage.input_tokens || 0) - cachedTokens,
+			output: response.usage.output_tokens || 0,
+			cacheRead: cachedTokens,
+			cacheWrite: 0,
+			totalTokens: response.usage.total_tokens || 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+	}
+	calculateCost(model, output.usage);
+	applyCompletedServiceTierPricing(output, response, options);
+	output.stopReason = mapStopReason(response?.status);
+	if (output.content.some((b) => b.type === "toolCall") && output.stopReason === "stop") {
+		output.stopReason = "toolUse";
+	}
+}
+
+function applyCompletedServiceTierPricing(
+	output: AssistantMessage,
+	response: Extract<ResponseStreamEvent, { type: "response.completed" }>["response"],
+	options?: OpenAIResponsesStreamOptions,
+): void {
+	if (!options?.applyServiceTierPricing) return;
+
+	const serviceTier = options.resolveServiceTier
+		? options.resolveServiceTier(response?.service_tier, options.serviceTier)
+		: (response?.service_tier ?? options.serviceTier);
+	options.applyServiceTierPricing(output.usage, serviceTier);
+}
+
+function throwResponsesStreamError(
+	event: Extract<ResponseStreamEvent, { type: "error" }>,
+): never {
+	throw new Error(
+		event.message
+			? `Error Code ${event.code}: ${event.message}`
+			: "Unknown error",
+	);
+}
+
+function throwResponsesStreamFailed(
+	event: Extract<ResponseStreamEvent, { type: "response.failed" }>,
+): never {
+	const error = event.response?.error;
+	const details = event.response?.incomplete_details;
+	const msg = error
+		? `${error.code || "unknown"}: ${error.message || "no message"}`
+		: details?.reason
+			? `incomplete: ${details.reason}`
+			: "Unknown error (no error details in response)";
+	throw new Error(msg);
 }
 
 function mapStopReason(status: OpenAI.Responses.ResponseStatus | undefined): StopReason {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Lower Sonar **typescript:S3776** on `processResponsesStream` in `packages/ai/src/providers/openai-responses-shared.ts` (reported cx 138 → under threshold 15) via extract-method: thin `for await` + `dispatchResponsesStreamEvent` switch, with focused helpers for output-item added/done, reasoning summary/text, content/refusal deltas, function-call args, completed usage/cost/service-tier, and error/failed.
- **Behavior preserved**: streaming order/types, partialJson + parseStreamingJson, signatures, stopReason + toolUse override, `calculateCost` / service-tier hooks unchanged.
- Left `convertResponsesMessages` (separate S3776) untouched.
- Added light unit coverage in `openai-responses-shared-stream.test.ts` (text, tool call, reasoning, service-tier hook, error/failed). Fixtures cast via `unknown` so `tsc -b` accepts omitted SDK bookkeeping fields.

## Type
- [x] Refactor

## Sonar
- Key: `20547541-2e11-44b3-a53e-63142c0b7036`
- No matching open GitHub issue found for this file+function (no `Closes`).

## Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (0 errors; pre-existing warnings elsewhere)
- [x] `@dome/ai` vitest passes
- [x] `pnpm --filter @dome/ai exec tsc -b` passes (CI package build)
- [x] `pnpm run check:sonar-patterns -- --diff=origin/main` OK
- [ ] i18n N/A
- [ ] No hardcoded colors N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e19b6e5-58ae-450c-814e-2a9426606ef0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e19b6e5-58ae-450c-814e-2a9426606ef0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

