### PR TITLE
fix: persistir user_id del intercambio de tokens de Provider

### DIFF
--- a/electron/__tests__/dome-native-login.test.mjs
+++ b/electron/__tests__/dome-native-login.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { resolveDomeUserId } from '../auth/dome-session-identity.cjs';
+
+function mintUnsigned(sub) {
+  const payload = Buffer.from(JSON.stringify({ sub, aud: 'dome-desktop' })).toString('base64url');
+  return `${payload}.sig`;
+}
+
+describe('resolveDomeUserId', () => {
+  it('prefers user_id from the provider token JSON', () => {
+    assert.equal(
+      resolveDomeUserId({
+        access_token: mintUnsigned('jwt-sub'),
+        user_id: '11111111-1111-4111-8111-111111111111',
+      }),
+      '11111111-1111-4111-8111-111111111111',
+    );
+  });
+
+  it('falls back to JWT sub when user_id is missing', () => {
+    assert.equal(resolveDomeUserId({ access_token: mintUnsigned('jwt-sub') }), 'jwt-sub');
+  });
+});

--- a/electron/auth/dome-native-login.cjs
+++ b/electron/auth/dome-native-login.cjs
@@ -15,6 +15,7 @@
 const { getDomeProviderBaseUrl } = require('../ai/dome-provider-url.cjs');
 const { getSupabaseCredentials } = require('./supabase-credentials.cjs');
 const { persistSession, getRemoteProfile } = require('./dome-oauth.cjs');
+const { resolveDomeUserId } = require('./dome-session-identity.cjs');
 
 class SupabaseAuthError extends Error {
   constructor(code, message) {
@@ -106,19 +107,6 @@ async function exchangeForDomeSession(supabaseAccessToken) {
 }
 
 /**
- * dome-provider's mintAccessToken (lib/oauth-store.ts) produces
- * base64url(JSON).base64url(HMAC) — not a verifiable JWT without
- * TOKEN_HMAC_SECRET, but we trust it: it just arrived over TLS directly from
- * dome-provider in response to our own request.
- */
-function extractUserIdFromDomeAccessToken(domeAccessToken) {
-  const [encoded] = String(domeAccessToken).split('.');
-  const payload = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
-  if (!payload?.sub) throw new SupabaseAuthError('exchange_failed', 'Token de Dome sin identificador de usuario');
-  return payload.sub;
-}
-
-/**
  * @param {object} database
  * @param {{ email: string, password: string, isRegister: boolean, name?: string, windowManager?: object }} params
  */
@@ -132,11 +120,17 @@ async function loginOrRegister(database, { email, password, isRegister, name, wi
   }
 
   const domeSession = await exchangeForDomeSession(supabaseResult.access_token);
-  const userId = extractUserIdFromDomeAccessToken(domeSession.access_token);
+  const userId = resolveDomeUserId(domeSession);
   const now = Date.now();
   const expiresAt = now + Number(domeSession.expires_in || 3600) * 1000;
 
-  persistSession(database.getQueries(), userId, domeSession.access_token, domeSession.refresh_token, expiresAt);
+  persistSession(
+    database.getQueries(),
+    userId,
+    domeSession.access_token,
+    domeSession.refresh_token || null,
+    expiresAt,
+  );
 
   const profile = await getRemoteProfile(database);
   const { runPostLoginBootstrap } = require('../storage/post-login-bootstrap.cjs');

--- a/electron/auth/dome-session-identity.cjs
+++ b/electron/auth/dome-session-identity.cjs
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * Shared identity helpers for Dome Provider token JSON + HMAC access tokens.
+ * Kept free of Electron so unit tests can import it.
+ */
+
+class DomeSessionIdentityError extends Error {
+  constructor(code, message) {
+    super(message || code);
+    this.code = code;
+  }
+}
+
+function extractUserIdFromDomeAccessToken(domeAccessToken) {
+  const [encoded] = String(domeAccessToken).split('.');
+  const payload = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
+  if (!payload?.sub) {
+    throw new DomeSessionIdentityError('exchange_failed', 'Token de Dome sin identificador de usuario');
+  }
+  return payload.sub;
+}
+
+/** Prefer `user_id` from the provider token JSON; fall back to JWT `sub`. */
+function resolveDomeUserId(domeSession) {
+  if (typeof domeSession?.user_id === 'string' && domeSession.user_id.trim()) {
+    return domeSession.user_id.trim();
+  }
+  return extractUserIdFromDomeAccessToken(domeSession.access_token);
+}
+
+module.exports = {
+  extractUserIdFromDomeAccessToken,
+  resolveDomeUserId,
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- El login nativo (email/contraseña) usa el `user_id` del JSON de `/api/auth/supabase-exchange` (el mismo contrato que OAuth PKCE y connect) y, si falta, el `sub` del JWT HMAC.
- El refresh token nulo ya no se pasa sin normalizar a `persistSession`.

## Type
- [x] Bug fix

## Checklist
- [x] Tests: `node --test electron/__tests__/dome-native-login.test.mjs`
- [ ] `pnpm run typecheck` (cambio CJS + test Node; sin UI)
- [ ] `pnpm run lint`
- [ ] `pnpm run build`
- [x] i18n: no aplica
- [x] No hardcoded colors

Par en provider: unifica el JSON de tokens para que `user_id` venga siempre.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e8369b1-aa6b-5e6e-a267-3c45927f5452?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e8369b1-aa6b-5e6e-a267-3c45927f5452&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

