### PR TITLE
fix(sonar): S2004 useResources.ts

### DIFF
--- a/app/lib/hooks/useResources.ts
+++ b/app/lib/hooks/useResources.ts
@@ -86,6 +86,16 @@ function normalizeResource(r: Resource): Resource {
     };
 }
 
+/**
+ * Insert a freshly-created resource at the head of `prev`, skipping if an entry
+ * with the same id already exists. Extracted from the `resource:created` listener
+ * to keep that handler's nesting depth ≤ 4 (Sonar S2004).
+ */
+function prependResourceIfNew(prev: Resource[], resource: Resource): Resource[] {
+    if (prev.some(r => r.id === resource.id)) return prev;
+    return [normalizeResource(resource), ...prev];
+}
+
 /** Merge a partial update into a single resource; returns the original when id mismatches. */
 function mergeResourceUpdate(resource: Resource, id: string, updates: Partial<Resource>): Resource {
     if (resource.id !== id) return resource;
@@ -192,10 +202,7 @@ export function useResources(filter?: ResourceFilter) {
 
         // Listener: Recurso creado
         const unsubscribeCreate = window.electron.on('resource:created', (resource: Resource) => {
-            setResources(prev => {
-                if (prev.some(r => r.id === resource.id)) return prev;
-                return [normalizeResource(resource), ...prev];
-            });
+            setResources(prev => prependResourceIfNew(prev, resource));
         });
 
         // Listener: Recurso actualizado


### PR DESCRIPTION
## Sonar quality loop (Jenkins)

Automated fix from `.quality-loop/batch.json`.

Closes #1625

## Local gates (Jenkins)

| Gate | Result |
|------|--------|
| Fast gates | pass |
| LLM reviewer | APPROVE |
| Full verify | pass |
| GitHub CI | pending |

## Checks (GitHub CI)
- typecheck, lint, test:coverage, build, depcruise
