### PR TITLE
fix: use live Dome Provider host in packaged builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ NODE_ENV=development
 VITE_ENABLE_DOME_PROVIDER=false
 
 # Dome Provider (opcional — backend en ../dome-provider)
-# Sin override: el main process usa http://localhost:3001 en dev y https://provider.dome.app si la app está empaquetada.
+# Sin override: el main process usa http://localhost:3001 en dev y https://dome-provider.dowi.es si la app está empaquetada.
 # DOME_PROVIDER_URL=http://localhost:3001
 
 # Login nativo Dome (onboarding) — credenciales públicas de Supabase Auth.

--- a/docs/features/dome-provider-integration.md
+++ b/docs/features/dome-provider-integration.md
@@ -30,7 +30,7 @@ La integración es **completamente opcional**. Dome funciona perfectamente sin P
    - code_challenge: SHA256(code_verifier) en base64url
 
 3. Dome abre el browser del OS en:
-   https://provider.dome.app/api/oauth/authorize
+   https://dome-provider.dowi.es/api/oauth/authorize
      ?client_id=dome-desktop
      &redirect_uri=dome://dome-auth/oauth/callback
      &code_challenge=xxx
@@ -61,9 +61,9 @@ La integración es **completamente opcional**. Dome funciona perfectamente sin P
 
 | Archivo | Rol |
 |---------|-----|
-| `electron/dome-provider-url.cjs` | URL base del provider (env, embed CI, fallback prod `:3001` dev) |
-| `electron/dome-oauth.cjs` | Gestión de sesión OAuth con el Provider |
-| `electron/ipc/dome-auth.cjs` | IPC handlers para `dome-auth:*` channels |
+| `electron/ai/dome-provider-url.cjs` | URL base del provider (env, embed CI, fallback prod / `:3001` dev) |
+| `electron/auth/dome-oauth.cjs` | Gestión de sesión OAuth con el Provider |
+| `electron/ipc/integrations/dome-auth.cjs` | IPC handlers para `dome-auth:*` channels |
 | `electron/ipc/agent-team.cjs` | Usa Provider como proveedor AI para Agent Teams |
 | `electron/ipc/ai.cjs` | Usa Provider como proveedor AI para el chat |
 | `electron/main.cjs` | Intercepta deep links `dome://dome-auth/oauth/callback` |
@@ -71,7 +71,7 @@ La integración es **completamente opcional**. Dome funciona perfectamente sin P
 
 ---
 
-## `electron/dome-oauth.cjs`
+## `electron/auth/dome-oauth.cjs`
 
 ```javascript
 // Obtener o refrescar sesión (usado por ai.cjs y agent-team.cjs)
@@ -128,7 +128,7 @@ El cliente AI (`app/lib/ai/client.ts`) trata al Provider como un endpoint OpenAI
 # .env o .env.local en el proyecto dome/
 DOME_PROVIDER_URL=http://localhost:3001        # Override explícito (dev o staging)
 # Producción empaquetada: si no defines DOME_PROVIDER_URL, el main process usa
-# https://provider.dome.app (o el valor en app-credentials tras `embed-env`).
+# https://dome-provider.dowi.es (o el valor en app-credentials tras `embed-env`).
 
 VITE_ENABLE_DOME_PROVIDER=true                 # Habilita la opción "Dome" en Settings
 ```

--- a/docs/manual-tecnico.md
+++ b/docs/manual-tecnico.md
@@ -640,16 +640,16 @@ Los plugins se guardan en:
 
 ### Configuración en Dome Desktop
 
-La URL base del provider se obtiene desde [`electron/dome-provider-url.cjs`](../../electron/dome-provider-url.cjs):
+La URL base del provider se obtiene desde [`electron/ai/dome-provider-url.cjs`](../../electron/ai/dome-provider-url.cjs):
 
 1. `process.env.DOME_PROVIDER_URL` (override en desarrollo / pruebas)
 2. Valor incluido en `electron/app-credentials.cjs` por `node scripts/embed-env.cjs` (clave `DOME_PROVIDER_URL`, opcional en CI)
-3. App empaquetada (`app.isPackaged`): `https://provider.dome.app`
+3. App empaquetada (`app.isPackaged`): `https://dome-provider.dowi.es`
 4. Desarrollo sin `.env`: `http://localhost:3001` (alineado con `APP_URL` de dome-provider)
 
 En desarrollo, puedes seguir usando `DOME_PROVIDER_URL=http://localhost:3001` en el `.env` de Dome.
 
-### OAuth session (`electron/dome-oauth.cjs`)
+### OAuth session (`electron/auth/dome-oauth.cjs`)
 
 ```javascript
 // Obtiene o refresca sesión

--- a/electron/ai/dome-provider-url.cjs
+++ b/electron/ai/dome-provider-url.cjs
@@ -5,9 +5,12 @@
  * Precedence:
  * 1. process.env.DOME_PROVIDER_URL (dev / overrides)
  * 2. electron/app-credentials.cjs DOME_PROVIDER_URL (CI embed-env)
- * 3. Packaged app: https://provider.dome.app
+ * 3. Packaged app: https://dome-provider.dowi.es (current Coolify/preprod host)
  * 4. Unpacked dev: http://localhost:3001 (aligns with dome-provider APP_URL default)
  */
+const PACKAGED_DOME_PROVIDER_URL = 'https://dome-provider.dowi.es';
+const DEV_DOME_PROVIDER_URL = 'http://localhost:3001';
+
 function getDomeProviderBaseUrl() {
   const env = (process.env.DOME_PROVIDER_URL || '').trim();
   if (env) return env;
@@ -22,12 +25,12 @@ function getDomeProviderBaseUrl() {
 
   try {
     const { app } = require('electron');
-    if (app?.isPackaged) return 'https://provider.dome.app';
+    if (app?.isPackaged) return PACKAGED_DOME_PROVIDER_URL;
   } catch (_) {
     // non-Electron context
   }
 
-  return 'http://localhost:3001';
+  return DEV_DOME_PROVIDER_URL;
 }
 
-module.exports = { getDomeProviderBaseUrl };
+module.exports = { getDomeProviderBaseUrl, PACKAGED_DOME_PROVIDER_URL, DEV_DOME_PROVIDER_URL };

--- a/scripts/embed-env.cjs
+++ b/scripts/embed-env.cjs
@@ -5,7 +5,7 @@
  *
  * Usage: node scripts/embed-env.cjs
  * Env vars read: DOME_GOOGLE_DRIVE_CLIENT_ID, DOME_GOOGLE_DRIVE_CLIENT_SECRET,
- *               DOME_PROVIDER_URL (optional; empty → runtime uses packaged https://provider.dome.app),
+ *               DOME_PROVIDER_URL (optional; empty → runtime uses packaged https://dome-provider.dowi.es),
  *               DOME_GITHUB_CLIENT_ID (GitHub OAuth App client id for project sync; public, safe to bake),
  *               SUPABASE_URL, SUPABASE_ANON_KEY (onboarding native login; anon key is public by
  *                 design — dome-provider's own web bundle already ships it — safe to bake),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Packaged Desktop fell back to `https://provider.dome.app`, which does not resolve in DNS.
- Default packaged URL is now `https://dome-provider.dowi.es`, matching companion Release and Coolify preprod.
- Docs and `.env.example` comments updated to the same host and to the real `electron/ai/` + `electron/auth/` paths.

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / config

## Checklist
- [x] `pnpm run typecheck` — not required (string constant + docs)
- [ ] `pnpm run lint` — not run (docs/config)
- [ ] `pnpm run build` — not run
- [x] i18n keys — N/A
- [x] No hardcoded colors

## Test notes
- Confirmed `provider.dome.app` has no DNS (`Name or service not known`).
- `getDomeProviderBaseUrl()` without env/embed still returns `http://localhost:3001` in non-packaged context.
- Override `DOME_PROVIDER_URL` still takes precedence.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-add2e15c-c839-50ed-8b28-d501294a1869?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-add2e15c-c839-50ed-8b28-d501294a1869&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

